### PR TITLE
feat(desktop): GUI 自动安装 ML 引擎变体 + 签名引擎清单(端到端 ML 最后一公里)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -550,13 +550,60 @@ jobs:
         with:
           subject-path: dist/vigils-chrome-extension.zip
 
+  # ── 5. Signed engine manifest (SHA trust anchor for desktop ML-engine auto-install)──────────
+  # Aggregate the cli-ml `.sha256` sidecars → engine-manifest.json (per-platform url+sha256) →
+  # minisign-sign with the release key → upload. The desktop GUI fetches + verifies this manifest
+  # (reusing the Tauri-updater minisign pubkey) to SHA-pin the ML engine download — the download
+  # source itself cannot forge a valid signature. The manifest carries the URLs too, so the GUI
+  # never hardcodes asset names (handles the Windows .zip / Unix .tar.gz divergence).
+  # Draft-safe: if this job fails the release stays a draft (finalize needs it).
+  engine-manifest:
+    needs: [create-release, cli-ml]
+    runs-on: ubuntu-latest
+    env:
+      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Download cli-ml checksums from the draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p sums
+          gh release download "${{ needs.create-release.outputs.tag }}" \
+            --repo "${{ github.repository }}" --pattern "vigils-cli-ml-*.sha256" --dir sums
+          ls -la sums
+      - name: Build engine-manifest.json
+        run: node scripts/gen-engine-manifest.mjs "${{ needs.create-release.outputs.tag }}" "${{ github.repository }}" sums
+      - name: Sign engine-manifest.json (minisign, release key)
+        if: env.TAURI_SIGNING_PRIVATE_KEY != ''
+        run: |
+          set -euo pipefail
+          cargo install tauri-cli --version "^2"
+          # tauri signer writes engine-manifest.json.sig (base64-wrapped minisign); GUI fetches `.minisig`
+          cargo tauri signer sign engine-manifest.json
+          mv engine-manifest.json.sig engine-manifest.json.minisig
+      - name: Upload signed engine manifest to the draft release
+        if: env.TAURI_SIGNING_PRIVATE_KEY != ''
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.create-release.outputs.tag }}
+          draft: true
+          files: |
+            engine-manifest.json
+            engine-manifest.json.minisig
+
   # ── 6. Finalize ───────────────────────────────────────────────────────────
   # ISS-20260621-005: publish the release (draft -> public) ONLY after every build job succeeded.
   # If any build fails this job is skipped (needs: all builds) and the release stays a draft, so a
   # failed build never leaves a public release with missing/partial assets. Mirrors — and now
   # enforces in CI — the manual rc-then-promote discipline in docs/releasing-gotchas.md.
   finalize:
-    needs: [create-release, cli, cli-ml, desktop, extension]
+    needs: [create-release, cli, cli-ml, desktop, extension, engine-manifest]
     runs-on: ubuntu-latest
     steps:
       - name: Publish release after all builds succeeded

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "ascii"
@@ -219,6 +222,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -949,6 +961,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1098,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,6 +1169,7 @@ dependencies = [
  "block-buffer",
  "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1282,6 +1333,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1420,6 +1495,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,6 +1508,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2745,6 +2836,12 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -4831,6 +4928,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5584,6 +5692,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5693,19 +5816,26 @@ dependencies = [
 name = "vigil-desktop"
 version = "0.4.1"
 dependencies = [
+ "base64 0.22.1",
+ "blake2",
  "clap",
  "dirs 6.0.0",
+ "ed25519-dalek",
+ "flate2",
  "hex",
+ "minisign-verify",
  "rusqlite",
  "serde",
  "serde_jcs",
  "serde_json",
  "sha2",
+ "tar",
  "tauri",
  "tauri-build",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "ureq",
  "vigil-audit",
  "vigil-firewall",
  "vigil-lease",
@@ -5714,6 +5844,7 @@ dependencies = [
  "vigil-runner",
  "vigil-types",
  "vigil-ui-protocol",
+ "zip",
 ]
 
 [[package]]
@@ -7290,6 +7421,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "yasna"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7416,7 +7557,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -46,6 +46,12 @@ gui = [
     "dep:vigil-mcp",
     "dep:vigil-firewall",
     "dep:vigil-policy",
+    "dep:ureq",
+    "dep:flate2",
+    "dep:tar",
+    "dep:zip",
+    "dep:minisign-verify",
+    "dep:base64",
 ]
 
 [dependencies]
@@ -73,6 +79,14 @@ tauri = { version = "2", optional = true, default-features = false, features = [
 tokio = { workspace = true, optional = true }
 # β5:用户数据目录解析(跨平台);仅 gui feature 需要,运行时定位 ledger 持久化路径
 dirs = { version = "6", optional = true }
+# ML 引擎变体安装(gui):下载(ureq/rustls)+ 解包(flate2/tar/zip 按魔数嗅探)+ 签名引擎清单验签
+# (minisign-verify + base64 解 Tauri 包装的 .sig)。全纯 Rust,无 C 依赖;仅 gui feature 拉。
+ureq = { version = "2", optional = true, default-features = false, features = ["tls"] }
+flate2 = { version = "1", optional = true }
+tar = { version = "0.4", optional = true }
+zip = { version = "2", optional = true, default-features = false, features = ["deflate"] }
+minisign-verify = { version = "0.2", optional = true }
+base64 = { version = "0.22", optional = true }
 
 [build-dependencies]
 tauri-build = { version = "2", optional = true, default-features = false , features = [] }
@@ -81,3 +95,6 @@ tauri-build = { version = "2", optional = true, default-features = false , featu
 tempfile = { workspace = true }
 vigil-lease = { path = "../../crates/vigil-lease" }
 rusqlite = { workspace = true }
+# 仅测试:测试内现造 minisign 风格预哈希签名,hermetic 验 verify_minisign(无外部工具/网络)。
+ed25519-dalek = "2"
+blake2 = "0.10"

--- a/apps/desktop/capabilities/default.json
+++ b/apps/desktop/capabilities/default.json
@@ -36,6 +36,7 @@
     "allow-daemon-start",
     "allow-daemon-stop",
     "allow-model-status",
-    "allow-model-install"
+    "allow-model-install",
+    "allow-download-ml-engine"
   ]
 }

--- a/apps/desktop/src/bin/vigils.rs
+++ b/apps/desktop/src/bin/vigils.rs
@@ -680,6 +680,16 @@ async fn model_install(
     vigil_desktop::ml_control::model_install(&app)
 }
 
+/// `invoke('download_ml_engine')` → **Write**:下载安装 ML 引擎变体(`--features ort` 的 vigil-hub +
+/// 同目录 ONNX Runtime 库;HTTPS + 签名清单 SHA-pin + 运行核验,fail-closed)到稳定目录,使 GUI 用户
+/// 的 ML 真正可用。返回安装后模型态(`ml_supported` 应翻 true)。
+#[tauri::command]
+async fn download_ml_engine(
+    app: tauri::AppHandle,
+) -> Result<vigil_desktop::ml_control::ModelStatus, String> {
+    vigil_desktop::ml_control::download_ml_engine(&app)
+}
+
 // ─────────────────────────── Tauri setup ──────────────────────────────────
 //
 // β5 Ledger 磁盘持久化:
@@ -786,6 +796,8 @@ fn main() {
             daemon_stop,
             model_status,
             model_install,
+            // ML 引擎变体安装(端到端 ML 最后一公里)
+            download_ml_engine,
         ])
         .setup(move |app| {
             let _main_window = app.get_webview_window("main");

--- a/apps/desktop/src/commands.rs
+++ b/apps/desktop/src/commands.rs
@@ -22,9 +22,9 @@
 
 /// Tauri `#[tauri::command]` 真白名单 —— 构建期与运行期 ACL 的 SSOT。
 ///
-/// **顺序不重要**(内部按 slugified 生成 permission);共 **28** 条
+/// **顺序不重要**(内部按 slugified 生成 permission);共 **29** 条
 /// (α1=1 + α2=3 + α3=3 + α4=10 + α5=2 + ISS-017=1 + ISS-018=1 + D19=1 + checkpoint=1
-/// + ML 控制平面=5[daemon_status/start/stop + model_status/install])。
+/// + ML 控制平面=5[daemon_status/start/stop + model_status/install] + ML 引擎变体安装=1[download_ml_engine])。
 pub const INVOKE_COMMANDS: &[&str] = &[
     // α1(Sessions smoke)
     "list_sessions",
@@ -64,6 +64,8 @@ pub const INVOKE_COMMANDS: &[&str] = &[
     "daemon_stop",
     "model_status",
     "model_install",
+    // ML 引擎变体安装(让 GUI 用户的 ML 真正可用)
+    "download_ml_engine",
 ];
 
 #[cfg(test)]
@@ -79,7 +81,7 @@ mod tests {
     fn invoke_commands_count_in_sync() {
         assert_eq!(
             INVOKE_COMMANDS.len(),
-            28,
+            29,
             "INVOKE_COMMANDS 漂移 —— 新增/删除 handler 时必须同步:\n\
              1) 本文件 `apps/desktop/src/commands.rs`\n\
              2) `apps/desktop/src/bin/vigils.rs` 的 `tauri::generate_handler!` 列表\n\

--- a/apps/desktop/src/ml_control.rs
+++ b/apps/desktop/src/ml_control.rs
@@ -35,8 +35,17 @@ pub fn stable_launcher_path() -> Option<PathBuf> {
     )
 }
 
-/// 解析 vigil-hub 引擎二进制:捆绑 resource → GUI exe 同目录 → 稳定启动器位置 → PATH。优雅 fall-through。
+/// 解析 vigil-hub 引擎二进制。顺序:**已装 ML 变体(稳定目录,dylib 信号)** → 捆绑 resource →
+/// GUI exe 同目录 → 稳定启动器 → PATH。优雅 fall-through。
+///
+/// ML 变体置顶:用户经 GUI 安装 ort 引擎到稳定目录后,必须盖过出厂硬指纹引擎(它可能在 exe 同目录 /
+/// PATH),否则 model/daemon/hook 仍跑硬指纹 → ML 形同未装。无 dylib 的普通引擎不触发本分支,顺序不变。
 fn resolve_engine(app: &AppHandle) -> Option<PathBuf> {
+    if let Some(p) = stable_launcher_path() {
+        if p.is_file() && stable_has_ml_dylib(&p) {
+            return Some(p);
+        }
+    }
     if let Ok(dir) = app.path().resource_dir() {
         let p = dir.join(ENGINE_BIN);
         if p.is_file() {
@@ -57,6 +66,15 @@ fn resolve_engine(app: &AppHandle) -> Option<PathBuf> {
         }
     }
     which_on_path(ENGINE_BIN)
+}
+
+/// 稳定启动器目录是否含当前平台 ONNX Runtime dylib(`download_ml_engine` 的落点信号)——
+/// 用于 [`resolve_engine`] 判定稳定目录里是不是用户装的 ML 引擎变体。
+fn stable_has_ml_dylib(engine: &Path) -> bool {
+    engine
+        .parent()
+        .map(|d| d.join(ort_dylib_basename()).is_file())
+        .unwrap_or(false)
 }
 
 fn which_on_path(bin: &str) -> Option<PathBuf> {
@@ -198,6 +216,406 @@ pub fn model_install(app: &AppHandle) -> Result<ModelStatus, String> {
     model_status(app)
 }
 
+// ─────────────────── ML 引擎变体安装(端到端 ML「最后一公里」)───────────────────────────
+// 出厂 GUI 不捆引擎,常态下用户装的是**非 ort** vigil-hub → `model status` 报 unsupported、
+// `--engine ml|auto` fail-closed 回落硬指纹 → ML 形同未发布。本段把已发布的 **ML 引擎变体** archive
+// (`--features ort` 的 vigil-hub + 同目录 ONNX Runtime 库)安全装到**稳定启动器目录** →
+// `resolve_engine` 经 dylib 信号优先命中 ort → daemon 可暖载、`model install/status` 可用、hook 真跑 ML。
+//
+// SHA 信任锚 = 发版期 **minisign 签名**的 `engine-manifest.json`(列 per-平台 {url,sha256});GUI 取
+// manifest + `.minisig` → 复用 Tauri 更新器同一把 key 验签 → 据此 SHA-pin(攻击者控下载源也伪造不出
+// 有效签名)。签名背书同时解决命名/格式分叉:公开 Windows 资产是 `.zip`(多 ORT 库)、Unix `.tar.gz`
+// —— 解包器按**魔数嗅探**。env 覆盖保留作测试 / 私有镜像旁路。
+
+/// 当前平台引擎资产标识(发布镜像命名;与签名清单平台键一致)。
+fn engine_platform() -> Result<&'static str, String> {
+    if cfg!(all(windows, target_arch = "x86_64")) {
+        Ok("windows-x64")
+    } else if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+        Ok("macos-arm64")
+    } else if cfg!(all(target_os = "macos", target_arch = "x86_64")) {
+        Ok("macos-x64")
+    } else if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
+        Ok("linux-x64")
+    } else {
+        Err("unsupported platform for ML engine auto-download".to_string())
+    }
+}
+
+/// 当前平台主 ONNX Runtime 库 basename(release.yml `dest` / 真发布资产主库名;也是稳定目录
+/// dylib 信号探测名 —— 两套 release 管线均保证此精确名就位)。
+fn ort_dylib_basename() -> &'static str {
+    if cfg!(windows) {
+        "onnxruntime.dll"
+    } else if cfg!(target_os = "macos") {
+        "libonnxruntime.dylib"
+    } else {
+        "libonnxruntime.so"
+    }
+}
+
+/// 是否为 ONNX Runtime 运行时库(跨平台 + 多文件:`onnxruntime.dll` /
+/// `onnxruntime_providers_shared.dll` / `libonnxruntime.so[.x]` / `libonnxruntime.*.dylib`)。
+/// ML 包可能捆多个 ORT 库 → 全取,勿只取主库。
+fn is_ort_lib(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    lower.starts_with("onnxruntime") || lower.starts_with("libonnxruntime")
+}
+
+fn sha256_file(p: &Path) -> Result<String, String> {
+    use sha2::{Digest, Sha256};
+    let mut file = std::fs::File::open(p).map_err(|e| format!("open for hashing failed: {e}"))?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut file, &mut hasher).map_err(|e| format!("hashing failed: {e}"))?;
+    Ok(hex::encode(hasher.finalize()))
+}
+
+fn download_to_file(url: &str, dest: &Path) -> Result<(), String> {
+    let resp = ureq::get(url)
+        .timeout(std::time::Duration::from_secs(120))
+        .call()
+        .map_err(|e| format!("download request failed: {e}"))?;
+    let mut reader = resp.into_reader();
+    let mut file =
+        std::fs::File::create(dest).map_err(|e| format!("create temp file failed: {e}"))?;
+    std::io::copy(&mut reader, &mut file).map_err(|e| format!("writing engine failed: {e}"))?;
+    Ok(())
+}
+
+/// ML 引擎变体下载源(archive URL + 可选 pinned sha256)。
+struct MlEngineSource {
+    url: String,
+    sha256: Option<String>,
+}
+
+// ── 签名引擎清单(SHA 信任锚)─────────────────────────────────────────────────────────────
+/// 复用 Tauri 更新器的 minisign 公钥(key 5B4B247DA77CEAC5;见 tauri.conf.json::plugins.updater.pubkey
+/// base64 解码后第二行)。引擎清单与桌面更新件由同一发布密钥签名 → 单一信任锚。
+const ENGINE_MANIFEST_PUBKEY: &str = "RWTF6nynfSRLW//J/K4inS8RdovCJ+MhwtfG5xUJ4sJK/silUB9E8D3c";
+
+/// 引擎清单一个 artifact 条目。
+#[derive(Debug, Clone, Deserialize)]
+struct EngineArtifact {
+    url: String,
+    sha256: String,
+}
+
+/// 签名引擎清单:`artifacts["vigil-cli-ml"]["windows-x64"]` → {url, sha256}。平台键对齐 `engine_platform()`。
+#[derive(Debug, Clone, Deserialize)]
+struct EngineManifest {
+    artifacts: std::collections::HashMap<String, std::collections::HashMap<String, EngineArtifact>>,
+}
+
+/// 签名引擎清单 URL(`VIGIL_ENGINE_MANIFEST_URL` 覆盖,否则版本拼默认镜像)。`.minisig` 在 `<url>.minisig`。
+/// host 即便错 / 被 MITM,验签失败即 fail-closed → host provisional 不损安全。
+fn engine_manifest_url() -> String {
+    if let Ok(url) = std::env::var("VIGIL_ENGINE_MANIFEST_URL") {
+        return url;
+    }
+    let ver = env!("CARGO_PKG_VERSION");
+    format!("https://vigils.ai/releases/engine/v{ver}/engine-manifest.json")
+}
+
+/// GET 文本(小文件:清单 + 签名)。
+fn fetch_text(url: &str) -> Result<String, String> {
+    ureq::get(url)
+        .timeout(std::time::Duration::from_secs(30))
+        .call()
+        .map_err(|e| format!("fetch {url} failed: {e}"))?
+        .into_string()
+        .map_err(|e| format!("read {url} body failed: {e}"))
+}
+
+/// 用 minisign 公钥验签 `data`。`wrapped_sig_b64` = Tauri 风格 base64(标准 minisign .minisig 全文)。
+/// base64 / 格式 / 验签任一失败 → Err,绝不放行未验证内容。
+fn verify_minisign(data: &[u8], wrapped_sig_b64: &str, pubkey_b64: &str) -> Result<(), String> {
+    use base64::Engine;
+    let sig_bytes = base64::engine::general_purpose::STANDARD
+        .decode(wrapped_sig_b64.trim())
+        .map_err(|e| format!("manifest signature base64 decode failed: {e}"))?;
+    let sig_text =
+        String::from_utf8(sig_bytes).map_err(|e| format!("manifest signature not UTF-8: {e}"))?;
+    let pk = minisign_verify::PublicKey::from_base64(pubkey_b64)
+        .map_err(|e| format!("bad minisign pubkey: {e}"))?;
+    let sig = minisign_verify::Signature::decode(&sig_text)
+        .map_err(|e| format!("bad manifest signature: {e}"))?;
+    pk.verify(data, &sig, false)
+        .map_err(|e| format!("manifest signature verification failed: {e}"))
+}
+
+/// 解析引擎清单 JSON。
+fn parse_engine_manifest(bytes: &[u8]) -> Result<EngineManifest, String> {
+    serde_json::from_slice(bytes).map_err(|e| format!("parse engine manifest failed: {e}"))
+}
+
+/// 取并验签引擎清单(GET manifest + `.minisig` → 内嵌 pubkey 验签 → 解析)。
+fn fetch_engine_manifest() -> Result<EngineManifest, String> {
+    let url = engine_manifest_url();
+    if !url.starts_with("https://") {
+        return Err(format!("refusing non-HTTPS manifest URL: {url}"));
+    }
+    let manifest = fetch_text(&url)?;
+    let sig = fetch_text(&format!("{url}.minisig"))?;
+    verify_minisign(manifest.as_bytes(), &sig, ENGINE_MANIFEST_PUBKEY)?;
+    parse_engine_manifest(manifest.as_bytes())
+}
+
+/// env 覆盖(测试 / 私有镜像):`VIGIL_ML_ENGINE_URL`(+可选 `_SHA256`)→ 直用,跳过清单。
+fn ml_engine_override() -> Option<MlEngineSource> {
+    let url = std::env::var("VIGIL_ML_ENGINE_URL").ok()?;
+    Some(MlEngineSource {
+        url,
+        sha256: std::env::var("VIGIL_ML_ENGINE_SHA256")
+            .ok()
+            .filter(|s| !s.is_empty()),
+    })
+}
+
+/// 解析当前平台 ML 引擎变体下载源:env 覆盖优先,否则取**签名清单** → `vigil-cli-ml` × `engine_platform()`。
+fn resolve_ml_engine_source() -> Result<MlEngineSource, String> {
+    if let Some(src) = ml_engine_override() {
+        return Ok(src);
+    }
+    let plat = engine_platform()?;
+    let manifest = fetch_engine_manifest()?;
+    let art = manifest
+        .artifacts
+        .get("vigil-cli-ml")
+        .and_then(|m| m.get(plat))
+        .ok_or_else(|| format!("engine manifest has no vigil-cli-ml entry for {plat}"))?;
+    Ok(MlEngineSource {
+        url: art.url.clone(),
+        sha256: Some(art.sha256.clone()),
+    })
+}
+
+/// 把一个解出的成员按 basename 落到 `staging`(引擎二进制设 +x)。仅写文件,不决定取舍。
+fn place_ml_member(staging: &Path, name: &str, data: &[u8]) -> Result<(), String> {
+    let out = staging.join(name);
+    std::fs::write(&out, data).map_err(|e| format!("write {name} failed: {e}"))?;
+    #[cfg(unix)]
+    if name == ENGINE_BIN {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = std::fs::metadata(&out) {
+            let mut perm = meta.permissions();
+            perm.set_mode(0o755);
+            let _ = std::fs::set_permissions(&out, perm);
+        }
+    }
+    Ok(())
+}
+
+/// zip 成员遍历(`PK\x03\x04`):basename 扁平,逐成员交 `place`。
+fn extract_zip_members<F: FnMut(&str, &[u8]) -> Result<(), String>>(
+    archive: &Path,
+    place: &mut F,
+) -> Result<(), String> {
+    use std::io::Read;
+    let f = std::fs::File::open(archive).map_err(|e| format!("open ML zip failed: {e}"))?;
+    let mut zip = zip::ZipArchive::new(f).map_err(|e| format!("read ML zip failed: {e}"))?;
+    for i in 0..zip.len() {
+        let mut entry = zip
+            .by_index(i)
+            .map_err(|e| format!("read ML zip entry failed: {e}"))?;
+        if !entry.is_file() {
+            continue;
+        }
+        let name = match Path::new(entry.name()).file_name().and_then(|n| n.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        let mut buf = Vec::new();
+        entry
+            .read_to_end(&mut buf)
+            .map_err(|e| format!("extract {name} failed: {e}"))?;
+        place(&name, &buf)?;
+    }
+    Ok(())
+}
+
+/// gzip+tar 成员遍历(`\x1f\x8b`):basename 扁平,逐成员交 `place`。
+fn extract_targz_members<F: FnMut(&str, &[u8]) -> Result<(), String>>(
+    archive: &Path,
+    place: &mut F,
+) -> Result<(), String> {
+    use std::io::Read;
+    let f = std::fs::File::open(archive).map_err(|e| format!("open ML archive failed: {e}"))?;
+    let gz = flate2::read::GzDecoder::new(f);
+    let mut tar = tar::Archive::new(gz);
+    let entries = tar
+        .entries()
+        .map_err(|e| format!("read ML archive entries failed: {e}"))?;
+    for entry in entries {
+        let mut entry = entry.map_err(|e| format!("read ML archive entry failed: {e}"))?;
+        let name = {
+            let path = entry
+                .path()
+                .map_err(|e| format!("bad entry path in ML archive: {e}"))?;
+            match path.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n.to_string(),
+                None => continue,
+            }
+        };
+        let mut buf = Vec::new();
+        entry
+            .read_to_end(&mut buf)
+            .map_err(|e| format!("extract {name} failed: {e}"))?;
+        place(&name, &buf)?;
+    }
+    Ok(())
+}
+
+/// 解包 ML archive 到 `staging`:按魔数嗅探 zip / tar.gz,仅提取 `vigil-hub[.exe]` + **全部**
+/// `onnxruntime*` 库(basename 扁平,防 traversal),其余忽略。引擎或 ORT 库缺失 → Err(拒装半包)。
+/// 返回落地的引擎二进制路径。调用方保证 `archive` 已 SHA-pin 校验。
+fn extract_ml_bundle(archive: &Path, staging: &Path) -> Result<PathBuf, String> {
+    let mut head = [0u8; 4];
+    {
+        use std::io::Read;
+        let mut f =
+            std::fs::File::open(archive).map_err(|e| format!("open ML archive failed: {e}"))?;
+        let _ = f
+            .read(&mut head)
+            .map_err(|e| format!("read ML archive header failed: {e}"))?;
+    }
+
+    let mut engine_found = false;
+    let mut ort_found = false;
+    let mut place = |name: &str, data: &[u8]| -> Result<(), String> {
+        if name == ENGINE_BIN {
+            place_ml_member(staging, name, data)?;
+            engine_found = true;
+        } else if is_ort_lib(name) {
+            place_ml_member(staging, name, data)?;
+            ort_found = true;
+        }
+        Ok(())
+    };
+
+    if head.starts_with(&[0x50, 0x4b, 0x03, 0x04]) {
+        extract_zip_members(archive, &mut place)?;
+    } else if head.starts_with(&[0x1f, 0x8b]) {
+        extract_targz_members(archive, &mut place)?;
+    } else {
+        return Err(format!(
+            "unrecognized ML archive format (expected .zip or .tar.gz): {}",
+            archive.display()
+        ));
+    }
+
+    if !engine_found {
+        return Err(format!(
+            "ML archive did not contain {ENGINE_BIN} — refusing to install a partial bundle"
+        ));
+    }
+    if !ort_found {
+        return Err(
+            "ML archive did not contain an ONNX Runtime library — refusing to install an unusable ML engine"
+                .to_string(),
+        );
+    }
+    Ok(staging.join(ENGINE_BIN))
+}
+
+/// AppHandle-free 安装核心(供 [`download_ml_engine`] 与对真发布 artifact 的集成测试共用):解析源 →
+/// 下载 → 整包 SHA-pin → 嗅探解包 → 运行核验 → 把引擎 + 全部 ORT 库移入 `bin_dir`。全程 fail-closed。
+fn install_ml_engine_into(bin_dir: &Path) -> Result<(), String> {
+    let src = resolve_ml_engine_source()?;
+    if !src.url.starts_with("https://") {
+        return Err(format!("refusing non-HTTPS ML engine URL: {}", src.url));
+    }
+    let expected_sha = src.sha256.as_deref().ok_or_else(|| {
+        "ML engine auto-download is not configured with a pinned SHA256 (set VIGIL_ML_ENGINE_SHA256, \
+         or this build predates the signed release manifest) — refusing to fetch an unverified bundle"
+            .to_string()
+    })?;
+
+    std::fs::create_dir_all(bin_dir)
+        .map_err(|e| format!("failed to create {}: {e}", bin_dir.display()))?;
+
+    let staging = bin_dir.join(".ml-staging");
+    let _ = std::fs::remove_dir_all(&staging);
+    std::fs::create_dir_all(&staging)
+        .map_err(|e| format!("failed to create ML staging dir: {e}"))?;
+
+    let archive = staging.join("ml-bundle.download");
+    if let Err(e) = download_to_file(&src.url, &archive) {
+        let _ = std::fs::remove_dir_all(&staging);
+        return Err(e);
+    }
+
+    let got = match sha256_file(&archive) {
+        Ok(h) => h,
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&staging);
+            return Err(e);
+        }
+    };
+    if !got.eq_ignore_ascii_case(expected_sha) {
+        let _ = std::fs::remove_dir_all(&staging);
+        return Err(format!(
+            "ML engine SHA256 mismatch (expected {expected_sha}, got {got}) — refusing to install"
+        ));
+    }
+
+    let staged_engine = match extract_ml_bundle(&archive, &staging) {
+        Ok(p) => p,
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&staging);
+            return Err(e);
+        }
+    };
+
+    let mut check = Command::new(&staged_engine);
+    check.arg("--version");
+    no_window(&mut check);
+    let runs = check.output().map(|o| o.status.success()).unwrap_or(false);
+    if !runs {
+        let _ = std::fs::remove_dir_all(&staging);
+        return Err(
+            "downloaded ML engine failed to run (--version) — refusing to install".to_string(),
+        );
+    }
+
+    // 移入稳定 bin 目录:引擎 + 全部 ORT 库(按谓词筛,跳过下载的压缩包)。Windows 下若旧二进制正被
+    // daemon 运行 → rename 失败,提示先停 daemon。
+    for entry in std::fs::read_dir(&staging).map_err(|e| format!("read ML staging failed: {e}"))? {
+        let from = entry
+            .map_err(|e| format!("read ML staging entry failed: {e}"))?
+            .path();
+        let fname = match from.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        if fname != ENGINE_BIN && !is_ort_lib(&fname) {
+            continue;
+        }
+        let to = bin_dir.join(&fname);
+        if let Err(e) = std::fs::rename(&from, &to) {
+            let _ = std::fs::remove_dir_all(&staging);
+            return Err(format!(
+                "failed to install {fname} to {} ({e}) — if the daemon is running from the old \
+                 engine, stop it first (Settings → daemon → stop) and retry",
+                to.display()
+            ));
+        }
+    }
+    let _ = std::fs::remove_dir_all(&staging);
+    Ok(())
+}
+
+/// 写:下载并安装 **ML 引擎变体** 到稳定启动器目录(见 [`install_ml_engine_into`]),装好后返回 ML
+/// 模型缓存态(此时 `ml_supported` 应翻 true)。缺 pinned SHA → 拒绝(绝不安装未校验产物)。
+pub fn download_ml_engine(app: &AppHandle) -> Result<ModelStatus, String> {
+    let stable = stable_launcher_path()
+        .ok_or_else(|| "could not resolve a stable install location".to_string())?;
+    let bin_dir = stable
+        .parent()
+        .ok_or_else(|| "invalid stable launcher path".to_string())?;
+    install_ml_engine_into(bin_dir)?;
+    model_status(app)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -238,5 +656,251 @@ mod tests {
         assert!(!s.injection_installed);
         assert!(s.ml_supported);
         assert!(s.engine_present);
+    }
+
+    // ── ML 引擎变体安装(端到端最后一公里)─────────────────────────────────────────
+
+    #[test]
+    fn engine_platform_is_known_on_test_host() {
+        assert!(engine_platform().is_ok());
+    }
+
+    #[test]
+    fn engine_manifest_url_default_https_version_pinned() {
+        if std::env::var("VIGIL_ENGINE_MANIFEST_URL").is_err() {
+            let url = engine_manifest_url();
+            assert!(
+                url.starts_with("https://"),
+                "manifest URL must be HTTPS: {url}"
+            );
+            assert!(
+                url.contains(env!("CARGO_PKG_VERSION")),
+                "manifest URL must be version-pinned: {url}"
+            );
+            assert!(url.ends_with("engine-manifest.json"), "manifest URL: {url}");
+        }
+    }
+
+    #[test]
+    fn parse_engine_manifest_extracts_platform_artifact() {
+        let json = br#"{"schema":1,"version":"0.4.2","artifacts":{
+            "vigil-cli-ml":{
+                "windows-x64":{"url":"https://x/y/vigils-cli-ml-windows-x64.zip","sha256":"abc123"},
+                "linux-x64":{"url":"https://x/y/vigils-cli-ml-linux-x64.tar.gz","sha256":"def456"}
+            }}}"#;
+        let m = parse_engine_manifest(json).expect("parse ok");
+        let art = m
+            .artifacts
+            .get("vigil-cli-ml")
+            .and_then(|p| p.get("windows-x64"))
+            .expect("win entry");
+        assert_eq!(art.sha256, "abc123");
+        assert!(art.url.ends_with("windows-x64.zip"));
+        assert!(m
+            .artifacts
+            .get("vigil-cli-ml")
+            .and_then(|p| p.get("solaris-sparc"))
+            .is_none());
+    }
+
+    #[test]
+    fn parse_engine_manifest_rejects_garbage() {
+        assert!(parse_engine_manifest(b"not json at all").is_err());
+    }
+
+    #[test]
+    fn verify_minisign_accepts_valid_rejects_tampered() {
+        use base64::Engine as _;
+        use blake2::{Blake2b512, Digest};
+        use ed25519_dalek::{Signer, SigningKey};
+
+        let b64 = base64::engine::general_purpose::STANDARD;
+        let sk = SigningKey::from_bytes(&[7u8; 32]);
+        let keyid = [1u8, 2, 3, 4, 5, 6, 7, 8];
+
+        let mut pkblob = Vec::new();
+        pkblob.extend_from_slice(b"Ed");
+        pkblob.extend_from_slice(&keyid);
+        pkblob.extend_from_slice(&sk.verifying_key().to_bytes());
+        let pubkey_b64 = b64.encode(&pkblob);
+
+        let data = br#"{"schema":1,"artifacts":{}}"#;
+        let prehash = Blake2b512::digest(data);
+        let main_sig = sk.sign(prehash.as_slice());
+        let mut sigblob = Vec::new();
+        sigblob.extend_from_slice(b"ED");
+        sigblob.extend_from_slice(&keyid);
+        sigblob.extend_from_slice(&main_sig.to_bytes());
+        let tc_body = "test";
+        let mut global_msg = main_sig.to_bytes().to_vec();
+        global_msg.extend_from_slice(tc_body.as_bytes());
+        let global_sig = sk.sign(&global_msg);
+
+        let minisig_text = format!(
+            "untrusted comment: test\n{}\ntrusted comment: {}\n{}\n",
+            b64.encode(&sigblob),
+            tc_body,
+            b64.encode(global_sig.to_bytes())
+        );
+        let wrapped = b64.encode(minisig_text.as_bytes());
+
+        verify_minisign(data, &wrapped, &pubkey_b64).expect("valid signature must verify");
+        assert!(verify_minisign(b"tampered-manifest", &wrapped, &pubkey_b64).is_err());
+        assert!(verify_minisign(data, "!!!not-base64!!!", &pubkey_b64).is_err());
+    }
+
+    fn write_test_targz(dest: &Path, files: &[(&str, &[u8])]) {
+        let f = std::fs::File::create(dest).expect("create archive");
+        let enc = flate2::write::GzEncoder::new(f, flate2::Compression::fast());
+        let mut b = tar::Builder::new(enc);
+        for (path, data) in files {
+            let mut h = tar::Header::new_gnu();
+            h.set_size(data.len() as u64);
+            h.set_mode(0o644);
+            b.append_data(&mut h, *path, *data).expect("append entry");
+        }
+        let enc = b.into_inner().expect("finish tar");
+        enc.finish().expect("finish gzip");
+    }
+
+    fn write_test_zip(dest: &Path, files: &[(&str, &[u8])]) {
+        use std::io::Write;
+        let f = std::fs::File::create(dest).expect("create zip");
+        let mut z = zip::ZipWriter::new(f);
+        let opts = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated);
+        for (path, data) in files {
+            z.start_file(*path, opts).expect("start zip entry");
+            z.write_all(data).expect("write zip entry");
+        }
+        z.finish().expect("finish zip");
+    }
+
+    #[test]
+    fn extract_ml_bundle_targz_takes_binary_and_libs_flattening_paths() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let archive = dir.path().join("b.tar.gz");
+        let dylib = ort_dylib_basename();
+        let bin_entry = format!("vigil-cli-ml-x/{ENGINE_BIN}");
+        let dylib_entry = format!("vigil-cli-ml-x/{dylib}");
+        write_test_targz(
+            &archive,
+            &[
+                (bin_entry.as_str(), b"#!fake-ort-binary"),
+                (dylib_entry.as_str(), b"fake-dylib-bytes"),
+                ("vigil-cli-ml-x/README-ML.txt", b"ignore me"),
+            ],
+        );
+        let staging = dir.path().join("stage");
+        std::fs::create_dir_all(&staging).expect("mk staging");
+        let engine = extract_ml_bundle(&archive, &staging).expect("extract ok");
+        assert_eq!(engine, staging.join(ENGINE_BIN));
+        assert!(staging.join(ENGINE_BIN).is_file());
+        assert!(staging.join(dylib).is_file());
+        assert!(!staging.join("README-ML.txt").exists());
+        assert!(!staging.join("vigil-cli-ml-x").exists());
+    }
+
+    #[test]
+    fn extract_ml_bundle_zip_takes_binary_and_all_ort_libs() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let archive = dir.path().join("b.zip");
+        let dylib = ort_dylib_basename();
+        let extra_ort = if cfg!(windows) {
+            "onnxruntime_providers_shared.dll"
+        } else {
+            "libonnxruntime.so.1.24.4"
+        };
+        write_test_zip(
+            &archive,
+            &[
+                (ENGINE_BIN, b"#!fake-ort-binary"),
+                (dylib, b"primary-ort"),
+                (extra_ort, b"extra-ort"),
+                ("README-ML.txt", b"ignore me"),
+            ],
+        );
+        let staging = dir.path().join("stage");
+        std::fs::create_dir_all(&staging).expect("mk staging");
+        let engine = extract_ml_bundle(&archive, &staging).expect("extract zip ok");
+        assert_eq!(engine, staging.join(ENGINE_BIN));
+        assert!(staging.join(ENGINE_BIN).is_file());
+        assert!(staging.join(dylib).is_file());
+        assert!(
+            staging.join(extra_ort).is_file(),
+            "extra ORT lib (providers_shared) must also be extracted"
+        );
+        assert!(!staging.join("README-ML.txt").exists());
+    }
+
+    #[test]
+    fn extract_ml_bundle_rejects_archive_missing_binary() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let archive = dir.path().join("b.tar.gz");
+        let dylib_entry = format!("x/{}", ort_dylib_basename());
+        write_test_targz(&archive, &[(dylib_entry.as_str(), b"only-ort-lib")]);
+        let staging = dir.path().join("stage");
+        std::fs::create_dir_all(&staging).expect("mk staging");
+        let err = extract_ml_bundle(&archive, &staging).expect_err("must reject missing binary");
+        assert!(
+            err.contains(ENGINE_BIN),
+            "error names the missing binary: {err}"
+        );
+    }
+
+    #[test]
+    fn extract_ml_bundle_rejects_archive_missing_ort_lib() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let archive = dir.path().join("b.tar.gz");
+        let bin_entry = format!("x/{ENGINE_BIN}");
+        write_test_targz(&archive, &[(bin_entry.as_str(), b"only-binary")]);
+        let staging = dir.path().join("stage");
+        std::fs::create_dir_all(&staging).expect("mk staging");
+        let err = extract_ml_bundle(&archive, &staging).expect_err("must reject missing ORT lib");
+        assert!(
+            err.contains("ONNX Runtime"),
+            "error should mention the missing ONNX Runtime lib: {err}"
+        );
+    }
+
+    #[test]
+    fn stable_has_ml_dylib_detects_colocated_dylib() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let engine = dir.path().join(ENGINE_BIN);
+        std::fs::write(&engine, b"bin").expect("write engine");
+        assert!(!stable_has_ml_dylib(&engine));
+        std::fs::write(dir.path().join(ort_dylib_basename()), b"lib").expect("write dylib");
+        assert!(stable_has_ml_dylib(&engine));
+    }
+
+    /// 对真发布 ML artifact 的端到端验证(不硬编码 URL,靠运行方设 `VIGIL_ML_ENGINE_URL` +
+    /// `VIGIL_ML_ENGINE_SHA256` 喂真包;未设则跳过)。默认 `#[ignore]`(含网络下载)。
+    #[test]
+    #[ignore = "network + needs VIGIL_ML_ENGINE_URL/SHA256 set to a real ML artifact"]
+    fn install_real_ml_artifact_makes_engine_ml_capable() {
+        if std::env::var("VIGIL_ML_ENGINE_URL").is_err() {
+            return;
+        }
+        let dir = tempfile::tempdir().expect("tempdir");
+        install_ml_engine_into(dir.path()).expect("install real ML engine");
+        let engine = dir.path().join(ENGINE_BIN);
+        assert!(engine.is_file(), "engine binary installed");
+        assert!(
+            dir.path().join(ort_dylib_basename()).is_file(),
+            "primary ORT lib installed alongside"
+        );
+        let out = std::process::Command::new(&engine)
+            .args(["model", "status"])
+            .output()
+            .expect("run model status");
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            !combined.to_ascii_lowercase().contains("unsupported"),
+            "installed ML engine must report ML support, got: {combined}"
+        );
     }
 }

--- a/apps/desktop/ui/src/api/ipc.ts
+++ b/apps/desktop/ui/src/api/ipc.ts
@@ -669,3 +669,12 @@ export async function modelStatus(): Promise<ModelStatus> {
 export async function modelInstall(): Promise<ModelStatus> {
   return await invoke<ModelStatus>("model_install");
 }
+
+/**
+ * 写：下载安装 ML 引擎变体（`--features ort` 的 vigil-hub + 同目录 ONNX Runtime 库；HTTPS + 签名
+ * 引擎清单 SHA-pin + 运行核验，fail-closed）。出厂硬指纹引擎无法装模型 —— 装好 ML 引擎后
+ * `ml_supported` 翻 true,方可继续装模型。回安装后状态。
+ */
+export async function downloadMlEngine(): Promise<ModelStatus> {
+  return await invoke<ModelStatus>("download_ml_engine");
+}

--- a/apps/desktop/ui/src/i18n/locales/en-US.json
+++ b/apps/desktop/ui/src/i18n/locales/en-US.json
@@ -297,6 +297,7 @@
       "not_installed": "NOT INSTALLED",
       "unsupported": "ML VARIANT REQUIRED",
       "install": "Install AI model",
+      "install_ml_engine": "Install ML engine",
       "error": "Model install failed: {msg}"
     }
   },

--- a/apps/desktop/ui/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/ui/src/i18n/locales/zh-CN.json
@@ -297,6 +297,7 @@
       "not_installed": "未安装",
       "unsupported": "需 ML 变体",
       "install": "安装 AI 模型",
+      "install_ml_engine": "安装 ML 引擎",
       "error": "模型安装失败: {msg}"
     }
   },

--- a/apps/desktop/ui/src/pages/Settings.vue
+++ b/apps/desktop/ui/src/pages/Settings.vue
@@ -25,6 +25,7 @@ import {
   daemonStop,
   modelStatus,
   modelInstall,
+  downloadMlEngine,
   type DaemonStatus,
   type ModelStatus,
 } from "@/api/ipc";
@@ -83,6 +84,19 @@ async function installModel(): Promise<void> {
   busy.value = "model:install";
   try {
     model.value = await modelInstall();
+  } catch (e) {
+    message.error(t("settings.model.error", { msg: String(e) }));
+  } finally {
+    busy.value = null;
+  }
+}
+
+// 装 ML 引擎变体（让 ml_supported 翻 true，再可装模型）。出厂硬指纹引擎无 ort，必经此步。
+async function installMlEngine(): Promise<void> {
+  if (busy.value) return;
+  busy.value = "ml-engine:install";
+  try {
+    model.value = await downloadMlEngine();
   } catch (e) {
     message.error(t("settings.model.error", { msg: String(e) }));
   } finally {
@@ -311,6 +325,17 @@ function updatePollingInterval(v: number | null): void {
             <NTag v-else size="small" :bordered="false" data-testid="model-state">
               {{ t("settings.model.status_unknown") }}
             </NTag>
+            <NButton
+              v-if="model && !model.ml_supported"
+              size="small"
+              type="primary"
+              :loading="busy === 'ml-engine:install'"
+              :disabled="busy !== null || !model?.engine_present"
+              data-testid="ml-engine-install"
+              @click="installMlEngine()"
+            >
+              {{ t("settings.model.install_ml_engine") }}
+            </NButton>
             <NButton
               size="small"
               tertiary

--- a/scripts/gen-engine-manifest.mjs
+++ b/scripts/gen-engine-manifest.mjs
@@ -1,0 +1,47 @@
+// Build the signed engine manifest (engine-manifest.json) from the cli-ml `.sha256` sidecars on the
+// draft release. Lists per-platform {url, sha256} for the `vigil-cli-ml` engine variant so the
+// desktop GUI can SHA-pin the ML engine download against a **minisign-signed** manifest — the SHA
+// trust anchor (the download source itself can't forge a valid signature). The manifest also carries
+// the per-platform URLs, so the GUI never hardcodes asset names (solves the naming/format divergence:
+// Windows `.zip` / Unix `.tar.gz`).
+//
+// Usage: node gen-engine-manifest.mjs <tag> <repo> <sumsDir>
+//   <tag>     release tag, e.g. v0.4.2
+//   <repo>    owner/name, e.g. duncatzat/vigils
+//   <sumsDir> dir containing the downloaded `vigils-cli-ml-*.sha256` sidecars
+// Emits engine-manifest.json in CWD. Platform keys (windows-x64 / linux-x64 / macos-arm64) align with
+// the desktop `engine_platform()`.
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const [tag, repo, sumsDir] = process.argv.slice(2);
+if (!tag || !repo || !sumsDir) {
+  console.error("usage: gen-engine-manifest.mjs <tag> <repo> <sumsDir>");
+  process.exit(2);
+}
+
+const cliMl = {};
+for (const f of readdirSync(sumsDir)) {
+  if (!f.startsWith("vigils-cli-ml-") || !f.endsWith(".sha256")) continue;
+  // sidecar content: "<hex-sha256>  <filename>"
+  const [hash, fname] = readFileSync(join(sumsDir, f), "utf8").trim().split(/\s+/);
+  if (!hash || !fname) continue;
+  // vigils-cli-ml-windows-x64.zip → plat = windows-x64
+  const m = fname.match(/^vigils-cli-ml-(.+?)\.(zip|tar\.gz)$/);
+  if (!m) continue;
+  cliMl[m[1]] = {
+    url: `https://github.com/${repo}/releases/download/${tag}/${fname}`,
+    sha256: hash,
+  };
+}
+
+const platforms = Object.keys(cliMl);
+if (platforms.length === 0) {
+  console.error(`FAIL: no vigils-cli-ml-*.sha256 sidecars found in ${sumsDir}`);
+  process.exit(1);
+}
+
+const manifest = { schema: 1, version: tag.replace(/^v/, ""), artifacts: { "vigil-cli-ml": cliMl } };
+// Newline-terminated; these exact bytes are what gets signed and what the GUI verifies.
+writeFileSync("engine-manifest.json", JSON.stringify(manifest, null, 2) + "\n");
+console.error(`engine-manifest.json: vigil-cli-ml platforms = ${platforms.join(", ")}`);


### PR DESCRIPTION
## 背景
出厂 GUI 捆**非 ort** vigil-hub → `model status` 报 `unsupported`、`--engine ml|auto` fail-closed 回落硬指纹 → ML 形同未发布。本 PR 让 GUI 用户**一键安装 ML 引擎变体**,daemon 暖载 + hook 主路径**端到端真跑 ML**。

## 改动
- **ml_control.rs**:HTTPS 下载 + **魔数嗅探解包**(zip / tar.gz;Windows 含多个 ORT 库 `onnxruntime.dll`+`onnxruntime_providers_shared.dll`)+ `--version` 运行核验 + 移入稳定启动器目录;`resolve_engine` 经 **dylib 信号**优先命中已装 ort 引擎(无 dylib 则顺序不变,向后兼容)。
- **SHA 信任锚 = 签名引擎清单**:`download_ml_engine` 取 minisign 签名的 `engine-manifest.json`(复用 Tauri 更新器同一把 key `5B4B247DA77CEAC5` 验签)→ 据此 SHA-pin(下载源伪造不出有效签名)。`release.yml` 新增 `engine-manifest` job 发版期从 `.sha256` sidecar 生成 + 签名 + 上传(**draft-safe**:任一 job 失败 → 停草稿不发布)。清单提供 URL,解决 Windows `.zip` / Unix `.tar.gz` 命名/格式分叉。`env` 覆盖(`VIGIL_ML_ENGINE_URL`/`_SHA256`)保留作测试/私有镜像旁路。
- **前端**:Settings 模型卡加"安装 ML 引擎"按钮(`ml_supported=false` 时显示);命令 SSOT 28→29。

## 验证(本地 / 32 核构建机)
- gui `clippy --all-targets -D warnings` 净;**31 lib 测试**(`verify_minisign` hermetic 正/负 + zip/tar 双路解包 + 多 ORT 库 + SSOT count=29/capability 集合匹配)。
- 前端 `vue-tsc --noEmit` 净;`cargo fmt -p vigil-desktop --check` 净。
- **真 artifact e2e**(`#[ignore]` `install_real_ml_artifact_makes_engine_ml_capable`,env 喂真包):已对**真发布 `vigils-cli-ml-windows-x64.zip`** 验证(下载→SHA-pin→zip 解包→装好引擎 `model status` 翻 ML 支持)。

## 如何测试
1. **PR CI**:fmt/clippy/test/ui 绿(注:gui feature CI 不编,gui clippy+test 已在构建机验)。
2. **env 覆盖(现可)**:GUI 设 `VIGIL_ML_ENGINE_URL`=真 cli-ml 资产 + `VIGIL_ML_ENGINE_SHA256` → 点"安装 ML 引擎"。
3. **Turnkey(发版后)**:打 beta tag → `engine-manifest` job 发签名清单 → GUI 点按钮自动装(无需 env)。

## 注
- `engine-manifest` job 的签名步(`cargo tauri signer sign`)只能在**带签名密钥的 release run** 验证;draft-safe 兜底:失败仅停草稿,不发布残缺。