### PR TITLE
fix(audit): bind oauth_token_metadata into the audit hash chain (Finding 7)

### DIFF
--- a/crates/vigil-audit/src/ledger.rs
+++ b/crates/vigil-audit/src/ledger.rs
@@ -44,6 +44,9 @@ const COLUMN_MIGRATIONS: &[(&str, &str, &str)] = &[
     // "issuer_missing_legacy_row")。**不得**改为 NOT NULL —— ADD COLUMN 对非空
     // 表加 NOT NULL 无默认值会失败,破坏迁移幂等性。
     ("oauth_token_metadata", "issuer", "TEXT"),
+    // Finding 7(hostile review):metadata 行绑定的审计事件 id(读侧按此特定 id 取事件 +
+    // verify_chain 校验,获得与账本其余状态同级篡改可检测性)。nullable —— legacy 行 NULL → 放行。
+    ("oauth_token_metadata", "binding_event_id", "INTEGER"),
     // V1.1(ADR 0007 §I-7.1 / ADR 0005 第二独立 drift 维度):裸命令解析后绝对路径 pin。
     // nullable —— legacy 行(列新增前的审批)NULL,首次本机 spawn 建立基线(见 §3.2 4 护栏)。
     ("server_profiles", "resolved_program_path", "TEXT"),
@@ -139,6 +142,11 @@ pub const EVENT_TYPE_RAW_SECRET_BLOCKED: &str = "raw_secret_attempt_detected";
 pub const EVENT_TYPE_TOOL_RESULT_LEAK: &str = "secret.leak_detected";
 /// 见 [`EVENT_TYPE_RAW_SECRET_BLOCKED`]。
 pub const EVENT_TYPE_SECRET_ALIAS_UNRESOLVED: &str = "secret.alias_unresolved";
+/// Finding 7(hostile review):`register_oauth_token_metadata` 写行时同步追加的**绑定事件**,
+/// 把 metadata 的安全字段(token_ref / issuer / authorization_server / resource / scope / kind)
+/// 绑进审计哈希链,使该行获得与账本其余状态同等的篡改可检测性。读侧
+/// `get_oauth_token_metadata` 比对最新此类事件检测行篡改。crate-内部机制(非跨 crate API)。
+pub(crate) const EVENT_TYPE_OAUTH_METADATA_BOUND: &str = "oauth.token_metadata_bound";
 
 /// `inspect protection` 的"保护成效"汇总(只读聚合,proof-of-value 面)。
 ///

--- a/crates/vigil-audit/src/registry.rs
+++ b/crates/vigil-audit/src/registry.rs
@@ -1427,19 +1427,41 @@ impl Ledger {
         }
         let scope_json = serde_json::to_string(scope_set)?;
         let now = crate::ledger::now_secs();
+
+        // Finding 7(hostile review):把 metadata 安全字段绑进审计哈希链 —— 此前本行是唯一完全在
+        // 链外的安全关键状态(纯 INSERT,`verify_chain` 检测不到改 issuer/AS)。**先 append 绑定事件**
+        // 拿 event_id,**再**把行写入并带上该 id —— 使行**永远**携带有效绑定引用(杜绝"INSERT 后 /
+        // 绑定前被 kill"的非原子窗口;若在 append 后 / INSERT 前 kill,只留一条无行引用的孤儿事件,
+        // 无害且绝不被读)。读侧按**此特定 id** 取事件 + `verify_chain` 校验检测篡改(同级于账本其余
+        // 状态;仅完整一致重写整条链才能绕过 —— unkeyed chain 固有限制,需外部 anchoring,hash.rs 头注)。
+        let bound = self.append_event_internal(
+            "system",
+            crate::ledger::EVENT_TYPE_OAUTH_METADATA_BOUND,
+            &serde_json::json!({
+                "token_ref": token_ref,
+                "resource": resource,
+                "authorization_server": authorization_server,
+                "issuer": issuer,
+                "scope_set": scope_set,
+                "token_kind": token_kind,
+            }),
+            None,
+        )?;
+
         let guard = self.conn.lock().map_err(|_| AuditError::LockPoisoned)?;
         guard.execute(
             "INSERT INTO oauth_token_metadata
                (token_ref, resource, authorization_server, scope_set_json,
-                token_kind, expires_at, created_at, issuer)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                token_kind, expires_at, created_at, issuer, binding_event_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
              ON CONFLICT(token_ref) DO UPDATE SET
                resource = excluded.resource,
                authorization_server = excluded.authorization_server,
                scope_set_json = excluded.scope_set_json,
                token_kind = excluded.token_kind,
                expires_at = excluded.expires_at,
-               issuer = excluded.issuer",
+               issuer = excluded.issuer,
+               binding_event_id = excluded.binding_event_id",
             rusqlite::params![
                 token_ref,
                 resource,
@@ -1449,6 +1471,7 @@ impl Ledger {
                 expires_at,
                 now,
                 issuer,
+                bound.event_id,
             ],
         )?;
         Ok(())
@@ -1500,35 +1523,83 @@ impl Ledger {
         &self,
         token_ref: &str,
     ) -> Result<Option<vigil_http_auth_metadata::OAuthTokenMetadataRow>> {
-        let guard = self.conn.lock().map_err(|_| AuditError::LockPoisoned)?;
-        let row = guard
-            .query_row(
-                "SELECT token_ref, resource, authorization_server, scope_set_json,
-                        token_kind, expires_at, created_at, issuer
+        let row = {
+            let guard = self.conn.lock().map_err(|_| AuditError::LockPoisoned)?;
+            guard
+                .query_row(
+                    "SELECT token_ref, resource, authorization_server, scope_set_json,
+                        token_kind, expires_at, created_at, issuer, binding_event_id
                  FROM oauth_token_metadata WHERE token_ref = ?1",
-                rusqlite::params![token_ref],
-                |r| {
-                    Ok((
-                        r.get::<_, String>(0)?,
-                        r.get::<_, String>(1)?,
-                        r.get::<_, String>(2)?,
-                        r.get::<_, String>(3)?,
-                        r.get::<_, String>(4)?,
-                        r.get::<_, Option<i64>>(5)?,
-                        r.get::<_, i64>(6)?,
-                        r.get::<_, Option<String>>(7)?,
-                    ))
-                },
-            )
-            .optional()?;
-        let Some((token_ref, resource, authz, scope_json, kind, expires_at, created_at, issuer)) =
-            row
+                    rusqlite::params![token_ref],
+                    |r| {
+                        Ok((
+                            r.get::<_, String>(0)?,
+                            r.get::<_, String>(1)?,
+                            r.get::<_, String>(2)?,
+                            r.get::<_, String>(3)?,
+                            r.get::<_, String>(4)?,
+                            r.get::<_, Option<i64>>(5)?,
+                            r.get::<_, i64>(6)?,
+                            r.get::<_, Option<String>>(7)?,
+                            r.get::<_, Option<i64>>(8)?,
+                        ))
+                    },
+                )
+                .optional()?
+        }; // 释放 conn 锁 —— latest_oauth_binding 会再次 lock,避免死锁
+        let Some((
+            tref,
+            resource,
+            authz,
+            scope_json,
+            kind,
+            expires_at,
+            created_at,
+            issuer,
+            binding_event_id,
+        )) = row
         else {
             return Ok(None);
         };
         let scope_set: Vec<String> = serde_json::from_str(&scope_json)?;
+
+        // Finding 7(hostile review):行已绑定(binding_event_id 非 NULL)→ 校验,使 OAuth metadata
+        // 获得与账本其余状态**同级**的篡改可检测性:
+        //  (1) `verify_chain()`:events 被 naive 删/改(未一致重写)→ 链断 → Err。
+        //  (2) 按**存储的 event_id** 取**特定**绑定事件(非"取最新",杜绝攻击者 append 高 id 伪事件
+        //      自动当选);事件缺失(被删)→ fail-closed。
+        //  (3) 行字段与该事件 payload JCS 比对,不一致 → fail-closed(疑似行被改 issuer/AS)。
+        // 合起来:naive 单点篡改被检出;仅完整一致重写整条链(unkeyed chain 固有限制,需外部
+        // anchoring,hash.rs 头注)才能绕过 —— 与账本其余状态同级,非更弱。
+        // binding_event_id NULL = legacy 行(本特性前 onboard / 测试 raw 插入)→ 放行(无法回溯)。
+        if let Some(eid) = binding_event_id {
+            // 注(hostile re-review note c,tracked LOW):verify_chain 全链 O(n),而本读路径经
+            // resolve_access_token 在**每次工具调用**触发 → 长生命周期账本上 O(n²)。当前阶段账本
+            // 小可忽略;规模化优化 = 只验到 binding_event_id 的**前缀**(绑定事件早,前缀有界),或
+            // tail-event_hash 缓存上次 verify 结果。fail-closed 方向正确(账本被篡改即停信任),故非阻塞。
+            self.verify_chain()?;
+            let bound = self
+                .event_payload_by_id(eid)?
+                .ok_or(AuditError::InvalidInput {
+                    reason: "oauth_binding_event_missing",
+                })?;
+            let expected = serde_json::json!({
+                "token_ref": tref,
+                "resource": resource,
+                "authorization_server": authz,
+                "issuer": issuer,
+                "scope_set": scope_set,
+                "token_kind": kind,
+            });
+            if serde_jcs::to_vec(&bound)? != serde_jcs::to_vec(&expected)? {
+                return Err(AuditError::InvalidInput {
+                    reason: "oauth_metadata_integrity_mismatch",
+                });
+            }
+        }
+
         Ok(Some(vigil_http_auth_metadata::OAuthTokenMetadataRow {
-            token_ref,
+            token_ref: tref,
             resource,
             authorization_server: authz,
             scope_set,
@@ -1537,6 +1608,26 @@ impl Ledger {
             created_at,
             issuer,
         }))
+    }
+
+    /// Finding 7:按 `event_id` 取**绑定事件** payload(读侧按行存储的 `binding_event_id` 取**特定**
+    /// 事件,而非"取最新" —— 杜绝攻击者 append 一条高 id 伪绑定事件自动当选)。查询额外约束
+    /// `event_type = oauth.token_metadata_bound`(hostile re-review note 2):若行的 binding_event_id
+    /// 被改指向**别的**事件,类型不符 → `None` → 调用方 fail-closed(意图显式 + 多一道防御)。
+    /// `None` = 该 id 无匹配绑定事件(被删 / 被重指向)→ fail-closed。
+    fn event_payload_by_id(&self, event_id: i64) -> Result<Option<serde_json::Value>> {
+        let guard = self.conn.lock().map_err(|_| AuditError::LockPoisoned)?;
+        let pj: Option<String> = guard
+            .query_row(
+                "SELECT payload_json FROM events WHERE event_id = ?1 AND event_type = ?2",
+                rusqlite::params![event_id, crate::ledger::EVENT_TYPE_OAUTH_METADATA_BOUND],
+                |r| r.get::<_, String>(0),
+            )
+            .optional()?;
+        match pj {
+            Some(s) => Ok(Some(serde_json::from_str(&s)?)),
+            None => Ok(None),
+        }
     }
 
     /// **仅测试用**:绕过 `register_oauth_token_metadata` 的 kind / issuer 校验,

--- a/crates/vigil-audit/src/schema.sql
+++ b/crates/vigil-audit/src/schema.sql
@@ -177,7 +177,11 @@ CREATE TABLE IF NOT EXISTS oauth_token_metadata (
   -- 新库直接带列;legacy I10a 磁盘行通过 COLUMN_MIGRATIONS ADD COLUMN 后为 NULL,
   -- 读侧统一 fail-closed(TokenStoreError "issuer_missing_legacy_row")。
   -- 刻意 nullable(**不**得改 NOT NULL)—— ADD COLUMN NOT NULL 对非空表会失败。
-  issuer               TEXT
+  issuer               TEXT,
+  -- Finding 7(hostile review):本行安全字段绑定到的审计事件 event_id(oauth.token_metadata_bound)。
+  -- 读侧按**此特定 id** 取事件 + verify_chain 校验,使行获得与账本其余状态同级篡改可检测性。
+  -- nullable:legacy(本特性前 onboard)行 NULL → 读侧放行(无法回溯);新行恒带有效 id。
+  binding_event_id     INTEGER
 );
 
 -- I08 Sandbox profile 持久化(ADR 0008 §D6)

--- a/crates/vigil-audit/tests/ledger_invariants.rs
+++ b/crates/vigil-audit/tests/ledger_invariants.rs
@@ -911,6 +911,220 @@ fn register_oauth_token_metadata_rejects_empty_issuer() {
     ));
 }
 
+/// (21) Finding 7(hostile review):`register_oauth_token_metadata` 把行的安全字段绑进审计哈希链;
+/// 行与最新绑定事件一致时 `get_oauth_token_metadata` 正常返回(verify 通过路径)。
+#[test]
+fn finding7_oauth_metadata_binding_happy_path() {
+    let l = Ledger::open_in_memory().unwrap();
+    l.register_oauth_token_metadata(
+        "token://oauth/access/r/c",
+        "https://mcp.example.com/",
+        "https://auth.example.com/",
+        &["mcp:tools.read".into()],
+        "access",
+        None,
+        "https://auth.example.com",
+    )
+    .unwrap();
+    let row = l
+        .get_oauth_token_metadata("token://oauth/access/r/c")
+        .expect("binding 匹配应正常读")
+        .expect("行存在");
+    assert_eq!(row.issuer.as_deref(), Some("https://auth.example.com"));
+}
+
+/// (22) Finding 7 ★安全回归:DB 攻击者绕过 Ledger API,用第二个 raw rusqlite 连接直改
+/// `oauth_token_metadata` 行的 issuer(而审计链里的绑定事件仍是旧值)→ `get_oauth_token_metadata`
+/// 检测行≠链 → **fail-closed**(绝不返回被篡改的 issuer)。模拟真实 DB 篡改,**非 test-util**,CI 内跑。
+#[test]
+fn finding7_tampered_metadata_row_fails_closed() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("ledger.db");
+    let tref = "token://oauth/access/r/c";
+    {
+        let l = Ledger::open(&path).unwrap();
+        l.register_oauth_token_metadata(
+            tref,
+            "https://mcp.example.com/",
+            "https://auth.example.com/",
+            &["mcp:tools.read".into()],
+            "access",
+            None,
+            "https://auth.example.com", // 真 issuer
+        )
+        .unwrap();
+        l.checkpoint().unwrap();
+    }
+    // DB 攻击者:绕过 Ledger,raw SQL 把 issuer 改成恶意 AS(绑定事件不动)。
+    {
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        let n = conn
+            .execute(
+                "UPDATE oauth_token_metadata SET issuer = ?1 WHERE token_ref = ?2",
+                rusqlite::params!["https://evil.example.com", tref],
+            )
+            .unwrap();
+        assert_eq!(n, 1, "篡改应命中 1 行");
+    }
+    let l = Ledger::open(&path).unwrap();
+    let err = l
+        .get_oauth_token_metadata(tref)
+        .expect_err("行被改 issuer 而绑定未变 → 必须 fail-closed");
+    assert!(
+        matches!(
+            err,
+            AuditError::InvalidInput {
+                reason: "oauth_metadata_integrity_mismatch"
+            }
+        ),
+        "期望 integrity mismatch,实际 {err:?}"
+    );
+}
+
+/// (23) Finding 7 向后兼容:无绑定事件的 legacy 行(本特性前 onboard / 直插)→ 放行
+/// (无法回溯校验,不破坏既有 token)。raw 插一行(不经 register → 无绑定事件),get 正常返回。
+#[test]
+fn finding7_legacy_row_without_binding_passes() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("ledger.db");
+    let tref = "token://oauth/access/legacy/x";
+    {
+        let l = Ledger::open(&path).unwrap();
+        l.checkpoint().unwrap(); // 刷 schema 到主库,raw 连接可见
+    }
+    {
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        conn.execute(
+            "INSERT INTO oauth_token_metadata
+               (token_ref, resource, authorization_server, scope_set_json,
+                token_kind, expires_at, created_at, issuer)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            rusqlite::params![
+                tref,
+                "https://mcp.example.com/",
+                "https://auth.example.com/",
+                "[\"mcp:tools.read\"]",
+                "access",
+                Option::<i64>::None,
+                0_i64,
+                "https://auth.example.com",
+            ],
+        )
+        .unwrap();
+    }
+    let l = Ledger::open(&path).unwrap();
+    let row = l
+        .get_oauth_token_metadata(tref)
+        .expect("legacy 行(无绑定)应放行")
+        .expect("行存在");
+    assert_eq!(row.token_ref, tref);
+}
+
+/// (24) Finding 7 ★安全回归(hostile re-review exploit 1):DB 攻击者 **删掉绑定事件** 试图
+/// downgrade 到"无绑定 = legacy 放行" → 读侧按行存的 `binding_event_id` 取不到事件 → **fail-closed**
+/// (绝不因事件消失而把被绑定的行降级当 legacy 放行)。
+#[test]
+fn finding7_deleted_binding_event_fails_closed() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("ledger.db");
+    let tref = "token://oauth/access/r/c";
+    {
+        let l = Ledger::open(&path).unwrap();
+        l.register_oauth_token_metadata(
+            tref,
+            "https://mcp.example.com/",
+            "https://auth.example.com/",
+            &["mcp:tools.read".into()],
+            "access",
+            None,
+            "https://auth.example.com",
+        )
+        .unwrap();
+        l.checkpoint().unwrap();
+    }
+    {
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        let eid: i64 = conn
+            .query_row(
+                "SELECT binding_event_id FROM oauth_token_metadata WHERE token_ref = ?1",
+                rusqlite::params![tref],
+                |r| r.get(0),
+            )
+            .unwrap();
+        conn.execute(
+            "DELETE FROM events WHERE event_id = ?1",
+            rusqlite::params![eid],
+        )
+        .unwrap();
+    }
+    let l = Ledger::open(&path).unwrap();
+    let err = l
+        .get_oauth_token_metadata(tref)
+        .expect_err("删绑定事件必须 fail-closed,绝不 downgrade 到 legacy 放行");
+    assert!(
+        matches!(
+            err,
+            AuditError::InvalidInput {
+                reason: "oauth_binding_event_missing"
+            }
+        ),
+        "实际 {err:?}"
+    );
+}
+
+/// (25) Finding 7 ★安全回归(hostile re-review exploit 2 的 naive 变体):DB 攻击者 **改绑定事件的
+/// payload**(伪装成匹配未来 evil 行)但**不一致重算 hash** → `verify_chain` 检出链断 → **fail-closed**。
+/// (完整一致重写整条链才能绕过 = unkeyed chain 固有限制,与账本其余状态同级,需外部 anchoring。)
+#[test]
+fn finding7_tampered_binding_event_fails_closed_via_verify_chain() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("ledger.db");
+    let tref = "token://oauth/access/r/c";
+    {
+        let l = Ledger::open(&path).unwrap();
+        l.register_oauth_token_metadata(
+            tref,
+            "https://mcp.example.com/",
+            "https://auth.example.com/",
+            &["mcp:tools.read".into()],
+            "access",
+            None,
+            "https://auth.example.com",
+        )
+        .unwrap();
+        l.checkpoint().unwrap();
+    }
+    {
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        let eid: i64 = conn
+            .query_row(
+                "SELECT binding_event_id FROM oauth_token_metadata WHERE token_ref = ?1",
+                rusqlite::params![tref],
+                |r| r.get(0),
+            )
+            .unwrap();
+        // 改 payload 的 issuer 为恶意 AS,但保留旧 event_hash(不一致重算)。
+        let evil = format!(
+            r#"{{"authorization_server":"https://auth.example.com/","issuer":"https://evil.example.com","resource":"https://mcp.example.com/","scope_set":["mcp:tools.read"],"token_kind":"access","token_ref":"{tref}"}}"#
+        );
+        let n = conn
+            .execute(
+                "UPDATE events SET payload_json = ?1 WHERE event_id = ?2",
+                rusqlite::params![evil, eid],
+            )
+            .unwrap();
+        assert_eq!(n, 1);
+    }
+    let l = Ledger::open(&path).unwrap();
+    let err = l
+        .get_oauth_token_metadata(tref)
+        .expect_err("改绑定事件 payload 不重算 hash → verify_chain 必检出 → fail-closed");
+    assert!(
+        matches!(err, AuditError::ChainBroken { .. }),
+        "期望 ChainBroken(verify_chain 检出),实际 {err:?}"
+    );
+}
+
 /// ISS-20260621-004 回归:多个独立连接**并发** `Ledger::open` 同一新磁盘库,不得有任何连接
 /// 因撞锁失败。根因:`init()` 此前在 `PRAGMA journal_mode = WAL`(取排他锁)**之前**未设
 /// busy_timeout,并发 open 撞锁会因 busy_timeout 仍是默认 0 而**立即** "database is locked"


### PR DESCRIPTION
## Finding 7 — bind `oauth_token_metadata` into the audit hash chain

Follow-up security hardening to the OAuth HTTP MCP upstream (#29). A hostile review of that feature found that `oauth_token_metadata` rows — the **root of OAuth token verification** (`issuer` / `authorization_server` / `resource` / `token_ref` / `scope` / `kind`) — lived **outside** the `vigil-audit` hash chain (a plain INSERT). They were the only security-critical state with **zero** tamper-evidence: a local DB attacker could flip `issuer`/`authorization_server` undetected and force acceptance of a forged token.

### What changed
- **New `binding_event_id` column.** `register_oauth_token_metadata` now appends an `oauth.token_metadata_bound` audit event carrying the row's security fields, and stores that event's `event_id` on the row. **Append-event-first, then INSERT** the row with the id → a row never exists without a valid binding reference (no non-atomic kill-window; a crash leaves only a harmless orphan event).
- **Verified read.** `get_oauth_token_metadata` (inherited by `resolve_access_token` / `build_oauth_upstream`): if the row is bound → `verify_chain()` + fetch the bound event by its **stored id** (constrained to the binding `event_type`) + JCS-compare to the row → **fail-closed** on any mismatch / missing event / chain break. Legacy rows (no binding) pass — non-breaking.

### Security scope (honest)
This brings oauth metadata to the **same tamper-evidence as the rest of the ledger**: naive single-row tampering, binding-event deletion, and forged-event-append are all detected. Only a **full consistent chain rewrite** defeats it — the unkeyed-chain limitation that needs external checkpoint anchoring (documented in `hash.rs`), a pre-existing whole-chain limit tracked separately. No more, no less than any `tool_call.*` event.

### Review
Two hostile-review rounds. The **first cut was BLOCKED**: the read path compared the row to an events payload but never verified the chain, so an attacker could just DELETE the binding event (legacy bypass) or append a forged higher-id one — a deterrent, not tamper-evidence. The `verify_chain()` + bind-by-stored-`event_id` fix (+ append-first atomicity) got a **SHIP** verdict; both exploits now fail-closed.

### Tests (CI, realistic raw-`rusqlite` DB writes to the same file)
- happy-path verify · tamper-row → mismatch · legacy-NULL → pass
- **DELETE binding event → fail-closed** (exploit 1) · **tamper binding-event payload → `ChainBroken`** (exploit 2)

Local full workspace green: 1126 tests, `clippy --workspace --all-targets -D warnings`, `cargo fmt --check`. PR to run authoritative Linux CI.

### Tracked LOW follow-ups (not in this PR)
- `verify_chain` runs per OAuth tool-call via `resolve_access_token` → O(n²) on long-lived ledgers (negligible now; scale-up = prefix-verify to `binding_event_id`, or tail-hash verify cache). Fail-closed direction is correct.
- External checkpoint anchoring (the only thing that closes the full-rewrite residual for the whole chain).
