### PR TITLE
ci(release): scope rust-cache key by matrix.os (prevent cross-ubuntu cache poisoning)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          # CI 卫生:key 含 OS 镜像版本,防 ubuntu-22.04/24.04 共享 target/(见 v0.4.0 gtk GLIBC 事故)。
+          prefix-key: "v0-rust-${{ matrix.os }}"
 
       - name: Install Linux deps (keyring / secret-service)
         # robust:按 runner OS 判定而非钉死版本字符串(改 runner 版本不漏装 = 不静默断 keyring 链)。
@@ -276,6 +279,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          # CI 卫生:key 含 OS 镜像版本,防 ubuntu-22.04/24.04 共享 target/(见 v0.4.0 gtk GLIBC 事故)。
+          prefix-key: "v0-rust-${{ matrix.os }}"
 
       - name: Install Linux deps (keyring / secret-service)
         if: runner.os == 'Linux'
@@ -411,6 +417,9 @@ jobs:
           node-version: 20
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          # CI 卫生:key 含 OS 镜像版本,防 ubuntu-22.04/24.04 共享 target/(见 v0.4.0 gtk GLIBC 事故)。
+          prefix-key: "v0-rust-${{ matrix.os }}"
 
       - name: Install Linux Tauri system deps
         if: matrix.os == 'ubuntu-22.04'


### PR DESCRIPTION
## Problem
The v0.4.0 Release run's `desktop (ubuntu-22.04, linux-x86_64)` job failed at the bundle step:

```
gtk v0.18.2 build-script-build: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

## Root cause
`Swatinem/rust-cache`'s key only includes `runner.os` ("Linux"), not the ubuntu image version. The 2026-06-22 change lowered the Linux desktop build floor from `ubuntu-latest` (24.04 / glibc 2.39) to `ubuntu-22.04` (glibc 2.35). v0.4.0 was the first release on 22.04, so the desktop-Linux job **prefix-restored a stale 24.04-built `target/`** whose cached `gtk` build-script binary links `GLIBC_2.39` — which cannot run on the 22.04 runner.

## Fix
Scope the rust-cache key by `matrix.os` on all three release build jobs (`cli`, `cli-ml`, `desktop`):

```yaml
with:
  prefix-key: "v0-rust-${{ matrix.os }}"
```

so `ubuntu-22.04` and `ubuntu-latest` never share a `target/`.

## Notes
- v0.4.0 was already unblocked out-of-band (deleted the stale caches + re-ran the failed job); **this PR prevents recurrence** on any future OS-floor change.
- One-time cache miss on the next release (new key namespace), then stable. No code / behaviour change.
