### PR TITLE
Fix v0.4.0 distribution bugs found by release-acceptance testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,7 +238,8 @@ jobs:
         run: |
           $f = "vigils-cli-${{ matrix.plat }}.${{ matrix.archive }}"
           $h = (Get-FileHash -Algorithm SHA256 "dist/$f").Hash.ToLower()
-          Set-Content -Path "dist/$f.sha256" -Value "$h  $f" -Encoding ascii
+          # LF (not CRLF) so `sha256sum -c` works in Unix-y environments / git-bash / WSL
+          Set-Content -Path "dist/$f.sha256" -Value "$h  $f`n" -NoNewline -Encoding ascii
 
       - name: Upload to release
         uses: softprops/action-gh-release@v2
@@ -371,7 +372,8 @@ jobs:
         run: |
           $f = "vigils-cli-ml-${{ matrix.plat }}.${{ matrix.archive }}"
           $h = (Get-FileHash -Algorithm SHA256 "dist/$f").Hash.ToLower()
-          Set-Content -Path "dist/$f.sha256" -Value "$h  $f" -Encoding ascii
+          # LF (not CRLF) so `sha256sum -c` works in Unix-y environments / git-bash / WSL
+          Set-Content -Path "dist/$f.sha256" -Value "$h  $f`n" -NoNewline -Encoding ascii
 
       - name: Upload ML to release
         uses: softprops/action-gh-release@v2

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ __pycache__/
 /ref-*.jpeg
 /ref-*.jpg
 /ref-*.png
+
+# release-acceptance suite local config (SSH targets)
+tests/acceptance/config.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5802,6 +5802,7 @@ dependencies = [
  "interprocess",
  "oauth2",
  "rusqlite",
+ "rustix 1.1.4",
  "serde",
  "serde_jcs",
  "serde_json",

--- a/apps/vigil-hub-cli/Cargo.toml
+++ b/apps/vigil-hub-cli/Cargo.toml
@@ -69,6 +69,11 @@ vigil-ui-protocol = { path = "../../crates/vigil-ui-protocol" }
 # R1 peer-credential + R2 读截止 在其 raw fd/handle 上另加(见 daemon/transport.rs)。
 interprocess = "2"
 
+# macOS daemon R1:`peer_creds().pid()` 在 macOS UDS 恒 None(无 SO_PEERCRED),euid 可用。
+# 用 rustix(安全封装,本 crate 仍 forbid unsafe)取自身 euid 与对端比对。版本对齐 lock 既有 1.x。
+[target.'cfg(target_os = "macos")'.dependencies]
+rustix = { version = "1", features = ["process"] }
+
 [dev-dependencies]
 # CLI 级集成测试用(β R1 MUST-FIX 4):InMemorySecretStore 注入 + mock AS
 vigil-audit = { path = "../../crates/vigil-audit", features = ["test-util"] }

--- a/apps/vigil-hub-cli/src/daemon/transport.rs
+++ b/apps/vigil-hub-cli/src/daemon/transport.rs
@@ -4,10 +4,12 @@
 //! - **单实例** = OS bind 失败守门([`bind`] 已有 listener → Err;一名一 listener)。
 //! - **R2**:整段查询(连接 + 握手 + 请求 + 读响应)跑在工作线程,主线程 `recv_timeout` 总截止;
 //!   超时 → None → 硬指纹(防慢 / 挤牙膏 daemon 楔死每次工具调用)。
-//! - **R1**(peer-credential):连接后核对**对端(server)进程 PID == `daemon.json.pid`**,经
-//!   interprocess **原生** `peer_creds().pid()`(其内部封装平台 unsafe;故本 crate 仍 forbid unsafe,
-//!   无需自有 FFI)。防同用户冒充 daemon(token 自洽不够 —— 冒充者伪造不了真 daemon 的 PID)。
-//!   取不到 / 不符 → fail-closed → 硬指纹。
+//! - **R1**(peer-credential):**Linux/Windows** 连接后核对**对端(server)进程 PID ==
+//!   `daemon.json.pid`**(经 interprocess 原生 `peer_creds().pid()`)。**macOS** 上
+//!   `peer_creds().pid()` 恒 None(无 `SO_PEERCRED`)→ 退化为 **euid 校验**(对端必须以**本用户**
+//!   身份运行)。注意:macOS 为 **euid-only,不作 pid 绑定**,故不主张 pid-reuse 保护——cross-user
+//!   由用户私有目录权限排除,同用户冒充由 token + 单实例 bind 兜底;且**永不 fail-open**(硬指纹
+//!   底座在 hook 内先跑,冒充/缺失至多抑制 ML recall)。取不到 / 不符 → fail-closed → 硬指纹。
 //! - **R6**(socket 权限硬化,后续):Unix 0600 / Windows pipe DACL。
 
 use std::sync::mpsc;
@@ -15,21 +17,97 @@ use std::time::Duration;
 use std::{io, thread};
 
 use interprocess::local_socket::prelude::*;
-use interprocess::local_socket::{GenericNamespaced, ListenerOptions, Stream as LocalStream};
+use interprocess::local_socket::{ListenerOptions, Stream as LocalStream};
+#[cfg(target_os = "macos")]
+use interprocess::local_socket::GenericFilePath;
+#[cfg(not(target_os = "macos"))]
+use interprocess::local_socket::GenericNamespaced;
 
 use super::client::{daemon_info_path, exchange, read_daemon_info, DaemonInfo};
 use super::protocol::{Request, Response};
 use super::server::{handle_connection, DaemonCaps};
 
-/// 默认 daemon socket 名(namespaced:Unix 抽象 UDS / Windows `\\.\pipe\`)。
+/// 默认 daemon socket 标识。
+///
+/// - **Linux**:`GenericNamespaced` → 抽象 UDS(`\0` 前缀,内核在进程死亡时自动回收,无 stale)。
+/// - **Windows**:`GenericNamespaced` → `\\.\pipe\vigil-daemon.sock`(named pipe,句柄关即清)。
+/// - **macOS**:**无抽象命名空间** —— namespaced 会落到世界可读的 `/tmp` 文件 socket、非干净
+///   退出不回收(EADDRINUSE 永久卡死重启)、且 `peer_creds().pid()` 恒 None(R1 失效)。故改用
+///   **用户私有数据目录下的显式文件 socket**(与 daemon.json 同目录;cross-user 由目录权限排除),
+///   配合 bind 前 stale 清理 + euid 版 R1(见 [`bind`] / [`connect_and_verify`])。
 pub fn default_socket_name() -> String {
-    "vigil-daemon.sock".to_string()
+    #[cfg(target_os = "macos")]
+    {
+        dirs::data_local_dir()
+            .map(|dir| {
+                dir.join("Vigil")
+                    .join("vigil-daemon.sock")
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .unwrap_or_else(|| {
+                // 回退也用**每用户私有** temp(macOS `$TMPDIR` = /var/folders/.../T,0700),
+                // 绝不用世界可写的 `/tmp`(防跨用户 squat / stale 不清 —— 正是本修复要消灭的类)。
+                std::env::temp_dir()
+                    .join("vigil-daemon.sock")
+                    .to_string_lossy()
+                    .into_owned()
+            })
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        "vigil-daemon.sock".to_string()
+    }
 }
 
-/// 绑定 socket(server)。**单实例**:已有同名 listener → `Err`(OS 强制一名一 listener)。
+/// 绑定 socket(server)。**单实例**:已有**存活**同名 listener → `Err`(OS 强制一名一 listener)。
+///
+/// macOS:文件 socket 在非干净退出(kill/crash,Drop 不跑)后残留 → 旧版 namespaced 永久
+/// `EADDRINUSE`。此处 bind 前 **probe-then-unlink**:文件在但连不通(stale)→ 删之重绑;
+/// 连得通(真有存活 daemon)→ 保留 → `create_sync` 返 `AddrInUse` → 单实例守门不破。
 pub fn bind(socket_name: &str) -> io::Result<interprocess::local_socket::Listener> {
-    let name = socket_name.to_ns_name::<GenericNamespaced>()?;
-    ListenerOptions::new().name(name).create_sync()
+    #[cfg(target_os = "macos")]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // bind 早于 write_daemon_info(其会建目录)→ 先确保父目录在并 **0700**(仅 owner;
+        // 不把 `~/Library` 默认权限当唯一屏障 —— 防同主机跨用户连接,且回退 temp 路径下也成立)。
+        if let Some(parent) = std::path::Path::new(socket_name).parent() {
+            if !parent.as_os_str().is_empty() {
+                let _ = std::fs::create_dir_all(parent);
+                let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700));
+            }
+        }
+        reclaim_stale_socket(socket_name);
+        let name = socket_name.to_fs_name::<GenericFilePath>()?;
+        let listener = ListenerOptions::new().name(name).create_sync()?;
+        // R6:socket 节点 0600(仅 owner 可连),目录权限之外再加一层。
+        let _ = std::fs::set_permissions(socket_name, std::fs::Permissions::from_mode(0o600));
+        Ok(listener)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let name = socket_name.to_ns_name::<GenericNamespaced>()?;
+        ListenerOptions::new().name(name).create_sync()
+    }
+}
+
+/// macOS:bind 前清理 stale 文件 socket。存活 daemon(连得通)→ 不动,让 `create_sync` 以
+/// `AddrInUse` 守单实例;连不通(unclean exit 残留)→ unlink,使重绑成功。
+#[cfg(target_os = "macos")]
+fn reclaim_stale_socket(path: &str) {
+    if !std::path::Path::new(path).exists() {
+        return;
+    }
+    // 存活探测带短重试:活 daemon(即便 accept backlog 瞬时满)会在几 ms 内接受连接,真 stale
+    // socket 永不接受。重试收窄 false-stale 窗口——瞬时不可达 + 并发 daemon start 竞态(给对端
+    // create_sync 完成的时间)——避免误删存活 daemon 的 socket(codex/hostile 双审 item 2)。
+    for _ in 0..5 {
+        if connect_raw(path).is_some() {
+            return; // 活 daemon —— 保留,单实例由 create_sync 的 AddrInUse 守门
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    let _ = std::fs::remove_file(path); // 连续探测均失败 → 确属 stale → 删之以便重绑
 }
 
 /// server accept 循环:每连接 spawn [`handle_connection`](thread-per-conn,简化;bounded 后续)。
@@ -49,6 +127,8 @@ pub fn serve(listener: interprocess::local_socket::Listener, caps: DaemonCaps) {
 /// `forbid(unsafe_code)`,无需自有 FFI)。取不到 → `None`(上游 fail-closed)。
 // interprocess `Pid` 平台相异:Windows = `u32`(`try_from` 是 no-op),Unix = `pid_t`(i32,需转 +
 // 滤负)。allow 让单一跨平台函数在两侧都正确(Windows 上的"多余转换"被刻意接受)。
+// macOS 上 `peer_creds().pid()` 恒 None(无 SO_PEERCRED)→ pid 版 R1 不适用,仅非 macOS 编译。
+#[cfg(not(target_os = "macos"))]
 #[allow(clippy::useless_conversion)]
 fn peer_pid(stream: &LocalStream) -> Option<u32> {
     let pid = stream.peer_creds().ok()?.pid()?;
@@ -57,6 +137,9 @@ fn peer_pid(stream: &LocalStream) -> Option<u32> {
 
 /// 连接 socket(**无 R1**)。供 transport 机制测试 + R1 落地后内部复用。
 fn connect_raw(socket_name: &str) -> Option<LocalStream> {
+    #[cfg(target_os = "macos")]
+    let name = socket_name.to_fs_name::<GenericFilePath>().ok()?;
+    #[cfg(not(target_os = "macos"))]
     let name = socket_name.to_ns_name::<GenericNamespaced>().ok()?;
     LocalStream::connect(name).ok()
 }
@@ -65,11 +148,34 @@ fn connect_raw(socket_name: &str) -> Option<LocalStream> {
 /// 取不到对端 pid(无凭据 / `peer_creds` 失败)→ 整体 fail-closed `None`(绝不连未经身份核验的 daemon)。
 fn connect_and_verify(socket_name: &str, expected_pid: u32) -> Option<LocalStream> {
     let stream = connect_raw(socket_name)?;
-    let pid = peer_pid(&stream)?;
-    if pid != expected_pid {
-        return None;
+    #[cfg(not(target_os = "macos"))]
+    {
+        // Linux/Windows:对端 server pid 必须 == daemon.json.pid。
+        if peer_pid(&stream)? != expected_pid {
+            return None;
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // macOS:peer_creds().pid() 恒 None(无 SO_PEERCRED);euid 可用。socket + daemon.json
+        // 均在用户私有目录(cross-user 由目录权限排除)→ R1 等价检查 = 对端 server 必须以**本
+        // 用户**身份运行(euid 相等);pid 在此无意义。
+        let _ = expected_pid;
+        if !peer_is_current_user(&stream) {
+            return None;
+        }
     }
     Some(stream)
+}
+
+/// macOS R1:对端(server)euid == 本进程 euid(都是当前用户)。取不到 → fail-closed。
+/// `rustix::process::geteuid` 安全封装(本 crate 仍 `forbid(unsafe_code)`)。
+#[cfg(target_os = "macos")]
+fn peer_is_current_user(stream: &LocalStream) -> bool {
+    match stream.peer_creds().ok().and_then(|c| c.euid()) {
+        Some(peer_euid) => peer_euid == rustix::process::geteuid().as_raw(),
+        None => false,
+    }
 }
 
 /// 用一个 [`DaemonInfo`] 跑一次查询(连接其 socket_path + R1 核 pid + exchange)。fail-closed。
@@ -103,7 +209,18 @@ mod tests {
 
     fn unique_sock(tag: &str) -> String {
         // 唯一名(进程 id + tag):防与真 daemon / 并行测试碰撞;**不碰真 daemon.json**。
-        format!("vigil-itest-{}-{}.sock", tag, std::process::id())
+        // macOS 用 GenericFilePath(文件路径)→ 落 temp 绝对路径,避免污染 CWD。
+        #[cfg(target_os = "macos")]
+        {
+            std::env::temp_dir()
+                .join(format!("vigil-itest-{}-{}.sock", tag, std::process::id()))
+                .to_string_lossy()
+                .into_owned()
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            format!("vigil-itest-{}-{}.sock", tag, std::process::id())
+        }
     }
 
     fn spawn_daemon(sock: &str, token: &str, up: u64) {
@@ -156,6 +273,8 @@ mod tests {
         );
     }
 
+    // pid 版 R1 仅非 macOS;macOS 走 euid(同进程必同 euid,无法用 pid 构造拒绝用例)。
+    #[cfg(not(target_os = "macos"))]
     #[test]
     fn r1_rejects_wrong_expected_pid() {
         // R1:对端真实 pid = 本进程;expected 设不可能值 → fail-closed None(防冒充 daemon)。

--- a/apps/vigil-hub-cli/src/daemon/transport.rs
+++ b/apps/vigil-hub-cli/src/daemon/transport.rs
@@ -17,11 +17,11 @@ use std::time::Duration;
 use std::{io, thread};
 
 use interprocess::local_socket::prelude::*;
-use interprocess::local_socket::{ListenerOptions, Stream as LocalStream};
 #[cfg(target_os = "macos")]
 use interprocess::local_socket::GenericFilePath;
 #[cfg(not(target_os = "macos"))]
 use interprocess::local_socket::GenericNamespaced;
+use interprocess::local_socket::{ListenerOptions, Stream as LocalStream};
 
 use super::client::{daemon_info_path, exchange, read_daemon_info, DaemonInfo};
 use super::protocol::{Request, Response};

--- a/apps/vigil-hub-cli/src/hook.rs
+++ b/apps/vigil-hub-cli/src/hook.rs
@@ -1916,31 +1916,52 @@ fn safe_label(label: &str) -> String {
 }
 
 /// 把 daemon 的 [`WireFinding`] span(相对前 `scanned_len` 字节前缀)应用到 `seg`,命中处替换为
-/// `[REDACTED <label>]`。**右→左单遍**(替换不挪未处理前缀的 offset);span 空/逆序、越出扫描前缀、
-/// 非 char-boundary、或与已处理区间重叠 → 跳过(防御 + 防 panic)。命中计入 `report.ml_hits` + 置 changed。
+/// `[REDACTED <label>]`。空/逆序、越出扫描前缀、非 char-boundary 的 span 先剔除(防 panic + 防御),
+/// 再**并集合并**成互不重叠区间后右→左单遍替换。
+///
+/// **为何并集而非"重叠跳过"(VIGIL-SEC-OVERLAP)**:daemon 可能对相邻实体吐嵌套/重叠 span。旧实现
+/// 右→左 + "与已处理区间重叠则跳过"会漏掉外层 span 独有的 PII 前缀 —— 例如 `[3,7)` 与已处理 `[5,9)`
+/// 重叠被整条跳过,其独有的 `[3,5)` 明文 PII **残留泄漏**;且嵌套场景产生破碎嵌套占位符。并集合并
+/// (与 vigil-redaction `build_redacted_text` 同款 leak-safe 策略)保证每个被任一 span 命中的字节都
+/// 落入某替换区间。`report.ml_hits` 计并集后实际替换的区间数。
 fn apply_wire_spans(
     seg: &str,
     scanned_len: usize,
     findings: &[WireFinding],
     report: &mut RedactReport,
 ) -> String {
-    let mut spans: Vec<&WireFinding> = findings.iter().collect();
-    spans.sort_by_key(|f| std::cmp::Reverse(f.start)); // 降序 by start → 右→左替换
+    // 剔除非法 span(空/逆序、越出扫描前缀、非 char-boundary),保留 (start, end, label)。
+    let mut spans: Vec<(usize, usize, &str)> = findings
+        .iter()
+        .filter(|f| {
+            f.start < f.end
+                && f.end <= scanned_len
+                && seg.is_char_boundary(f.start)
+                && seg.is_char_boundary(f.end)
+        })
+        .map(|f| (f.start, f.end, f.label.as_str()))
+        .collect();
+    if spans.is_empty() {
+        return seg.to_string();
+    }
+    // start 升序、同 start 时 end 降序(长 span 作并集代表名)。
+    spans.sort_by(|a, b| a.0.cmp(&b.0).then(b.1.cmp(&a.1)));
+    // 并集合并成互不重叠区间(代表 label 取并集内 start 最小→最长者)。
+    let mut merged: Vec<(usize, usize, &str)> = Vec::with_capacity(spans.len());
+    for (start, end, label) in spans {
+        match merged.last_mut() {
+            Some(last) if start < last.1 => {
+                if end > last.1 {
+                    last.1 = end;
+                }
+            }
+            _ => merged.push((start, end, label)),
+        }
+    }
+    // 右→左替换(merged 已 start 升序且互不重叠,从后往前不影响前面区间 index)。
     let mut out = seg.to_string();
-    let mut lowest_applied = out.len(); // 已替换区间的最小起点(防重叠)
-    for f in spans {
-        if f.start >= f.end || f.end > scanned_len {
-            continue; // 空/逆序 span,或越出扫描前缀
-        }
-        if f.end > lowest_applied {
-            continue; // 与已替换区间重叠(merge 应已无重叠;防御性)
-        }
-        if !out.is_char_boundary(f.start) || !out.is_char_boundary(f.end) {
-            continue;
-        }
-        let label = safe_label(&f.label);
-        out.replace_range(f.start..f.end, &format!("[REDACTED {label}]"));
-        lowest_applied = f.start;
+    for &(start, end, label) in merged.iter().rev() {
+        out.replace_range(start..end, &format!("[REDACTED {}]", safe_label(label)));
         report.ml_hits += 1;
         report.changed = true;
     }
@@ -2335,12 +2356,31 @@ mod tests {
     }
 
     #[test]
-    fn apply_wire_spans_overlap_defensive_skip() {
-        // 重叠 span(merge 本应无,防御性):右→左,[3,7) 与已处理 [5,9) 重叠 → 跳过。
+    fn apply_wire_spans_overlap_union_merged_no_leak() {
+        // 重叠 span 并集合并(VIGIL-SEC-OVERLAP):[3,7) 与 [5,9) → 并集 [3,9),全覆盖。
+        // 旧"重叠跳过"实现会留下 [3,7) 独有的 "de"(残留泄漏 "abcde[REDACTED a]j");并集后无残留。
         let seg = "abcdefghij";
         let mut report = RedactReport::default();
         let out = apply_wire_spans(seg, seg.len(), &[wf("a", 5, 9), wf("b", 3, 7)], &mut report);
-        assert_eq!(out, "abcde[REDACTED a]j");
+        assert_eq!(out, "abc[REDACTED b]j", "重叠应并集为单一占位符,覆盖 [3,9)");
+        assert!(!out.contains("de"), "[3,7) 独有前缀 de 不得残留:{out}");
+        assert_eq!(report.ml_hits, 1);
+    }
+
+    #[test]
+    fn apply_wire_spans_nested_no_leak() {
+        // 嵌套 span:外 [0,40] 套内 [15,40](内层长)。旧右→左 + 重叠跳过会跳过外层 →
+        // 外层前缀 "Jonathan Whitfi" 明文泄漏("Jonathan Whitfi[REDACTED person]")。
+        let seg = "Jonathan Whitfield Robert Smith Junior!!"; // 40 字节(ASCII)
+        let mut report = RedactReport::default();
+        let out = apply_wire_spans(
+            seg,
+            seg.len(),
+            &[wf("person", 0, 40), wf("person", 15, 40)],
+            &mut report,
+        );
+        assert!(!out.contains("Jonathan"), "外层 PII 前缀泄漏:{out}");
+        assert_eq!(out, "[REDACTED person]", "嵌套应并集为单一占位符");
         assert_eq!(report.ml_hits, 1);
     }
 

--- a/apps/vigil-hub-cli/src/hook.rs
+++ b/apps/vigil-hub-cli/src/hook.rs
@@ -1924,6 +1924,13 @@ fn safe_label(label: &str) -> String {
 /// 重叠被整条跳过,其独有的 `[3,5)` 明文 PII **残留泄漏**;且嵌套场景产生破碎嵌套占位符。并集合并
 /// (与 vigil-redaction `build_redacted_text` 同款 leak-safe 策略)保证每个被任一 span 命中的字节都
 /// 落入某替换区间。`report.ml_hits` 计并集后实际替换的区间数。
+///
+/// **已知 P2(无泄漏,VIGIL-SEC-OVERLAP-PH)**:daemon 在 `redact_boundary_value` 已脱敏(含
+/// `[REDACTED …]` 占位符)的文本上扫描,其 ML span 可 over-capture 延伸进占位符 → `replace_range`
+/// 切碎成破碎嵌套占位符(macOS 实测 `[[REDACTED address]DACTED email]`)。**无原值泄漏**(被切的
+/// 是占位符,真值早被硬指纹脱敏)。安全修法须从脱敏步骤**透传真实占位符字节区间**给本函数后做减法
+/// —— 不可用正则识别 `[REDACTED …]`(攻击者可在工具输出伪造假占位符把语义 PII 包进去 → ML 跳过 →
+/// 绕过脱敏)。待后续 slice 实现该 plumbing。
 fn apply_wire_spans(
     seg: &str,
     scanned_len: usize,

--- a/crates/vigil-redaction/src/bootstrap/download.rs
+++ b/crates/vigil-redaction/src/bootstrap/download.rs
@@ -28,9 +28,28 @@ use sha2::{Digest, Sha256};
 
 use super::error::BootstrapError;
 
-/// 单 chunk 下载超时(ADR 0012 §3.4)。900 MB onnx ÷ 16 chunks ≈ 56 MB / chunk;
-/// 30s 在 5 MB/s 慢线下也够;过长会拖慢全失败 fallback 决策。
+/// 控制类小请求超时(ETag 短路 GET `Range: 0-0` 等轻请求)。
+/// 注:**chunk 体下载**不再用此固定值 —— 见 [`chunk_timeout`](按 chunk 大小动态定)。
 const CHUNK_TIMEOUT: Duration = Duration::from_secs(30);
+
+// chunk 体下载的动态超时参数。
+//
+// 根因复盘(v0.4.0 Linux 真机):16 chunk **并发共享带宽**,~48 MB/chunk 在 ~11.5 MB/s 链路上
+// 单 chunk 实测 ~65s;旧固定 30s **总请求**超时会中途砍断 body 读取(reqwest
+// "error decoding response body")→ 整下载失败,而 curl(无超时)同链路 70s 跑完。
+// 旧注释"30s 在 5 MB/s 慢线够"忽略了 16 路并发每路只剩 ~0.7 MB/s。
+// 改:按 chunk 字节数 / 最低可接受吞吐换算超时,使"慢但持续推进"的链路也能成功;
+// truly-dead 连接由 `connect_timeout`(10s)兜底,极端中途 stall 由 ceil 上限收敛。
+const MIN_CHUNK_BYTES_PER_SEC: u64 = 128 * 1024; // 128 KiB/s/chunk(≈ 2 MiB/s 聚合 @16）
+const CHUNK_TIMEOUT_FLOOR_SECS: u64 = 60;
+const CHUNK_TIMEOUT_CEIL_SECS: u64 = 900; // 与单流路径 900s 上限一致
+
+/// 按本 chunk 大小推导**下载体**总超时,夹逼到 `[floor, ceil]`。
+fn chunk_timeout(chunk_bytes: u64) -> Duration {
+    let secs =
+        (chunk_bytes / MIN_CHUNK_BYTES_PER_SEC).clamp(CHUNK_TIMEOUT_FLOOR_SECS, CHUNK_TIMEOUT_CEIL_SECS);
+    Duration::from_secs(secs)
+}
 
 /// HEAD 探测同样 30s 上限(轻请求,正常 < 1s)。
 const HEAD_TIMEOUT: Duration = Duration::from_secs(30);
@@ -406,10 +425,14 @@ fn fetch_chunk_once(
     start: u64,
     end_incl: u64,
 ) -> Result<(), BootstrapError> {
-    let client = build_client(CHUNK_TIMEOUT).map_err(|e| BootstrapError::DownloadFailed {
-        url: url.to_string(),
-        status: 0,
-        source: e,
+    // 按本 chunk 大小定**下载体**超时(见 chunk_timeout):16 路并发共享带宽时,大 chunk
+    // 合法地需要 >30s;固定 30s 总超时会砍断进行中的 body 读取(v0.4.0 Linux 真机失败根因)。
+    let client = build_client(chunk_timeout(end_incl - start + 1)).map_err(|e| {
+        BootstrapError::DownloadFailed {
+            url: url.to_string(),
+            status: 0,
+            source: e,
+        }
     })?;
     let range_val = format!("bytes={start}-{end_incl}");
     // Accept-Encoding: identity 必须与 url_supports_ranges 探测一致 —— 否则探测(identity)
@@ -543,5 +566,18 @@ mod chunk_math_tests {
         let chunk = total.div_ceil(n).max(1); // = 1
         assert_eq!(chunk, 1);
         // idx 0:start=0, end_incl=0 → 单字节;idx 1+:start>=1 → 空 partial
+    }
+
+    #[test]
+    fn chunk_timeout_scales_with_size_and_clamps() {
+        use super::{chunk_timeout, CHUNK_TIMEOUT_CEIL_SECS, CHUNK_TIMEOUT_FLOOR_SECS};
+        // 小请求 → floor(不让 3 KB config 等 900s)
+        assert_eq!(chunk_timeout(1024).as_secs(), CHUNK_TIMEOUT_FLOOR_SECS);
+        // ~48 MiB chunk(真机失败规模):远超旧 30s,且 < ceil → 慢链路也能跑完
+        let secs = chunk_timeout(50_566_375).as_secs();
+        assert!(secs > 300, "48MB chunk timeout should comfortably exceed 65s real time, got {secs}");
+        assert!(secs <= CHUNK_TIMEOUT_CEIL_SECS);
+        // 超大 → ceil 收敛
+        assert_eq!(chunk_timeout(u64::MAX).as_secs(), CHUNK_TIMEOUT_CEIL_SECS);
     }
 }

--- a/crates/vigil-redaction/src/bootstrap/download.rs
+++ b/crates/vigil-redaction/src/bootstrap/download.rs
@@ -46,8 +46,8 @@ const CHUNK_TIMEOUT_CEIL_SECS: u64 = 900; // 与单流路径 900s 上限一致
 
 /// 按本 chunk 大小推导**下载体**总超时,夹逼到 `[floor, ceil]`。
 fn chunk_timeout(chunk_bytes: u64) -> Duration {
-    let secs =
-        (chunk_bytes / MIN_CHUNK_BYTES_PER_SEC).clamp(CHUNK_TIMEOUT_FLOOR_SECS, CHUNK_TIMEOUT_CEIL_SECS);
+    let secs = (chunk_bytes / MIN_CHUNK_BYTES_PER_SEC)
+        .clamp(CHUNK_TIMEOUT_FLOOR_SECS, CHUNK_TIMEOUT_CEIL_SECS);
     Duration::from_secs(secs)
 }
 
@@ -575,7 +575,10 @@ mod chunk_math_tests {
         assert_eq!(chunk_timeout(1024).as_secs(), CHUNK_TIMEOUT_FLOOR_SECS);
         // ~48 MiB chunk(真机失败规模):远超旧 30s,且 < ceil → 慢链路也能跑完
         let secs = chunk_timeout(50_566_375).as_secs();
-        assert!(secs > 300, "48MB chunk timeout should comfortably exceed 65s real time, got {secs}");
+        assert!(
+            secs > 300,
+            "48MB chunk timeout should comfortably exceed 65s real time, got {secs}"
+        );
         assert!(secs <= CHUNK_TIMEOUT_CEIL_SECS);
         // 超大 → ceil 收敛
         assert_eq!(chunk_timeout(u64::MAX).as_secs(), CHUNK_TIMEOUT_CEIL_SECS);

--- a/crates/vigil-redaction/src/scan.rs
+++ b/crates/vigil-redaction/src/scan.rs
@@ -372,41 +372,58 @@ pub(crate) fn risk_of(kind: &str) -> u32 {
     }
 }
 
-/// 按 findings 的 span 从后往前替换,避免 offset 漂移。
-/// 替换文案走 `PrivacyLabel::as_str()`(稳定契约);未识别 kind 降级用原字面量,
-/// 保证不丢信息。
+/// 按 findings 的 span 替换为 `[REDACTED <label>]`;替换文案走 `PrivacyLabel::as_str()`
+/// (稳定契约),未识别 kind 降级用原字面量,保证不丢信息。
 ///
-/// **重叠 span 的 leak 安全性(D16 审计修正)**:`merge_findings` 已去掉与 Hard 重叠的
-/// Model,但 **Hard×Hard 内部确实会重叠** —— 最常见 `env_assignment` 匹配整段 `KEY=secret`、
-/// 同时内层硬规则(`github_token`/`database_url`/…)匹配 `secret` 部分(此前注释误称"不出现
-/// 跨规则同位重叠",已证伪)。本实现对重叠**仍 leak-safe**,依据:① 按 start **降序**处理,
-/// 内层(start 更大)secret **先**被 `replace_range` 覆盖;② 外层 `env_assignment`(start 更小、
-/// 跨度更长)随后因 `end > out.len()`(内层替换缩短了串)被**跳过**,只留下非 secret 的 `KEY=`
-/// 前缀/尾部可见。即"真正的 secret 字节总被内层先覆盖"。与网关路径 `redact_string`(D16 改用
-/// 单遍 + 并集合并)是**两条独立实现**,本路径靠"内层先替换 + 越界跳过"达成同等 leak 安全
-/// (非并集合并);`overlapping_hard_spans_no_leak` 回归测试锁定该不变量,防未来规则改动破坏。
+/// **重叠 span 的 leak 安全性(VIGIL-SEC-OVERLAP 审计修正)**:`merge_findings` 只去掉与
+/// Hard 重叠的 Model,但 **Hard×Hard / Model×Model 内部仍会重叠**(env_assignment 套
+/// github_token;模型对相邻实体吐嵌套 person/address span)。
+///
+/// 旧实现靠"按 start **降序** + 内层先 `replace_range` + 外层 `end > out.len()` 越界跳过"
+/// 达成 leak 安全 —— 但该不变量**仅当外层独有前缀非密时成立**(env_assignment 的 `KEY=` 前缀)。
+/// 若外层独有前缀本身是 PII(模型嵌套 span:外 `[0,40]` person 套内 `[15,40]` person),内层
+/// 替换缩短串令外层 `end > len` 被跳过 → 外层前缀 `[0,15]` 明文 PII **泄漏**(标准复现:
+/// `"Jonathan Whitfield Robert Smith Junior"` → `"Jonathan Whitfi[REDACTED person]"`)。
+///
+/// 故改为与网关 [`crate::redact_string`] 同款 **并集合并**:重叠 span 先合并成互不重叠的
+/// `[min_start, max_end)` 区间,再单次替换。保证每个被任一 finding 命中的字节都落入某个被替换
+/// 区间(leak-safe),且占位符良构(无嵌套破碎)。`overlapping_hard_spans_no_leak` +
+/// `model_overlap_no_leak` 回归测试锁定该不变量。
 fn build_redacted_text(input: &str, findings: &[Finding]) -> String {
-    // sort 副本,不改 caller 给的 findings;span.0 降序(右→左替换避免 index 漂移)。
-    // v0.13:rust 1.95 clippy::unnecessary_sort_by 推荐用 sort_by_key + Reverse 表达。
+    // 拷贝 + 排序:start 升序;同 start 时 end **降序**(长 span 作并集代表名,与网关
+    // redact_string 对齐)。不改 caller 给的 findings。
     let mut sorted: Vec<&Finding> = findings.iter().collect();
-    sorted.sort_by_key(|f| std::cmp::Reverse(f.span.0));
+    sorted.sort_by(|a, b| a.span.0.cmp(&b.span.0).then(b.span.1.cmp(&a.span.1)));
 
-    let mut out = input.to_string();
+    // 重叠区间**并集合并**(leak-safe):代表 kind 取并集内 start 最小→span 最长者(排序已保证)。
+    // 越界 / 非 char boundary 的手工构造 Finding 在并入前剔除,避免 replace_range panic。
+    let mut merged: Vec<(usize, usize, &str)> = Vec::with_capacity(sorted.len());
     for f in sorted {
         let (start, end) = f.span;
-        // 越界防御:理论上 merge 后的 span 来自 regex 命中,不会越界;但 caller
-        // 可能构造 Finding 手动塞进 merge。越界直接跳过,避免 panic。
-        if start > end || end > out.len() {
+        if start > end
+            || end > input.len()
+            || !input.is_char_boundary(start)
+            || !input.is_char_boundary(end)
+        {
             continue;
         }
-        // UTF-8 char boundary 校验:非 char boundary 跳过,保证 out.replace_range
-        // 不会 panic。regex Match 总在 char boundary,但手工构造的 span 可能不是。
-        if !out.is_char_boundary(start) || !out.is_char_boundary(end) {
-            continue;
+        match merged.last_mut() {
+            // 重叠(strict-less,相邻 end==start 不算)→ 扩展并集上界;代表名保持先者
+            Some(last) if start < last.1 => {
+                if end > last.1 {
+                    last.1 = end;
+                }
+            }
+            _ => merged.push((start, end, f.kind)),
         }
-        let placeholder = match PrivacyLabel::from_kind(f.kind) {
+    }
+
+    // 右→左替换:merged 已 start 升序且互不重叠,从后往前替换不影响前面区间 index。
+    let mut out = input.to_string();
+    for &(start, end, kind) in merged.iter().rev() {
+        let placeholder = match PrivacyLabel::from_kind(kind) {
             Some(label) => format!("[REDACTED {}]", label.as_str()),
-            None => format!("[REDACTED {}]", f.kind),
+            None => format!("[REDACTED {}]", kind),
         };
         out.replace_range(start..end, &placeholder);
     }
@@ -807,6 +824,53 @@ mod tests {
         let out = build_redacted_text(text, &[bad]);
         // 跳过则原文不变;不崩就算通过
         assert_eq!(out, text);
+    }
+
+    /// VIGIL-SEC-OVERLAP 回归:**模型嵌套 / 跨类重叠 span** 必须 leak-safe + 占位符良构。
+    /// 旧"右→左 + 越界跳过"实现下,内层(start 更大)替换缩短串令外层 `end > len` 被跳过,
+    /// 外层独有的 PII 前缀明文泄漏。union-merge 修复后并集全覆盖,无泄漏、无破碎占位符。
+    #[test]
+    fn model_overlap_no_leak() {
+        // ① 嵌套同类:外 person [0,40] 套内 person [15,40](内层长→缩串→旧实现跳外层)。
+        //    旧输出 "Jonathan Whitfi[REDACTED person]"(前缀泄漏);修复后并集 [0,40) 全脱敏。
+        let input = "Jonathan Whitfield Robert Smith Junior!!";
+        let findings = vec![
+            Finding::model("private_person", (0, 40), 0.9, 5),
+            Finding::model("private_person", (15, 40), 0.9, 5),
+        ];
+        let out = build_redacted_text(input, &findings);
+        assert!(!out.contains("Jonathan"), "外层 PII 前缀泄漏:{out:?}");
+        assert!(!out.contains("Whitfi"), "外层 PII 前缀泄漏:{out:?}");
+        assert_eq!(out, "[REDACTED person]", "嵌套同类应并集为单一占位符");
+
+        // ② 跨类部分重叠:address [0,47] 与 email [41,54] 交叠(a<c<b<d)。
+        //    旧实现产 "[REDACTED address]TED email]"(破碎);修复后并集 [0,54) 良构。
+        let input2 = "742 Evergreen Terrace Springfield, email jw@clinic.org";
+        let findings2 = vec![
+            Finding::model("private_address", (0, 47), 0.9, 5),
+            Finding::model("private_email", (41, 54), 0.9, 5),
+        ];
+        let out2 = build_redacted_text(input2, &findings2);
+        assert!(!out2.contains("Evergreen"), "address 泄漏:{out2:?}");
+        assert!(!out2.contains("jw@clinic.org"), "email 泄漏:{out2:?}");
+        assert_eq!(
+            out2.matches("[REDACTED").count(),
+            out2.matches(']').count(),
+            "占位符破碎(开闭不配对):{out2:?}"
+        );
+
+        // ③ 非重叠 span 仍各自独立占位符(防 union-merge 过度合并回归)。
+        let input3 = "Bob from Berlin";
+        let findings3 = vec![
+            Finding::model("private_person", (0, 3), 0.9, 5),
+            Finding::model("private_address", (9, 15), 0.9, 5),
+        ];
+        let out3 = build_redacted_text(input3, &findings3);
+        assert_eq!(
+            out3.matches("[REDACTED").count(),
+            2,
+            "非重叠应保两占位符:{out3:?}"
+        );
     }
 
     // ──────────────────────────── risk_of 分级回归 ────────────────────────────

--- a/tests/acceptance/README.md
+++ b/tests/acceptance/README.md
@@ -16,14 +16,17 @@ cp config.env.example config.env      # fill in REPO + your test-machine SSH tar
 ```
 
 Passwordless SSH to each test machine must be configured. Platforms with a blank SSH
-target in `config.env` are skipped.
+target in `config.env` are skipped. The gate is **fail-closed**: any sub-script that
+detects a defect propagates its exit code, and `run.sh` exits non-zero (earlier `|| true`
++ a trailing `rm` swallowed failures — the gate always "passed" and didn't block release).
 
 ## What it does
 
 | Phase | Script | Needs | Checks |
 |-------|--------|-------|--------|
-| 1 Local audit | `local-audit.sh` | `gh`, `file`, `python3`+`pynacl` | all CLI `sha256` (+CRLF lint), per-platform binary **architecture** (flat-collision regression), ML **dylib bundling** exe-adjacent + arch + ORT version, desktop **minisign** signatures (crypto verify), **OTA** manifest version/url |
-| 2 Runtime e2e (Linux/macOS) | `ml-e2e.sh` | test machine | ML binary runs; dylib loads; turnkey `model install`→`daemon start`→`engine set ml`→hook; **R1** daemon reachability; **ML scrubs semantic PII** (person/address) beyond hard-fingerprints; **fail-closed** (no leak, exit 0) |
+| 1 Local audit | `local-audit.sh` | `gh`, `file`, `python3`+`pynacl` | all CLI `sha256` (+CRLF lint), per-platform binary **architecture** (flat-collision regression), **`vigil-native-host` bundled** in CLI archives (browser native-messaging), ML **dylib bundling** exe-adjacent + arch + ORT version, desktop **minisign** signatures (crypto verify), **OTA** manifest version/url |
+| 2 Runtime e2e (Linux/macOS) | `ml-e2e.sh` | test machine | ML binary runs; dylib loads; turnkey `model install`→`daemon start`→`engine set ml`→hook; **R1** daemon reachability; **ML scrubs semantic PII** (person/address) beyond hard-fingerprints; **fail-closed** (no leak, exit 0); then runs `functional-sweep.sh` against the same published binary |
+| 2 Functional sweep | `functional-sweep.sh` (+ `mcp_probe.py`) | any `vigil-hub` (`HUB=…`) | core protection scenarios: `demo` audit-chain + redaction roundtrip, `demo --tamper` chain-break **falsifiability**, hook PreToolUse **deny** (exit 2, no raw echo), hook PostToolUse **redact** + overlap well-formed (no leak), posture/engine persistence, `inspect`/`verify` chain, `serve --stdio` **MCP handshake** (initialize+tools/list), read-only `quickstart` |
 | 2 Runtime e2e (Linux/macOS) | `daemon-regression.sh` | test machine | **R1** peer-credential reachability + **stale-socket** rebind after `kill -9` (regresses the two macOS daemon bugs; model-less, fast) |
 | 2 Runtime e2e (Windows) | `win-acceptance.ps1` | test machine | ML binary runs; `onnxruntime.dll` LoadLibrary (PE + VC++ deps); turnkey model install; named-pipe **R1** daemon reachability |
 
@@ -38,6 +41,13 @@ target in `config.env` are skipped.
 - **macOS stale-socket** — `daemon-regression.sh` fails if `daemon start` can't rebind after
   `kill -9` (filesystem socket not reclaimed). Fixed in the same change.
 - **Windows `.sha256` CRLF** — `local-audit.sh` flags CRLF line endings in checksum files.
+- **Overlapping-span PII leak (found during macOS daemon hook-ML)** — two independent
+  span-replacement sites (`vigil-redaction` `build_redacted_text`, `vigil-hub-cli`
+  `apply_wire_spans`) used right-to-left replace + skip-on-overlap; nested model spans
+  (outer prefix is PII) leaked the outer's plaintext prefix and produced broken nested
+  placeholders. Both rewritten to **union-merge** (like the gateway `redact_string`).
+  Regression: `model_overlap_no_leak`, `apply_wire_spans_{overlap_union_merged,nested}_no_leak`;
+  `functional-sweep.sh` S3b asserts well-formed placeholders on the shipped binary.
 
 ## Safety
 

--- a/tests/acceptance/README.md
+++ b/tests/acceptance/README.md
@@ -48,6 +48,13 @@ detects a defect propagates its exit code, and `run.sh` exits non-zero (earlier 
   placeholders. Both rewritten to **union-merge** (like the gateway `redact_string`).
   Regression: `model_overlap_no_leak`, `apply_wire_spans_{overlap_union_merged,nested}_no_leak`;
   `functional-sweep.sh` S3b asserts well-formed placeholders on the shipped binary.
+  - **Known P2 (no leak, `VIGIL-SEC-OVERLAP-PH`)** — on the daemon hook-ML path, a daemon ML
+    span can over-capture into a hard-fingerprint placeholder inserted by the prior scrub,
+    producing a *broken nested placeholder* in the model-facing output (e.g.
+    `[[REDACTED address]DACTED email]`). **No raw PII leaks** (the cut bytes are placeholder,
+    the real value was already scrubbed). The safe fix plumbs the *genuine* placeholder byte
+    ranges from the scrub step into `apply_wire_spans` (regex-detecting `[REDACTED …]` is
+    unsafe — a tool result can forge fake placeholders to evade ML). Tracked for a follow-up.
 
 ## Safety
 

--- a/tests/acceptance/README.md
+++ b/tests/acceptance/README.md
@@ -1,0 +1,48 @@
+# Vigils release-acceptance suite
+
+Downloads the **published** release artifacts and tests them **as a real user** across
+Linux / macOS / Windows, to catch packaging & distribution defects that local builds and
+CI cannot see (wrong-arch binaries, un-bundled/un-loadable ORT dylib, broken signatures,
+platform-specific daemon failures, turnkey model-download failures, …).
+
+Foundation for future end-to-end functional testing — parameterized, isolated, idempotent.
+
+## Quick start
+
+```bash
+cd tests/acceptance
+cp config.env.example config.env      # fill in REPO + your test-machine SSH targets
+./run.sh v0.4.0
+```
+
+Passwordless SSH to each test machine must be configured. Platforms with a blank SSH
+target in `config.env` are skipped.
+
+## What it does
+
+| Phase | Script | Needs | Checks |
+|-------|--------|-------|--------|
+| 1 Local audit | `local-audit.sh` | `gh`, `file`, `python3`+`pynacl` | all CLI `sha256` (+CRLF lint), per-platform binary **architecture** (flat-collision regression), ML **dylib bundling** exe-adjacent + arch + ORT version, desktop **minisign** signatures (crypto verify), **OTA** manifest version/url |
+| 2 Runtime e2e (Linux/macOS) | `ml-e2e.sh` | test machine | ML binary runs; dylib loads; turnkey `model install`→`daemon start`→`engine set ml`→hook; **R1** daemon reachability; **ML scrubs semantic PII** (person/address) beyond hard-fingerprints; **fail-closed** (no leak, exit 0) |
+| 2 Runtime e2e (Linux/macOS) | `daemon-regression.sh` | test machine | **R1** peer-credential reachability + **stale-socket** rebind after `kill -9` (regresses the two macOS daemon bugs; model-less, fast) |
+| 2 Runtime e2e (Windows) | `win-acceptance.ps1` | test machine | ML binary runs; `onnxruntime.dll` LoadLibrary (PE + VC++ deps); turnkey model install; named-pipe **R1** daemon reachability |
+
+## Regression coverage (v0.4.0 findings)
+
+- **Linux `model install` timeout** — `ml-e2e.sh` fails if the turnkey download fails. Root
+  cause was a fixed 30 s per-chunk timeout < the ~65 s a 48 MB chunk needs on a
+  bandwidth-shared link (16 concurrent chunks). Fixed in `vigil-redaction` `download.rs`.
+- **macOS daemon R1 broken** — `daemon-regression.sh` / `ml-e2e.sh` fail if `daemon status`
+  is not "running" (peer_creds().pid() is None on macOS). Fixed in `vigil-hub-cli`
+  `transport.rs` (euid-based R1 + `GenericFilePath`).
+- **macOS stale-socket** — `daemon-regression.sh` fails if `daemon start` can't rebind after
+  `kill -9` (filesystem socket not reclaimed). Fixed in the same change.
+- **Windows `.sha256` CRLF** — `local-audit.sh` flags CRLF line endings in checksum files.
+
+## Safety
+
+Every test isolates state into a throwaway sandbox (`HOME`/`XDG_*` redirect on Unix) and
+cleans up on exit. Windows `dirs` ignores env overrides, so `win-acceptance.ps1`
+snapshots/restores `daemon.json` and removes **only** artifacts the run created — never
+the shared `%LOCALAPPDATA%\Vigil` dir (NTFS is case-insensitive: `Vigil` == `vigil`).
+`config.env` (with internal SSH targets) is gitignored; only `config.env.example` is committed.

--- a/tests/acceptance/config.env.example
+++ b/tests/acceptance/config.env.example
@@ -1,0 +1,22 @@
+# Vigils release-acceptance suite — environment config.
+# Copy to `config.env` (gitignored) and fill in your test machines.
+# The suite never hardcodes internal IPs; everything platform-specific lives here.
+
+# GitHub repo that publishes the release under test.
+REPO="duncatzat/vigils"
+
+# Per-platform test machines (SSH targets). Leave blank to skip that platform.
+# Format: "user@host". Passwordless SSH must be configured.
+LINUX_SSH="user@linux-host"          # x86_64 Linux (ELF, abstract-UDS daemon)
+MACOS_SSH="user@macos-host"          # arm64 macOS (Mach-O, file-socket daemon, Gatekeeper)
+WINDOWS_SSH="administrator@win-host" # x86_64 Windows (PE, named-pipe daemon); remote shell = cmd.exe
+
+# Optional explicit ssh identity (e.g. when the agent key differs per host).
+# MACOS_SSH_OPTS="-o IdentitiesOnly=yes -i $HOME/.ssh/id_rsa"
+LINUX_SSH_OPTS=""
+MACOS_SSH_OPTS=""
+WINDOWS_SSH_OPTS=""
+
+# Run the full 738MB ML model turnkey (model install -> daemon warm-load -> hook ML scrub)?
+# 0 = model-less fail-closed path only (fast); 1 = full real-model ML e2e (slow, ~minutes).
+RUN_ML_MODEL=1

--- a/tests/acceptance/daemon-regression.sh
+++ b/tests/acceptance/daemon-regression.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Regression for the two macOS daemon-transport bugs found in v0.4.0 acceptance (also a
+# positive check on Linux). Uses the published *model-less* ML binary (no 738MB download).
+#   R1    : daemon must be reachable via peer-credential check (status -> running).
+#           Pre-fix macOS: "not responding / R1 peer-cred mismatch" (peer_creds().pid()==None).
+#   stale : after an unclean exit (kill -9, Drop doesn't run), `daemon start` must rebind.
+#           Pre-fix macOS: permanent EADDRINUSE (GenericNamespaced /tmp socket not reclaimed).
+# Env: VERSION, REPO.
+set -u
+: "${VERSION:?}"; : "${REPO:?}"
+case "$(uname -s)/$(uname -m)" in
+  Linux/x86_64) PLAT=linux-x64 ;; Darwin/arm64) PLAT=macos-arm64 ;;
+  *) echo "unsupported $(uname -s)/$(uname -m)"; exit 2 ;;
+esac
+SBX="${TMPDIR:-/tmp}/vigil-dreg-$$"; rm -rf "$SBX"; mkdir -p "$SBX/home"
+export HOME="$SBX/home" XDG_DATA_HOME="$SBX/home/.local/share" \
+       XDG_CONFIG_HOME="$SBX/home/.config" XDG_CACHE_HOME="$SBX/home/.cache"
+HUB="$SBX/ml/vigil-hub"; P=0; F=0
+ok(){ printf '  PASS %s\n' "$*"; P=$((P+1)); }; no(){ printf '  FAIL %s\n' "$*"; F=$((F+1)); }
+cleanup(){ pkill -f "$SBX/ml/vigil-hub" 2>/dev/null || true
+           rm -f /tmp/vigil-daemon.sock /private/tmp/vigil-daemon.sock 2>/dev/null || true; rm -rf "$SBX"; }
+trap cleanup EXIT
+
+curl -fsSL -o "$SBX/ml.tgz" "https://github.com/$REPO/releases/download/$VERSION/vigils-cli-ml-${PLAT}.tar.gz" \
+  || { echo "download failed"; exit 1; }
+mkdir -p "$SBX/ml"; tar -xzf "$SBX/ml.tgz" -C "$SBX/ml"; chmod +x "$HUB"
+
+wait_running(){ for i in $(seq 1 25); do sleep 1; "$HUB" daemon status 2>&1 | grep -q 'running (pid' && return 0; done; return 1; }
+
+echo "### daemon regression ($PLAT, model-less) ###"
+nohup "$HUB" daemon start >"$SBX/d1.log" 2>&1 & D1=$!
+if wait_running; then ok "R1: daemon reachable (status: running)"; else no "R1: daemon UNREACHABLE"; cat "$SBX/d1.log"; fi
+kill -9 "$D1" 2>/dev/null; sleep 1
+nohup "$HUB" daemon start >"$SBX/d2.log" 2>&1 & D2=$!
+if wait_running; then ok "stale-socket: rebind succeeds after kill -9 (no EADDRINUSE)"; else no "stale-socket: cannot rebind after unclean exit"; cat "$SBX/d2.log"; fi
+"$HUB" daemon stop >/dev/null 2>&1; kill -9 "$D2" 2>/dev/null || true
+
+printf '\n### result: %d passed, %d failed (%s) ###\n' "$P" "$F" "$PLAT"; [ "$F" = 0 ]

--- a/tests/acceptance/functional-sweep.sh
+++ b/tests/acceptance/functional-sweep.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# ----------------------------------------------------------------------------
+# functional-sweep.sh — Vigil 核心防护场景功能性测试套件(可复用,发版后跑)
+#
+# 以真实用户身份对一个 vigil-hub 二进制跑核心安全场景。自隔离(临时 HOME +
+# 独立 ledger)、自清理、PASS/FAIL 计数、任一 FAIL → 退出非 0。
+#
+# 用法:  HUB=/path/to/vigil-hub bash functional-sweep.sh
+#   可选:VIGIL_FN_MCP_PROBE=/path/to/mcp_probe.py(默认同目录)
+#
+# 覆盖(每条都是"防护真发生"的可证伪断言,非 hard-code):
+#   S1  demo            零设置 default-deny + 可逆脱敏往返 + 哈希链有效
+#   S1b demo --tamper   篡改账本一行 → 链断裂被检出(证伪 demo 非作弊)
+#   S2  hook PreToolUse 裸 secret 工具调用 deny(exit 2)+ 不回显原值
+#   S3  hook PostToolUse 结果携密 → 占位符替换 + 不泄漏
+#   S3b hook 重叠硬指纹 结果 → 占位符良构(开闭配对,无破碎/泄漏)
+#   S4  posture         high/low 往返
+#   S5  engine          ml/hardfp 持久化
+#   S6  inspect         保护汇总渲染 + 审计链完整
+#   S7  verify          审计链完整性
+#   S8  serve --stdio   MCP initialize + tools/list 握手(mcp_probe.py)
+#   S9  quickstart      只读引导(不改配置)
+# ----------------------------------------------------------------------------
+set -u
+: "${HUB:?set HUB=path to vigil-hub}"
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MCP_PROBE="${VIGIL_FN_MCP_PROBE:-$SELF_DIR/mcp_probe.py}"
+
+SBX="${TMPDIR:-/tmp}/vigil-fn-$$"; rm -rf "$SBX"; mkdir -p "$SBX/home"
+export HOME="$SBX/home" \
+       XDG_DATA_HOME="$SBX/home/.local/share" \
+       XDG_CONFIG_HOME="$SBX/home/.config" \
+       XDG_CACHE_HOME="$SBX/home/.cache"
+export VIGIL_LEDGER_PATH="$SBX/ledger.sqlite3"
+trap 'rm -rf "$SBX"' EXIT
+
+P=0; F=0
+ok(){ printf '  \033[32mPASS\033[0m %s\n' "$*"; P=$((P+1)); }
+no(){ printf '  \033[31mFAIL\033[0m %s\n' "$*"; F=$((F+1)); }
+brackets_balanced(){ [ "$(printf '%s' "$1" | grep -o '\[REDACTED' | wc -l)" = "$(printf '%s' "$1" | grep -o ']' | wc -l)" ]; }
+
+echo "### Vigil functional sweep — $("$HUB" --version 2>&1 | head -1) ###"
+
+echo "== S1 demo: zero-setup default-deny + redaction roundtrip + audit chain =="
+D="$("$HUB" demo 2>&1)"
+echo "$D" | grep -qiE 'hash-chain valid|chain.*valid|integrity.*intact|chain.*intact' && ok "demo: audit hash-chain valid" || no "demo: no hash-chain-valid marker"
+echo "$D" | grep -qiE 'redact|placeholder|REDACTED' && ok "demo: redaction roundtrip shown" || no "demo: no redaction shown"
+
+echo "== S1b demo --tamper: ledger tamper -> chain破裂被检出(falsifiable)=="
+DT="$("$HUB" demo --tamper 2>&1)"
+echo "$DT" | grep -qiE 'tamper|invalid|broken|mismatch|detected|BROKEN|FAIL|corrupt' && ok "demo --tamper: chain break detected" || no "demo --tamper: tamper not flagged"
+
+echo "== S2 hook PreToolUse deny: bare AWS key in a native tool call =="
+EV='{"hook_event_name":"PreToolUse","tool_name":"Bash","session_id":"fn","tool_input":{"command":"aws configure set k AKIAIOSFODNN7EXAMPLE"}}'
+OUT="$(printf '%s' "$EV" | "$HUB" hook --cli claude 2>&1)"; RC=$?
+[ "$RC" = 2 ] && ok "PreToolUse bare-secret deny -> exit 2" || no "PreToolUse exit=$RC (want 2)"
+printf '%s' "$OUT" | grep -q 'AKIAIOSFODNN7EXAMPLE' && no "PreToolUse: raw key echoed in reason" || ok "PreToolUse: no raw-secret echo"
+
+echo "== S3 hook PostToolUse redact: result carrying secrets =="
+EV='{"hook_event_name":"PostToolUse","tool_name":"Bash","session_id":"fn","tool_response":{"stdout":"token ghp_1234567890abcdef1234567890abcdef1234 and key AKIAIOSFODNN7EXAMPLE"}}'
+OUT="$(printf '%s' "$EV" | "$HUB" hook --cli claude --redact-results 2>&1)"; RC=$?
+[ "$RC" = 0 ] && ok "PostToolUse redact -> exit 0" || no "PostToolUse exit=$RC"
+printf '%s' "$OUT" | grep -q 'REDACTED' && ok "PostToolUse: secrets -> placeholders" || no "PostToolUse: no REDACTED"
+printf '%s' "$OUT" | grep -qE 'AKIAIOSFODNN7EXAMPLE|ghp_1234567890abcdef' && no "PostToolUse: raw secret leaked" || ok "PostToolUse: no raw-secret leak"
+
+echo "== S3b hook PostToolUse overlapping hard fingerprints: well-formed placeholders =="
+EV='{"hook_event_name":"PostToolUse","tool_name":"Bash","session_id":"fn","tool_response":{"stdout":"export GITHUB_TOKEN=ghp_abcdef1234567890abcdef1234567890abcd done"}}'
+OUT="$(printf '%s' "$EV" | "$HUB" hook --cli claude --redact-results 2>&1)"
+RT="$(printf '%s' "$OUT" | grep -o '"stdout":"[^"]*"' | head -1)"
+printf '%s' "$OUT" | grep -qE 'ghp_abcdef1234567890' && no "overlap: raw token leaked" || ok "overlap: no raw-token leak"
+if [ -n "$RT" ] && brackets_balanced "$RT"; then ok "overlap: placeholders well-formed (brackets balanced)"; else no "overlap: malformed/nested placeholders ($RT)"; fi
+
+echo "== S4 posture: set high then low =="
+"$HUB" posture set high >/dev/null 2>&1
+"$HUB" posture show 2>&1 | grep -qi high && ok "posture set/show high" || no "posture high roundtrip"
+"$HUB" posture set low >/dev/null 2>&1
+
+echo "== S5 engine: set ml then hardfp =="
+"$HUB" engine set ml >/dev/null 2>&1
+[ "$("$HUB" engine show 2>&1)" = "ml" ] && ok "engine set ml persisted" || no "engine set ml"
+"$HUB" engine set hardfp >/dev/null 2>&1
+[ "$("$HUB" engine show 2>&1)" = "hardfp" ] && ok "engine set hardfp persisted" || no "engine set hardfp"
+
+echo "== S6 inspect: protection summary + audit chain (after demo populated ledger) =="
+"$HUB" demo >/dev/null 2>&1
+if "$HUB" inspect protection >/dev/null 2>&1; then
+  IN="$("$HUB" inspect protection 2>&1)"
+  echo "$IN" | grep -qiE 'protect|secret|event|chain|intact|[0-9]' && ok "inspect protection renders summary" || no "inspect empty"
+else
+  echo "  SKIP inspect (binary lacks inspect subcommand)"
+fi
+
+echo "== S7 verify: audit chain integrity =="
+if "$HUB" verify >/dev/null 2>&1; then
+  VC="$("$HUB" verify 2>&1)"; echo "$VC" | grep -qiE 'valid|ok|intact|consistent' && ok "verify: chain intact" || no "verify: $(echo "$VC" | head -1)"
+elif "$HUB" inspect verify-chain >/dev/null 2>&1; then
+  VC="$("$HUB" inspect verify-chain 2>&1)"; echo "$VC" | grep -qiE 'valid|ok|intact|consistent' && ok "inspect verify-chain: intact" || no "verify-chain: $(echo "$VC" | head -1)"
+else
+  echo "  SKIP verify (no verify / inspect verify-chain subcommand)"
+fi
+
+echo "== S8 serve --stdio: MCP initialize + tools/list handshake =="
+if command -v python3 >/dev/null 2>&1 && [ -f "$MCP_PROBE" ]; then
+  SP="$(python3 "$MCP_PROBE" "$HUB" 2>&1)"
+  echo "$SP" | grep -q 'PASS: initialize ok' && ok "serve --stdio: MCP initialize handshake" || no "serve --stdio: $(echo "$SP" | head -1)"
+  echo "$SP" | grep -q 'PASS: tools/list ok' && ok "serve --stdio: tools/list" || echo "  NOTE: $(echo "$SP" | grep -iE 'tools|WARN' | head -1)"
+else
+  echo "  SKIP serve MCP (python3 or mcp_probe.py missing)"
+fi
+
+echo "== S9 quickstart: read-only guidance (no config mutation) =="
+if "$HUB" quickstart >/dev/null 2>&1; then
+  QS="$("$HUB" quickstart 2>&1)"; echo "$QS" | grep -qiE 'demo|protect|verify|detect|agent|step|setup' && ok "quickstart: guidance shown" || no "quickstart: no guidance"
+else
+  echo "  SKIP quickstart (no quickstart subcommand)"
+fi
+
+printf '\n### functional sweep: \033[32m%d passed\033[0m, \033[31m%d failed\033[0m ###\n' "$P" "$F"
+[ "$F" = 0 ]

--- a/tests/acceptance/lib.sh
+++ b/tests/acceptance/lib.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Shared helpers for the Vigils release-acceptance suite. Source, don't execute.
+set -u
+
+SUITE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- result tracking ------------------------------------------------------
+PASS_N=0; FAIL_N=0; FAILED=()
+ok()   { printf '  \033[32mPASS\033[0m %s\n' "$*"; PASS_N=$((PASS_N+1)); }
+bad()  { printf '  \033[31mFAIL\033[0m %s\n' "$*"; FAIL_N=$((FAIL_N+1)); FAILED+=("$*"); }
+info() { printf '  ---- %s\n' "$*"; }
+hdr()  { printf '\n=== %s ===\n' "$*"; }
+# assert "label" <expected> <actual>
+asrt() { if [ "$2" = "$3" ]; then ok "$1 ($3)"; else bad "$1 (want=$2 got=$3)"; fi; }
+suite_summary() {
+  printf '\n========== SUMMARY: %d passed, %d failed ==========\n' "$PASS_N" "$FAIL_N"
+  if [ "$FAIL_N" -gt 0 ]; then printf '  FAILED:\n'; for f in "${FAILED[@]}"; do printf '   - %s\n' "$f"; done; return 1; fi
+  return 0
+}
+
+# --- config ---------------------------------------------------------------
+load_config() {
+  if [ -f "$SUITE_DIR/config.env" ]; then . "$SUITE_DIR/config.env"; else
+    echo "FATAL: $SUITE_DIR/config.env not found (copy config.env.example)"; exit 2; fi
+  : "${REPO:?REPO unset}"
+  : "${RUN_ML_MODEL:=1}"
+}
+
+asset_url() { echo "https://github.com/$REPO/releases/download/$VERSION/$1"; }
+
+# ssh/scp with per-platform opts. $1=plat (linux|macos|windows)
+plat_ssh_target() { local v; v="$(echo "$1" | tr a-z A-Z)_SSH"; echo "${!v:-}"; }
+plat_ssh_opts()   { local v; v="$(echo "$1" | tr a-z A-Z)_SSH_OPTS"; echo "${!v:-}"; }
+psh()  { local p=$1; shift; local t; t="$(plat_ssh_target "$p")"; [ -z "$t" ] && return 9
+         ssh -o BatchMode=yes -o ConnectTimeout=12 $(plat_ssh_opts "$p") "$t" "$@"; }
+pscp() { local p=$1 src=$2 dst=$3; local t; t="$(plat_ssh_target "$p")"; [ -z "$t" ] && return 9
+         scp -q -o BatchMode=yes $(plat_ssh_opts "$p") "$src" "$t:$dst"; }

--- a/tests/acceptance/local-audit.sh
+++ b/tests/acceptance/local-audit.sh
@@ -31,6 +31,13 @@ for plat in linux-x64 macos-arm64 windows-x64; do
     hub=$(find "$d" -name 'vigil-hub*' | head -1)
     if file -b "$hub" | grep -q "${WANT[$plat]%\**}"; then ok "${kind}${plat}: vigil-hub is ${WANT[$plat]}"; \
       else bad "${kind}${plat}: wrong arch: $(file -b "$hub")"; fi
+    if [ "$kind" = "" ]; then
+      # CLI(非 ML)归档必含浏览器 native-messaging host(release.yml 与 vigil-hub 同打包);
+      # 缺失 = MV3 扩展无法连本机 → 静默丢浏览器防护。ML 归档故意不含(与 ML 无关)。
+      nh=$(find "$d" -iname 'vigil-native-host*' | head -1)
+      [ -n "$nh" ] && ok "${plat}: vigil-native-host bundled (browser native messaging)" \
+        || bad "${plat}: vigil-native-host MISSING from CLI archive"
+    fi
     if [ "$kind" = "ml-" ]; then
       dy=$(find "$d" -iname '*onnxruntime*' | grep -viE 'providers' | head -1)
       [ -n "$dy" ] && ok "${plat}: ORT dylib bundled exe-adjacent ($(basename "$dy"))" || bad "${plat} ML: dylib missing"

--- a/tests/acceptance/local-audit.sh
+++ b/tests/acceptance/local-audit.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Local (controller-side) audit of a published release: download all assets, verify
+# checksums, per-platform binary architecture, ML dylib bundling, desktop signatures,
+# and OTA manifests. Catches packaging/distribution defects without any test machine.
+# Env: VERSION, REPO. Requires: gh, file, tar, unzip, sha256sum, python3+pynacl (for sigs).
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; . "$HERE/lib.sh"
+: "${VERSION:?}"; : "${REPO:?}"
+W="${TMPDIR:-/tmp}/vigil-acc-local"; rm -rf "$W"; mkdir -p "$W/assets" "$W/ex"
+
+hdr "Download all release assets ($VERSION)"
+gh release download "$VERSION" -R "$REPO" -D "$W/assets" --clobber >/dev/null 2>&1 \
+  && ok "downloaded $(ls "$W/assets" | wc -l) assets" || { bad "gh release download failed"; suite_summary; exit 1; }
+
+hdr "CLI checksums (+ CRLF lint)"
+for s in "$W"/assets/*.sha256; do
+  exp=$(tr -d '\r' < "$s" | awk '{print $1}'); f="${s%.sha256}"
+  act=$(sha256sum "$f" 2>/dev/null | awk '{print $1}')
+  asrt "checksum $(basename "$f")" "$exp" "$act"
+  if file "$s" | grep -q CRLF; then bad "$(basename "$s") has CRLF line endings (Unix sha256sum -c breaks)"; fi
+done
+
+hdr "Binary architecture (flat-collision regression) + ML dylib bundling"
+declare -A WANT=( [linux-x64]="ELF*x86-64" [macos-arm64]="Mach-O*arm64" [windows-x64]="PE32+*x86-64" )
+for plat in linux-x64 macos-arm64 windows-x64; do
+  for kind in "" "ml-"; do
+    a="$W/assets/vigils-cli-${kind}${plat}"; [ -f "$a.tar.gz" ] && a="$a.tar.gz" || a="$a.zip"
+    [ -f "$a" ] || { bad "missing archive $(basename "$a")"; continue; }
+    d="$W/ex/${kind}${plat}"; mkdir -p "$d"
+    case "$a" in *.tar.gz) tar -xzf "$a" -C "$d";; *.zip) unzip -oq "$a" -d "$d";; esac
+    hub=$(find "$d" -name 'vigil-hub*' | head -1)
+    if file -b "$hub" | grep -q "${WANT[$plat]%\**}"; then ok "${kind}${plat}: vigil-hub is ${WANT[$plat]}"; \
+      else bad "${kind}${plat}: wrong arch: $(file -b "$hub")"; fi
+    if [ "$kind" = "ml-" ]; then
+      dy=$(find "$d" -iname '*onnxruntime*' | grep -viE 'providers' | head -1)
+      [ -n "$dy" ] && ok "${plat}: ORT dylib bundled exe-adjacent ($(basename "$dy"))" || bad "${plat} ML: dylib missing"
+      grep -aoE '1\.2[0-9]\.[0-9]+' "$dy" 2>/dev/null | sort -u | grep -q . && info "ORT version strings: $(grep -aoE '1\.2[0-9]\.[0-9]+' "$dy" | sort -u | tr '\n' ' ')"
+    fi
+  done
+done
+
+hdr "Desktop updater signatures (minisign crypto verify)"
+PUB=$(gh api "repos/$REPO/contents/apps/desktop/tauri.conf.json?ref=$VERSION" -H "Accept: application/vnd.github.raw" 2>/dev/null | grep -oE '"pubkey": *"[^"]+"' | sed 's/.*"pubkey": *"//;s/"//')
+if [ -n "$PUB" ] && python3 -c 'import nacl' 2>/dev/null; then
+  pairs=(); for sig in "$W"/assets/*.sig; do pairs+=("${sig%.sig}" "$sig"); done
+  if python3 "$HERE/verify_minisign.py" "$PUB" "${pairs[@]}"; then ok "all updater artifacts cryptographically signed by repo key"; else bad "signature verification FAILED"; fi
+else info "skip sig verify (need pubkey + python3 pynacl)"; fi
+
+hdr "OTA manifests"
+for j in "$W"/assets/latest-*.json; do
+  [ -f "$j" ] || continue
+  v=$(grep -oE '"version": *"[^"]+"' "$j" | head -1 | sed 's/.*"version": *"//;s/"//')
+  asrt "$(basename "$j") version" "${VERSION#v}" "$v"
+  u=$(grep -oE 'https://[^"]+' "$j" | head -1)
+  # GitHub release asset URLs answer 302 -> CDN; a 2xx/3xx means it resolves (updater follows).
+  code=$(curl -fsS -o /dev/null -w '%{http_code}' -I "$u" 2>/dev/null || echo 000)
+  case "$code" in 2*|3*) ok "$(basename "$j") url resolves ($code)";; *) bad "$(basename "$j") url HTTP $code";; esac
+done
+
+rm -rf "$W"
+suite_summary

--- a/tests/acceptance/mcp_probe.py
+++ b/tests/acceptance/mcp_probe.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Minimal MCP stdio client to functionally probe `vigil-hub serve --stdio`.
+
+Drives the newline-delimited JSON-RPC handshake the way a real MCP host does:
+  initialize -> notifications/initialized -> tools/list
+
+Robust framing (proper JSON over a real subprocess pipe) replaces fragile
+shell `printf | ssh` attempts whose nested quoting mangled the request.
+
+Usage:  mcp_probe.py <vigil-hub> [extra serve args...]
+Exit 0 + 'PASS:' lines when initialize (and ideally tools/list) succeed.
+"""
+import json
+import subprocess
+import sys
+import threading
+import time
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: mcp_probe.py <vigil-hub> [extra serve args...]", file=sys.stderr)
+        return 2
+    hub = sys.argv[1]
+    extra = sys.argv[2:]
+    proc = subprocess.Popen(
+        [hub, "serve", "--stdio", *extra],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    results: dict = {}
+
+    def send(obj: dict) -> None:
+        assert proc.stdin is not None
+        proc.stdin.write(json.dumps(obj) + "\n")
+        proc.stdin.flush()
+
+    def reader() -> None:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except Exception:
+                continue
+            if msg.get("id") == 1 and "result" in msg:
+                results["init"] = msg["result"]
+            elif msg.get("id") == 2 and "result" in msg:
+                results["tools"] = msg["result"]
+
+    threading.Thread(target=reader, daemon=True).start()
+
+    send({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "vigil-acceptance-probe", "version": "1"},
+        },
+    })
+    for _ in range(100):
+        if "init" in results:
+            break
+        time.sleep(0.05)
+    if "init" not in results:
+        err = (proc.stderr.read() if proc.stderr else "")[:400]
+        print(f"FAIL: no initialize result; stderr head: {err!r}")
+        proc.kill()
+        return 1
+
+    send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+    send({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+    for _ in range(100):
+        if "tools" in results:
+            break
+        time.sleep(0.05)
+
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except Exception:
+        proc.kill()
+
+    si = results["init"].get("serverInfo", {})
+    print(
+        f"PASS: initialize ok (server={si.get('name', '?')} "
+        f"v{si.get('version', '?')}, protocol={results['init'].get('protocolVersion', '?')})"
+    )
+    if "tools" in results:
+        tools = results["tools"].get("tools", [])
+        names = [t.get("name") for t in tools][:8]
+        print(f"PASS: tools/list ok ({len(tools)} tool(s): {names})")
+    else:
+        print("WARN: no tools/list result (server may expose no tools without an upstream)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/acceptance/ml-e2e.sh
+++ b/tests/acceptance/ml-e2e.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# daemon hook-ML end-to-end against a PUBLISHED CLI ML variant (Linux/macOS).
+# Runs ON a test machine. Env: VERSION, REPO, RUN_ML_MODEL (0/1). Self-isolating + self-cleaning.
+#
+# Verifies, as a real user would experience it:
+#   - ML variant binary runs; bundled ORT dylib is exe-adjacent + loads
+#   - turnkey: `model install` -> `daemon start` (warm-load) -> `engine set ml` -> hook PostToolUse
+#   - daemon reachable via R1 (this is what was BROKEN on macOS pre-fix)
+#   - ML scrubs SEMANTIC PII (person/address) that hard-fingerprints cannot
+#   - fail-closed: daemon-less / model-less still scrubs hard fingerprints, no leak, exit 0
+set -u
+: "${VERSION:?set VERSION}"; : "${REPO:?set REPO}"; : "${RUN_ML_MODEL:=1}"
+
+case "$(uname -s)/$(uname -m)" in
+  Linux/x86_64)   PLAT=linux-x64;    EXT=tar.gz; DYLIB=libonnxruntime.so ;;
+  Darwin/arm64)   PLAT=macos-arm64;  EXT=tar.gz; DYLIB=libonnxruntime.dylib ;;
+  *) echo "unsupported $(uname -s)/$(uname -m)"; exit 2 ;;
+esac
+ARCHIVE="vigils-cli-ml-${PLAT}.${EXT}"
+URL="https://github.com/$REPO/releases/download/$VERSION/$ARCHIVE"
+
+SBX="${TMPDIR:-/tmp}/vigil-acc-$$"; rm -rf "$SBX"; mkdir -p "$SBX/home"
+export HOME="$SBX/home" XDG_DATA_HOME="$SBX/home/.local/share" \
+       XDG_CACHE_HOME="$SBX/home/.cache" XDG_CONFIG_HOME="$SBX/home/.config"
+HUB="$SBX/ml/vigil-hub"
+P=0; F=0
+ok(){ printf '  PASS %s\n' "$*"; P=$((P+1)); }; no(){ printf '  FAIL %s\n' "$*"; F=$((F+1)); }
+
+cleanup(){ "$HUB" daemon stop >/dev/null 2>&1 || true
+           pkill -f "$SBX/ml/vigil-hub" 2>/dev/null || true
+           rm -f /tmp/vigil-daemon.sock /private/tmp/vigil-daemon.sock 2>/dev/null || true
+           rm -rf "$SBX"; }
+trap cleanup EXIT
+
+echo "### ML hook-ML e2e: $ARCHIVE (RUN_ML_MODEL=$RUN_ML_MODEL) ###"
+curl -fsSL -o "$SBX/ml.$EXT" "$URL" || { echo "download $URL failed"; exit 1; }
+mkdir -p "$SBX/ml"; tar -xzf "$SBX/ml.$EXT" -C "$SBX/ml"; chmod +x "$HUB"
+
+# --- bundled dylib present, exe-adjacent, right arch ---
+[ -f "$SBX/ml/$DYLIB" ] && ok "ORT dylib bundled exe-adjacent ($DYLIB)" || no "ORT dylib missing"
+case "$(uname -s)/$(file -b "$SBX/ml/$DYLIB" 2>/dev/null)" in
+  Linux/*ELF*x86-64*|Darwin/*Mach-O*arm64*) ok "dylib arch matches platform" ;;
+  *) no "dylib arch mismatch: $(file -b "$SBX/ml/$DYLIB")" ;;
+esac
+VER_OUT="$("$HUB" --version)"
+[ "$VER_OUT" = "vigil-hub ${VERSION#v}" ] && ok "version == ${VERSION#v}" || no "version mismatch: $VER_OUT"
+
+"$HUB" engine set ml >/dev/null 2>&1
+[ "$("$HUB" engine show)" = "ml" ] && ok "engine set ml persisted" || no "engine set ml failed"
+
+# --- turnkey real-model path ---
+DAEMON_UP=0
+if [ "$RUN_ML_MODEL" = "1" ]; then
+  echo "  ---- model install --privacy (real ~738MB turnkey)…"
+  if "$HUB" model install --privacy >"$SBX/install.log" 2>&1; then
+    ok "model install --privacy (turnkey download)"
+    nohup "$HUB" daemon start >"$SBX/daemon.log" 2>&1 &
+    for i in $(seq 1 40); do sleep 1; "$HUB" daemon status 2>&1 | grep -q 'running (pid' && { DAEMON_UP=1; break; }; done
+    if [ "$DAEMON_UP" = 1 ]; then
+      ok "daemon reachable via R1 (status: running)"
+      "$HUB" daemon status 2>&1 | grep -q 'pii_loaded=true' && ok "daemon warm-loaded real PII model" || no "daemon pii_loaded != true"
+    else
+      no "daemon NOT reachable (R1 broken? — was the macOS pre-fix failure)"
+      info=$(cat "$SBX/daemon.log" 2>/dev/null); echo "  ---- daemon.log: $info"
+    fi
+  else
+    no "model install FAILED (download bug?): $(tail -1 "$SBX/install.log")"
+  fi
+fi
+
+# --- hook PostToolUse with semantic + hard PII ---
+EVENT='{"hook_event_name":"PostToolUse","tool_name":"Bash","session_id":"acc","tool_response":{"stdout":"Patient Jonathan Whitfield at 742 Evergreen Terrace Springfield, email jw@x.org, awskey AKIAIOSFODNN7EXAMPLE"}}'
+OUT="$(printf '%s' "$EVENT" | "$HUB" hook --cli claude --redact-results 2>&1)"; RC=$?
+[ "$RC" = 0 ] && ok "hook exit 0" || no "hook exit $RC"
+echo "$OUT" | grep -q 'AKIAIOSFODNN7EXAMPLE' && no "RAW AWS KEY LEAKED (fail-open!)" || ok "fail-closed: bare AWS key never leaks"
+echo "$OUT" | grep -q 'REDACTED aws_access_key_id' && ok "hard-fingerprint floor scrubbed AWS key" || no "hard-fp floor did not scrub"
+if [ "$DAEMON_UP" = 1 ]; then
+  echo "$OUT" | grep -qiE 'REDACTED (person|name)' && ok "ML scrubbed semantic PII (person) — beyond hard-fp" || no "ML did not scrub person name (daemon up but no ML span)"
+fi
+echo "  ---- redacted: $(echo "$OUT" | grep -o '"stdout":"[^"]*"' | head -1)"
+
+printf '\n### result: %d passed, %d failed (%s) ###\n' "$P" "$F" "$PLAT"
+[ "$F" = 0 ]

--- a/tests/acceptance/ml-e2e.sh
+++ b/tests/acceptance/ml-e2e.sh
@@ -79,5 +79,16 @@ if [ "$DAEMON_UP" = 1 ]; then
 fi
 echo "  ---- redacted: $(echo "$OUT" | grep -o '"stdout":"[^"]*"' | head -1)"
 
+# --- core functional scenario sweep (reuse this published binary, run.sh wires VIGIL_FN_SWEEP) ---
+if [ -n "${VIGIL_FN_SWEEP:-}" ] && [ -f "$VIGIL_FN_SWEEP" ]; then
+  echo "  ---- functional sweep (HUB=$HUB)…"
+  if HUB="$HUB" VIGIL_FN_MCP_PROBE=/tmp/mcp_probe.py bash "$VIGIL_FN_SWEEP" >"$SBX/fn.log" 2>&1; then
+    ok "functional sweep: all scenarios passed ($(grep -oE '[0-9]+ passed' "$SBX/fn.log" | head -1))"
+  else
+    no "functional sweep: scenario failure(s) — $(grep -oE '[0-9]+ passed, [0-9]+ failed' "$SBX/fn.log" | head -1)"
+    grep -iE 'FAIL ' "$SBX/fn.log" | head -5
+  fi
+fi
+
 printf '\n### result: %d passed, %d failed (%s) ###\n' "$P" "$F" "$PLAT"
 [ "$F" = 0 ]

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Vigils release-acceptance orchestrator: downloads published artifacts and tests them
+# as a real user across platforms, to catch packaging/distribution defects that local
+# builds and CI cannot see. Usage:  ./run.sh <version>      (e.g. ./run.sh v0.4.0)
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"; . "$HERE/lib.sh"
+VERSION="${1:?usage: run.sh <version, e.g. v0.4.0>}"; export VERSION
+load_config; export REPO RUN_ML_MODEL
+
+echo "######## Vigils acceptance — $REPO @ $VERSION ########"
+
+echo; echo ">>> Phase 1: local artifact audit (no test machine required)"
+bash "$HERE/local-audit.sh" || true
+
+run_unix(){
+  local p=$1 t; t="$(plat_ssh_target "$p")"
+  [ -z "$t" ] && { echo ">>> [$p] skipped (no SSH configured in config.env)"; return; }
+  echo; echo ">>> Phase 2: [$p] runtime e2e on $t"
+  pscp "$p" "$HERE/ml-e2e.sh" /tmp/vigil-ml-e2e.sh
+  pscp "$p" "$HERE/daemon-regression.sh" /tmp/vigil-dreg.sh
+  psh "$p" "VERSION=$VERSION REPO=$REPO RUN_ML_MODEL=$RUN_ML_MODEL bash /tmp/vigil-ml-e2e.sh; \
+            VERSION=$VERSION REPO=$REPO bash /tmp/vigil-dreg.sh; rm -f /tmp/vigil-ml-e2e.sh /tmp/vigil-dreg.sh"
+}
+run_unix linux
+run_unix macos
+
+WT="$(plat_ssh_target windows)"
+if [ -n "$WT" ]; then
+  echo; echo ">>> Phase 2: [windows] runtime e2e on $WT"
+  scp -q -o BatchMode=yes $(plat_ssh_opts windows) "$HERE/win-acceptance.ps1" "$WT:C:/Users/Administrator/win-acceptance.ps1"
+  ssh -o BatchMode=yes $(plat_ssh_opts windows) "$WT" \
+    "powershell -NoProfile -ExecutionPolicy Bypass -File C:/Users/Administrator/win-acceptance.ps1 -Version $VERSION -Repo $REPO -RunMlModel $RUN_ML_MODEL"
+else echo ">>> [windows] skipped (no SSH configured)"; fi
+
+echo; echo "######## acceptance run complete ########"

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -2,15 +2,27 @@
 # Vigils release-acceptance orchestrator: downloads published artifacts and tests them
 # as a real user across platforms, to catch packaging/distribution defects that local
 # builds and CI cannot see. Usage:  ./run.sh <version>      (e.g. ./run.sh v0.4.0)
+#
+# FAIL-CLOSED gate: any phase that detects a defect propagates its exit code and makes
+# the whole run exit non-zero. (Earlier `|| true` + trailing `rm` swallowed sub-script
+# failures → the gate always "passed" → packaging defects didn't block release.)
 set -u
 HERE="$(cd "$(dirname "$0")" && pwd)"; . "$HERE/lib.sh"
 VERSION="${1:?usage: run.sh <version, e.g. v0.4.0>}"; export VERSION
 load_config; export REPO RUN_ML_MODEL
 
 echo "######## Vigils acceptance — $REPO @ $VERSION ########"
+FAILED=0
+fail(){ echo ">>> \033[31mFAIL\033[0m: $*"; FAILED=$((FAILED+1)); }
 
 echo; echo ">>> Phase 1: local artifact audit (no test machine required)"
-bash "$HERE/local-audit.sh" || true
+bash "$HERE/local-audit.sh" || fail "local-audit (packaging/checksum/sig/arch/dylib/OTA)"
+
+# Optional functional sweep against the published CLI on the local-audit host (if downloaded).
+if [ -n "${VIGIL_FN_HUB:-}" ]; then
+  echo; echo ">>> Phase 1b: functional sweep (local HUB=$VIGIL_FN_HUB)"
+  HUB="$VIGIL_FN_HUB" bash "$HERE/functional-sweep.sh" || fail "functional-sweep (local)"
+fi
 
 run_unix(){
   local p=$1 t; t="$(plat_ssh_target "$p")"
@@ -18,8 +30,16 @@ run_unix(){
   echo; echo ">>> Phase 2: [$p] runtime e2e on $t"
   pscp "$p" "$HERE/ml-e2e.sh" /tmp/vigil-ml-e2e.sh
   pscp "$p" "$HERE/daemon-regression.sh" /tmp/vigil-dreg.sh
-  psh "$p" "VERSION=$VERSION REPO=$REPO RUN_ML_MODEL=$RUN_ML_MODEL bash /tmp/vigil-ml-e2e.sh; \
-            VERSION=$VERSION REPO=$REPO bash /tmp/vigil-dreg.sh; rm -f /tmp/vigil-ml-e2e.sh /tmp/vigil-dreg.sh"
+  pscp "$p" "$HERE/functional-sweep.sh" /tmp/vigil-fn-sweep.sh
+  pscp "$p" "$HERE/mcp_probe.py" /tmp/mcp_probe.py
+  # 退出码必须传播(不被尾部 rm 吞):任一子脚本失败 → 本平台失败。每步 `|| rc=1`,
+  # 单独 rm,最后 `exit $rc`。functional-sweep 复用 ml-e2e 落地的二进制(VIGIL_FN_HUB)。
+  psh "$p" "rc=0; \
+            VERSION=$VERSION REPO=$REPO RUN_ML_MODEL=$RUN_ML_MODEL VIGIL_FN_SWEEP=/tmp/vigil-fn-sweep.sh \
+              bash /tmp/vigil-ml-e2e.sh || rc=1; \
+            VERSION=$VERSION REPO=$REPO bash /tmp/vigil-dreg.sh || rc=1; \
+            rm -f /tmp/vigil-ml-e2e.sh /tmp/vigil-dreg.sh /tmp/vigil-fn-sweep.sh /tmp/mcp_probe.py; \
+            exit \$rc" || fail "[$p] runtime e2e"
 }
 run_unix linux
 run_unix macos
@@ -29,7 +49,14 @@ if [ -n "$WT" ]; then
   echo; echo ">>> Phase 2: [windows] runtime e2e on $WT"
   scp -q -o BatchMode=yes $(plat_ssh_opts windows) "$HERE/win-acceptance.ps1" "$WT:C:/Users/Administrator/win-acceptance.ps1"
   ssh -o BatchMode=yes $(plat_ssh_opts windows) "$WT" \
-    "powershell -NoProfile -ExecutionPolicy Bypass -File C:/Users/Administrator/win-acceptance.ps1 -Version $VERSION -Repo $REPO -RunMlModel $RUN_ML_MODEL"
+    "powershell -NoProfile -ExecutionPolicy Bypass -File C:/Users/Administrator/win-acceptance.ps1 -Version $VERSION -Repo $REPO -RunMlModel $RUN_ML_MODEL" \
+    || fail "[windows] runtime e2e"
 else echo ">>> [windows] skipped (no SSH configured)"; fi
 
-echo; echo "######## acceptance run complete ########"
+echo
+if [ "$FAILED" = 0 ]; then
+  printf '######## acceptance \033[32mPASSED\033[0m ########\n'
+else
+  printf '######## acceptance \033[31mFAILED\033[0m: %d phase(s) ########\n' "$FAILED"
+fi
+exit "$FAILED"

--- a/tests/acceptance/verify_minisign.py
+++ b/tests/acceptance/verify_minisign.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Verify tauri-updater minisign signatures. Pure Python (pynacl), no minisign binary.
+# Tauri uses prehashed 'ED' = Ed25519 over Blake2b-512(file). Usage:
+#   verify_minisign.py <pubkey_b64> <artifact1> <sig1> [<artifact2> <sig2> ...]
+import sys, base64, hashlib
+from nacl.signing import VerifyKey
+
+def parse_pubkey(b64):
+    blob = base64.b64decode(base64.b64decode(b64).decode().splitlines()[1])
+    return blob[:2], blob[2:10], blob[10:42]  # alg, keyid, ed25519_pk
+
+def parse_sig(path):
+    lines = base64.b64decode(open(path, "rb").read()).decode().splitlines()
+    sb = base64.b64decode(lines[1]); tc = lines[2].split("trusted comment:", 1)[1].strip()
+    return sb[:2], sb[2:10], sb[10:74], tc, base64.b64decode(lines[3])  # alg,keyid,sig,tc,globalsig
+
+_, pkid, pk = parse_pubkey(sys.argv[1]); vk = VerifyKey(pk); allok = True
+args = sys.argv[2:]
+for i in range(0, len(args), 2):
+    art, sig = args[i], args[i+1]
+    alg, kid, s, tc, g = parse_sig(sig)
+    data = open(art, "rb").read()
+    msg = hashlib.blake2b(data, digest_size=64).digest() if alg == b"ED" else data
+    kok = kid == pkid
+    try: vk.verify(msg, s); fok = True
+    except Exception: fok = False
+    try: vk.verify(s + tc.encode(), g); gok = True
+    except Exception: gok = False
+    print(f"  {art.split('/')[-1]:36s} keyid={'ok' if kok else 'BAD'} file_sig={'ok' if fok else 'BAD'} tc_sig={'ok' if gok else 'BAD'}")
+    allok = allok and kok and fok and gok
+sys.exit(0 if allok else 1)

--- a/tests/acceptance/win-acceptance.ps1
+++ b/tests/acceptance/win-acceptance.ps1
@@ -1,0 +1,50 @@
+param([Parameter(Mandatory)][string]$Version, [Parameter(Mandatory)][string]$Repo, [int]$RunMlModel = 1)
+# Windows runtime e2e for a published CLI ML variant. Env-SAFE: snapshots/restores
+# daemon.json and removes only artifacts this run created (NTFS is case-insensitive:
+# Vigil == vigil — never blind-delete the shared dir).
+$ErrorActionPreference='Continue'; $ProgressPreference='SilentlyContinue'
+$script:P=0; $script:F=0
+function ok($m){ Write-Host "  PASS $m"; $script:P++ }
+function no($m){ Write-Host "  FAIL $m"; $script:F++ }
+
+$vigilDir="$env:LOCALAPPDATA\Vigil"; $dj="$vigilDir\daemon.json"
+$djBak    = if (Test-Path $dj) { Get-Content $dj -Raw } else { $null }
+$preVigil = Test-Path $vigilDir
+$preModel = Test-Path "$vigilDir\models\privacy-filter-0.5.1"
+Get-Process vigil-hub -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+$sbx="$env:TEMP\vigil-acc-win"; Remove-Item -Recurse -Force $sbx -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $sbx | Out-Null; Set-Location $sbx
+
+try {
+  Write-Host "### windows runtime e2e: $Version ###"
+  curl.exe -fsSL -o ml.zip "https://github.com/$Repo/releases/download/$Version/vigils-cli-ml-windows-x64.zip"
+  Expand-Archive -Force ml.zip ml
+  $hub="$sbx\ml\vigil-hub.exe"
+  $verExp = "vigil-hub " + ($Version -replace '^v','')
+  if ((& $hub --version) -eq $verExp) { ok "version == $verExp" } else { no "version: $(& $hub --version)" }
+  if (Test-Path "$sbx\ml\onnxruntime.dll") { ok "ORT dll bundled exe-adjacent" } else { no "onnxruntime.dll missing" }
+  Add-Type -TypeDefinition @"
+using System;using System.Runtime.InteropServices;
+public class L{[DllImport("kernel32",SetLastError=true,CharSet=CharSet.Unicode)]public static extern IntPtr LoadLibrary(string p);
+ public static bool T(string p){return LoadLibrary(p)!=IntPtr.Zero;}}
+"@
+  if ([L]::T("$sbx\ml\onnxruntime.dll")) { ok "onnxruntime.dll loads (PE + VC++ runtime deps)" } else { no "onnxruntime.dll LoadLibrary failed err=$([Runtime.InteropServices.Marshal]::GetLastWin32Error())" }
+
+  if ($RunMlModel -eq 1) {
+    & $hub model install --privacy 2>&1 | Out-Null
+    if ($LASTEXITCODE -eq 0) { ok "model install --privacy (turnkey download)" } else { no "model install FAILED" }
+  }
+  $d = Start-Process $hub -ArgumentList 'daemon','start' -PassThru -WindowStyle Hidden -RedirectStandardOutput "$sbx\d.out" -RedirectStandardError "$sbx\d.err"
+  $up=$false; for($i=0;$i -lt 40;$i++){ Start-Sleep 1; if ((& $hub daemon status 2>&1|Out-String) -match 'running \(pid'){$up=$true;break}; if($d.HasExited){break} }
+  if ($up) { ok "daemon reachable via R1 (named-pipe)" } else { no "daemon unreachable"; Get-Content "$sbx\d.out","$sbx\d.err" -ErrorAction SilentlyContinue }
+  & $hub daemon stop 2>&1 | Out-Null
+  if (-not $d.HasExited){ Stop-Process -Id $d.Id -Force -ErrorAction SilentlyContinue }
+}
+finally {
+  if ($null -ne $djBak){ Set-Content -Path $dj -Value $djBak -NoNewline } elseif (Test-Path $dj){ Remove-Item $dj -Force }
+  if (-not $preVigil) { Remove-Item -Recurse -Force $vigilDir -ErrorAction SilentlyContinue }
+  elseif (-not $preModel) { Remove-Item -Recurse -Force "$vigilDir\models\privacy-filter-0.5.1" -ErrorAction SilentlyContinue }
+  Remove-Item -Recurse -Force $sbx -ErrorAction SilentlyContinue
+}
+Write-Host ""; Write-Host "### result: $script:P passed, $script:F failed (windows) ###"
+if ($script:F -gt 0){ exit 1 }


### PR DESCRIPTION
Found by downloading the **published v0.4.0 artifacts** and testing them as a real user across Linux / macOS / Windows. These bugs only surface in published artifacts on real hardware — local builds and CI can't see them.

## Fixes

| Sev | Bug | Fix |
|---|---|---|
| 🔴 | **Linux `model install` reproducibly fails** — the fixed 30s per-chunk timeout is shorter than the ~65s a 48 MB chunk needs when 16 concurrent chunks share an ~11.5 MB/s link, so reqwest aborts mid-body (`error decoding response body`). | `download.rs`: `chunk_timeout(bytes)` scales the per-chunk timeout to chunk size (128 KiB/s floor, clamp [60, 900]s). |
| 🔴 | **macOS daemon unreachable → ML-on-hook dead** — `peer_creds().pid()` is `None` on macOS (no `SO_PEERCRED`), so pid-based R1 always failed and every hook/`status` treated the daemon as down. | `transport.rs`: macOS uses `GenericFilePath` + **euid**-based R1 (`peer euid == geteuid`). Linux/Windows keep `GenericNamespaced` + pid R1 unchanged. |
| 🟠 | **macOS daemon can't restart after unclean exit** — the `/tmp` filesystem socket isn't reclaimed on `kill -9`/crash → permanent `EADDRINUSE`. | `transport.rs`: probe-then-unlink stale reclaim before bind; socket moved into a private `0700` `<data_local>/Vigil` dir and chmod `0600`. |
| 🟡 | **Windows `.sha256` files use CRLF** → `sha256sum -c` breaks in Unix-y environments. | `release.yml`: write the checksum files with LF. |

## Verification

- **Linux download**: root cause proven by curl on the failing machine — 16×50 MB `--max-time 30` all time out, `--max-time 300` all succeed in 70s. Unit test added for `chunk_timeout`.
- **macOS daemon**: verified on real Apple Silicon — `daemon status` now reports `running`, restart after `kill -9` succeeds, socket `0600` / dir `0700`; 3 transport unit tests; `clippy` clean (with and without `ort`).
- **Cross-platform**: `clippy --workspace --all-targets -D warnings` clean on Windows; Linux/Windows transport behavior byte-identical.
- **Adversarial review** by two independent reviewers (codex + a hostile sub-agent); both converged on the `/tmp`-fallback hardening, now applied (private `$TMPDIR` fallback + `0700`/`0600`).

## Regression suite

`tests/acceptance/` downloads the published artifacts and tests them as a real user across platforms (integrity / arch / ML dylib / minisign signatures / OTA + daemon hook-ML e2e + R1/stale-socket regression), so these distribution bugs can't ship again.

Suggest a **v0.4.1** patch release after merge.
