### PR TITLE
feat(cli): vigil-hub 国际化(中/英按系统语言)

### DIFF
--- a/apps/vigil-hub-cli/Cargo.toml
+++ b/apps/vigil-hub-cli/Cargo.toml
@@ -69,6 +69,11 @@ vigil-ui-protocol = { path = "../../crates/vigil-ui-protocol" }
 # R1 peer-credential + R2 读截止 在其 raw fd/handle 上另加(见 daemon/transport.rs)。
 interprocess = "2"
 
+# CLI/帮助文本国际化(i18n):按系统语言(Windows 用户默认 UI 语言 / Unix LANG 等)选择
+# 中/英输出。workspace `unsafe_code = "forbid"` 禁止自写 Windows `GetUserDefaultLocaleName`
+# FFI;sys-locale 封装各平台 locale 探测(纯封装,MIT OR Apache-2.0,跨平台)。
+sys-locale = "0.3"
+
 # macOS daemon R1:`peer_creds().pid()` 在 macOS UDS 恒 None(无 SO_PEERCRED),euid 可用。
 # 用 rustix(安全封装,本 crate 仍 forbid unsafe)取自身 euid 与对端比对。版本对齐 lock 既有 1.x。
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/apps/vigil-hub-cli/src/daemon/lifecycle.rs
+++ b/apps/vigil-hub-cli/src/daemon/lifecycle.rs
@@ -15,6 +15,15 @@ use super::client::{daemon_info_path, read_daemon_info, write_daemon_info, Daemo
 use super::protocol::{Request, Response, PROTOCOL_VERSION};
 use super::server::DaemonCaps;
 use super::transport::{bind, default_socket_name, query_daemon, serve};
+use crate::i18n::Lang;
+
+/// 按语言取静态文案(中 / 英并排)。用户直面命令(`daemon start|status|stop`),输出按系统语言本地化。
+fn tr(lang: Lang, en: &'static str, zh: &'static str) -> &'static str {
+    match lang {
+        Lang::En => en,
+        Lang::Zh => zh,
+    }
+}
 
 /// 生成 per-launch token(128-bit CSPRNG → 32 hex)。熵失败 → `None`。
 fn generate_token() -> Option<String> {
@@ -43,10 +52,12 @@ fn open_canonical_ledger() -> Option<std::sync::Arc<vigil_audit::Ledger>> {
 ///
 /// 单实例:`bind` 失败(同名 socket 已被占用 = 已有 daemon)→ `Err` 退出。成功则**阻塞**于
 /// `serve` accept 循环直到进程被杀(GUI 生命周期 P2.4 负责 spawn/kill)。
-pub fn run_start() -> Result<(), String> {
+pub fn run_start(lang: Lang) -> Result<(), String> {
     let socket = default_socket_name();
-    let listener =
-        bind(&socket).map_err(|e| format!("bind failed (a daemon may already be running): {e}"))?;
+    let listener = bind(&socket).map_err(|e| match lang {
+        Lang::En => format!("bind failed (a daemon may already be running): {e}"),
+        Lang::Zh => format!("绑定 socket 失败(可能已有 daemon 在运行):{e}"),
+    })?;
 
     // ort 暖载层(ADR 0024):**在 serve spawn 任何线程之前**(进程仍单线程)暖载 PII scanner —— 复用
     // serve 的 ort init 纪律(dylib 稳源 + loader-lock 安全超时 abort)。best-effort:模型未缓存 /
@@ -69,8 +80,14 @@ pub fn run_start() -> Result<(), String> {
     let inj_loaded = false;
     let ledger = open_canonical_ledger(); // best-effort:开不了 → 注入信号不落(PII 仍工作)
 
-    let token =
-        generate_token().ok_or_else(|| "failed to generate a token (no entropy)".to_string())?;
+    let token = generate_token().ok_or_else(|| {
+        tr(
+            lang,
+            "failed to generate a token (no entropy)",
+            "生成 token 失败(无可用熵源)",
+        )
+        .to_string()
+    })?;
 
     // daemon.json 的 `pii_loaded` / `inj_loaded` 反映**真实**暖载结果(GUI / `status` 据此显示就绪态)。
     let info = DaemonInfo {
@@ -81,17 +98,35 @@ pub fn run_start() -> Result<(), String> {
         pii_loaded,
         inj_loaded,
     };
-    let path =
-        daemon_info_path().ok_or_else(|| "cannot locate the daemon.json directory".to_string())?;
-    write_daemon_info(&path, &info).map_err(|e| format!("failed to write daemon.json: {e}"))?;
+    let path = daemon_info_path().ok_or_else(|| {
+        tr(
+            lang,
+            "cannot locate the daemon.json directory",
+            "无法定位 daemon.json 所在目录",
+        )
+        .to_string()
+    })?;
+    write_daemon_info(&path, &info).map_err(|e| match lang {
+        Lang::En => format!("failed to write daemon.json: {e}"),
+        Lang::Zh => format!("写入 daemon.json 失败:{e}"),
+    })?;
 
-    eprintln!(
-        "vigil-hub daemon: listening on `{}` (pid {}); PII {}, injection {}",
-        info.socket_path,
-        info.pid,
-        if pii_loaded { "warm" } else { "off" },
-        if inj_loaded { "warm" } else { "off" }
-    );
+    match lang {
+        Lang::En => eprintln!(
+            "vigil-hub daemon: listening on `{}` (pid {}); PII {}, injection {}",
+            info.socket_path,
+            info.pid,
+            if pii_loaded { "warm" } else { "off" },
+            if inj_loaded { "warm" } else { "off" }
+        ),
+        Lang::Zh => eprintln!(
+            "vigil-hub daemon:正在监听 `{}`(pid {});PII {},注入 {}",
+            info.socket_path,
+            info.pid,
+            if pii_loaded { "已暖载" } else { "未加载" },
+            if inj_loaded { "已暖载" } else { "未加载" }
+        ),
+    }
     let caps = DaemonCaps {
         token,
         scanner,
@@ -112,9 +147,16 @@ pub fn run_start() -> Result<(), String> {
 /// `vigil-hub daemon status`:读 daemon.json + 试 `query_daemon(Status)` 报告运行态。
 ///
 /// daemon.json 缺 → 未运行;存在但 query 失败(未响应 / R1 不符 / 超时)→ 陈旧或异常。
-pub fn run_status() -> Result<(), String> {
+pub fn run_status(lang: Lang) -> Result<(), String> {
     let Some(info) = daemon_info_path().and_then(|p| read_daemon_info(&p)) else {
-        println!("daemon: not running (no daemon.json)");
+        println!(
+            "{}",
+            tr(
+                lang,
+                "daemon: not running (no daemon.json)",
+                "daemon:未运行(无 daemon.json)",
+            )
+        );
         return Ok(());
     };
     match query_daemon(Request::Status, Duration::from_secs(2)) {
@@ -123,19 +165,32 @@ pub fn run_status() -> Result<(), String> {
             inj_loaded,
             uptime_secs,
             inflight,
-        }) => {
-            println!(
+        }) => match lang {
+            Lang::En => println!(
                 "daemon: running (pid={}, pii_loaded={}, inj_loaded={}, uptime={}s, inflight={})",
                 info.pid, pii_loaded, inj_loaded, uptime_secs, inflight
-            );
-        }
-        _ => {
-            println!(
-                "daemon: daemon.json present (pid={}) but not responding (stale, or R1 peer-cred \
-                 mismatch — not the recorded daemon)",
+            ),
+            Lang::Zh => println!(
+                "daemon:运行中(pid={};PII 模型 {};注入模型 {};已运行 {}s;处理中 {})",
+                info.pid,
+                if pii_loaded { "已暖载" } else { "未加载" },
+                if inj_loaded { "已暖载" } else { "未加载" },
+                uptime_secs,
+                inflight
+            ),
+        },
+        _ => match lang {
+            Lang::En => println!(
+                "daemon: recorded (pid={}) but not responding -- it may have exited, or this pid \
+                 is now reused by another program (not the original Vigil daemon). Re-run vigil-hub daemon start.",
                 info.pid
-            );
-        }
+            ),
+            Lang::Zh => println!(
+                "daemon:有记录(pid={}),但联系不上 —— 可能已退出,或这个 pid 已被别的程序占用 \
+                 (并非原来的 Vigil 守护进程)。可重新运行 vigil-hub daemon start。",
+                info.pid
+            ),
+        },
     }
     Ok(())
 }
@@ -145,9 +200,16 @@ pub fn run_status() -> Result<(), String> {
 /// **防 pid 重用误杀**:先 `query_daemon(Status)` 经 **R1 peer-cred + token** 确认 daemon.json.pid
 /// 真是活着的、本人的 Vigil daemon,**才** kill;不响应(可能已死、pid 已被无辜进程重用)→ 只清理
 /// 陈旧 daemon.json,**绝不**杀那个 pid。
-pub fn run_stop() -> Result<(), String> {
+pub fn run_stop(lang: Lang) -> Result<(), String> {
     let Some(info) = daemon_info_path().and_then(|p| read_daemon_info(&p)) else {
-        println!("daemon: not running (no daemon.json)");
+        println!(
+            "{}",
+            tr(
+                lang,
+                "daemon: not running (no daemon.json)",
+                "daemon:未运行(无 daemon.json)",
+            )
+        );
         return Ok(());
     };
     let path = daemon_info_path();
@@ -156,23 +218,32 @@ pub fn run_stop() -> Result<(), String> {
         if let Some(p) = &path {
             let _ = std::fs::remove_file(p);
         }
-        println!(
-            "daemon: not responding; cleaned stale daemon.json (did NOT kill pid {} — could be \
-             reused by an unrelated process)",
-            info.pid
-        );
+        match lang {
+            Lang::En => println!(
+                "daemon: not reachable -- likely already exited. Removed the leftover record file; \
+                 did NOT kill pid {} (it may now be reused by an unrelated program).",
+                info.pid
+            ),
+            Lang::Zh => println!(
+                "daemon:联系不上,可能早已退出。已清理残留的记录文件;没有强行结束进程号 {}(它可能已被其它无关程序占用,以免误杀)。",
+                info.pid
+            ),
+        }
         return Ok(());
     }
-    kill_pid(info.pid)?;
+    kill_pid(lang, info.pid)?;
     if let Some(p) = &path {
         let _ = std::fs::remove_file(p); // 强杀不会触发 serve 的自清理,这里补上
     }
-    println!("daemon: stopped (pid {})", info.pid);
+    match lang {
+        Lang::En => println!("daemon: stopped (pid {})", info.pid),
+        Lang::Zh => println!("daemon:已停止(pid {})", info.pid),
+    }
     Ok(())
 }
 
 /// 跨平台按 pid 结束进程(无 `unsafe`:走 OS 工具 `taskkill`/`kill`,不引 libc FFI,守 forbid unsafe)。
-fn kill_pid(pid: u32) -> Result<(), String> {
+fn kill_pid(lang: Lang, pid: u32) -> Result<(), String> {
     let mut cmd = if cfg!(windows) {
         let mut c = std::process::Command::new("taskkill");
         c.args(["/F", "/PID", &pid.to_string()]);
@@ -182,14 +253,21 @@ fn kill_pid(pid: u32) -> Result<(), String> {
         c.arg(pid.to_string());
         c
     };
-    let status = cmd
-        .status()
-        .map_err(|e| format!("failed to spawn the kill helper: {e}"))?;
+    let status = cmd.status().map_err(|e| match lang {
+        Lang::En => format!("failed to spawn the kill helper: {e}"),
+        Lang::Zh => format!("启动结束进程助手失败:{e}"),
+    })?;
     if !status.success() {
-        return Err(format!(
-            "failed to stop daemon pid {pid} (kill helper exit {:?})",
-            status.code()
-        ));
+        return Err(match lang {
+            Lang::En => format!(
+                "failed to stop daemon pid {pid} (kill helper exit {:?})",
+                status.code()
+            ),
+            Lang::Zh => format!(
+                "停止 daemon(pid {pid})失败(结束助手退出码 {:?})",
+                status.code()
+            ),
+        });
     }
     Ok(())
 }

--- a/apps/vigil-hub-cli/src/demo.rs
+++ b/apps/vigil-hub-cli/src/demo.rs
@@ -6,6 +6,8 @@
 //! **诚实第一**:本 demo 走 Vigil **真实运行时代码路径**(firewall DecisionRecord / SecretAliasMap
 //! detokenize seam / 审计 hash-chain),**只模拟**外部 model/tool provider —— 不联系任何 LLM。seeded
 //! secret 在进程内**本地生成**、明确标注,且证明它**从不**越过受保护边界(模型/账本)。
+//!
+//! 屏面文案按系统语言本地化(i18n):静态行用 [`tr`] 中 / 英并排,YES/NO 用 [`yn`]。
 
 #![allow(clippy::uninlined_format_args)]
 
@@ -27,6 +29,8 @@ use vigil_types::{
     ApprovalScope, DecisionKind, DecisionRecord, EffectVector, ServerProfile, TransportKind,
     TrustLevel,
 };
+
+use crate::i18n::Lang;
 
 /// `vigil-hub demo` 参数。
 #[derive(Debug, Clone, Default)]
@@ -124,8 +128,8 @@ fn req(id: i64, args: Value) -> JsonRpcRequest {
 }
 
 /// demo 主入口。
-pub fn run(args: &DemoArgs) -> Result<(), DemoError> {
-    banner();
+pub fn run(args: &DemoArgs, lang: Lang) -> Result<(), DemoError> {
+    banner(lang);
 
     // ── 装配真 Hub(in-memory 账本 + 真 firewall + 真 SecretAliasMap + 真审计)──
     let ledger = Arc::new(Ledger::open_in_memory()?);
@@ -187,27 +191,42 @@ pub fn run(args: &DemoArgs) -> Result<(), DemoError> {
     hub.set_session_id_for_test(&session_id)?;
     hub.inject_route_for_test(SERVER_ID, TOOL_NAME, "demo_descriptor_hash")?;
 
-    teaching_moment(&demo_secret);
+    teaching_moment(lang, &demo_secret);
 
     // ── [1] 默认拒绝:agent 把**裸 secret**塞进工具调用 → 真 firewall 拒,绝不透传 ──
-    section("[1] default-deny: agent puts the RAW secret in the tool call");
+    section(tr(
+        lang,
+        "[1] default-deny: agent puts the RAW secret in the tool call",
+        "[1] 默认拒绝:agent(你接入的 AI 助手)把明文密钥直接塞进工具调用",
+    ));
     let raw_args = json!({ "token": demo_secret });
     let resp_a = hub
         .handle_request(req(1, raw_args))?
         .ok_or_else(|| DemoError::SelfCheck("raw-secret call produced no response".into()))?;
-    print_decision(&resp_a, "github.create_issue", &demo_secret)?;
+    print_decision(lang, &resp_a, "github.create_issue")?;
     if resp_a.error.is_none() {
         return Err(DemoError::SelfCheck(
             "expected raw secret to be DENIED, but it was allowed".into(),
         ));
     }
-    println!("    -> Vigil refuses to forward a raw secret to a tool/upstream.\n");
+    println!(
+        "    -> {}\n",
+        tr(
+            lang,
+            "Vigil refuses to forward a raw secret to a tool/upstream.",
+            "Vigil 拒绝把明文密钥转发给工具 / 上游。",
+        )
+    );
 
     // ── [2] Vigil 之道:agent 改传**占位符** secret://github_pat ──
-    section("[2] the Vigil way: the agent passes a PLACEHOLDER instead");
+    section(tr(
+        lang,
+        "[2] the Vigil way: the agent passes a PLACEHOLDER instead",
+        "[2] Vigil 之道:agent 改传一个占位符",
+    ));
     let alias_args = json!({ "token": "secret://github_pat" });
     // 预批准一次(模拟"你点了 Approve once");走真 scope-allow 路径 → 真 Allow 决策
-    seed_one_time_approval(&ledger, &session_id, &alias_args)?;
+    seed_one_time_approval(lang, &ledger, &session_id, &alias_args)?;
     let resp_b = hub
         .handle_request(req(2, alias_args.clone()))?
         .ok_or_else(|| DemoError::SelfCheck("alias call produced no response".into()))?;
@@ -231,28 +250,59 @@ pub fn run(args: &DemoArgs) -> Result<(), DemoError> {
         .clone()
         .ok_or_else(|| DemoError::SelfCheck("alias call had no result".into()))?;
 
-    println!("    What the REMOTE MODEL saw (args, as sent to the model boundary):");
+    println!(
+        "    {}",
+        tr(
+            lang,
+            "What the REMOTE MODEL saw (the call arguments sent to the model):",
+            "远端模型看到的(也就是发给模型的调用参数):",
+        )
+    );
     println!("      {}", compact(remote_model_payload));
     print_scan(
-        "      plaintext secret?",
+        lang,
+        tr(lang, "      real secret here?", "      含真密钥?"),
         remote_model_payload,
         &demo_secret,
     );
-    println!("      [no LLM is contacted in this demo - this is the exact payload Vigil would forward]\n");
+    println!(
+        "      {}\n",
+        tr(
+            lang,
+            "[no LLM is contacted in this demo - this is the exact payload Vigil would forward]",
+            "[本 demo 不联系任何 LLM —— 这就是 Vigil 会转发的确切载荷]",
+        )
+    );
 
-    println!("    What the LOCAL TOOL received (detokenized, in-memory only):");
+    println!(
+        "    {}",
+        tr(
+            lang,
+            "What the LOCAL TOOL received (placeholder restored to the real value, in memory only):",
+            "本地工具收到的(占位符已还原成真值,只存在于内存里):",
+        )
+    );
     println!("      {}", compact(&local_tool_invocation));
     print_scan(
-        "      contains real value?",
+        lang,
+        tr(lang, "      real secret here?", "      含真密钥?"),
         &local_tool_invocation,
         &demo_secret,
     );
     println!();
 
-    println!("    The tool's result LEAKED a credential; Vigil re-redacted it (Slice 1):");
+    println!(
+        "    {}",
+        tr(
+            lang,
+            "The tool's result LEAKED a credential; Vigil caught it before it reached the model:",
+            "工具的返回结果里夹带了一个凭据;Vigil 在回传给模型前把它挡了下来:",
+        )
+    );
     println!("      {}", compact(&model_visible_result));
     print_scan(
-        "      plaintext secret back to model?",
+        lang,
+        tr(lang, "      real secret here?", "      含真密钥?"),
         &model_visible_result,
         &leaked_secret,
     );
@@ -268,7 +318,11 @@ pub fn run(args: &DemoArgs) -> Result<(), DemoError> {
     )?;
 
     // ── [3] 防篡改审计账本(零明文)──
-    section("[3] tamper-evident audit ledger (no plaintext secrets stored)");
+    section(tr(
+        lang,
+        "[3] tamper-evident audit ledger (no plaintext secrets stored)",
+        "[3] 防篡改审计账本(不存任何明文密钥)",
+    ));
     let events = ledger.replay_session_verified(&session_id)?;
     print_ledger(&events);
     ledger.verify_chain()?;
@@ -276,8 +330,11 @@ pub fn run(args: &DemoArgs) -> Result<(), DemoError> {
         .iter()
         .any(|e| event_contains(e, &demo_secret) || event_contains(e, &leaked_secret));
     println!(
-        "    hash chain valid: YES        plaintext secret in audit: {}",
-        yes_no(!plaintext_in_ledger, /*good_is*/ false)
+        "    {}: {}        {}: {}",
+        tr(lang, "hash chain valid", "哈希链有效"),
+        yn(lang, true),
+        tr(lang, "plaintext secret in audit", "审计中含明文密钥"),
+        yn(lang, plaintext_in_ledger),
     );
     if plaintext_in_ledger {
         return Err(DemoError::SelfCheck(
@@ -288,19 +345,31 @@ pub fn run(args: &DemoArgs) -> Result<(), DemoError> {
 
     // ── [4] 可证伪:篡改账本 → 真 verify 失败 ──
     if args.tamper {
-        section("[4] prove it's real - tamper with the ledger and re-verify");
-        run_tamper_proof()?;
+        section(tr(
+            lang,
+            "[4] prove it's real - tamper with the ledger and re-verify",
+            "[4] 证明它是真的 —— 篡改账本再重新校验",
+        ));
+        run_tamper_proof(lang)?;
         println!();
     } else {
-        println!("    (run `vigil-hub demo --tamper` to alter a ledger row and watch verification FAIL)\n");
+        println!(
+            "    {}\n",
+            tr(
+                lang,
+                "(run `vigil-hub demo --tamper` to alter a ledger row and watch verification FAIL)",
+                "(运行 `vigil-hub demo --tamper` 篡改一条账本行,看校验失败)",
+            )
+        );
     }
 
-    ending_screen();
+    ending_screen(lang);
     Ok(())
 }
 
 /// scope 预批准一次(真 `create_approval` + `approve`,让下一次同 args 调用走真 Allow 路径)。
 fn seed_one_time_approval(
+    lang: Lang,
     ledger: &Ledger,
     session_id: &str,
     call_args: &Value,
@@ -330,12 +399,19 @@ fn seed_one_time_approval(
         ctx,
     )?;
     ledger.approve(&prev.approval_id, ApprovalScope::ThisSession, Some("you"))?;
-    println!("    firewall: needs approval -> [you approve once] -> ALLOW");
+    println!(
+        "    {}",
+        tr(
+            lang,
+            "firewall: needs approval -> [you approve once] -> ALLOW",
+            "防火墙:需要审批 -> [你批准一次] -> ALLOW",
+        )
+    );
     Ok(())
 }
 
 /// tamper 证明:临时文件账本 → 写 2 条事件(verify 通过)→ 直接 SQL 改一行 → verify 失败。
-fn run_tamper_proof() -> Result<(), DemoError> {
+fn run_tamper_proof(lang: Lang) -> Result<(), DemoError> {
     let dir = std::env::temp_dir().join(format!("vigil-demo-tamper-{}", std::process::id()));
     std::fs::create_dir_all(&dir).map_err(|e| DemoError::Tamper(e.to_string()))?;
     let path = dir.join("ledger.sqlite");
@@ -357,7 +433,12 @@ fn run_tamper_proof() -> Result<(), DemoError> {
             Some("another row"),
         )?;
         ledger.verify_chain()?;
-        println!("    wrote 2 audit rows -> hash chain valid: YES");
+        println!(
+            "    {} -> {}: {}",
+            tr(lang, "wrote 2 audit rows", "写入 2 条审计行"),
+            tr(lang, "hash chain valid", "哈希链有效"),
+            yn(lang, true),
+        );
 
         // 直接改一行的 redacted_text(不更新其 event_hash)→ 链断裂
         let conn =
@@ -369,10 +450,13 @@ fn run_tamper_proof() -> Result<(), DemoError> {
             )
             .map_err(|e| DemoError::Tamper(e.to_string()))?;
         drop(conn);
-        println!(
-            "    altered {} ledger row in place (changed its content, not its hash)",
-            n
-        );
+        match lang {
+            Lang::En => println!(
+                "    altered {} ledger row in place (changed its content, not its hash)",
+                n
+            ),
+            Lang::Zh => println!("    就地篡改了 {} 条账本行(改了内容,没改哈希)", n),
+        }
 
         let ledger2 = Ledger::open(&path)?;
         match ledger2.verify_chain() {
@@ -381,7 +465,11 @@ fn run_tamper_proof() -> Result<(), DemoError> {
             )),
             Err(_) => {
                 println!(
-                    "    re-verify after tamper -> hash chain valid: NO  [x]  tamper DETECTED"
+                    "    {} -> {}: {}  [x]  {}",
+                    tr(lang, "re-verify after tamper", "篡改后重新校验"),
+                    tr(lang, "hash chain valid", "哈希链有效"),
+                    yn(lang, false),
+                    tr(lang, "tamper DETECTED", "检测到篡改"),
                 );
                 Ok(())
             }
@@ -417,29 +505,69 @@ fn self_check(
     Ok(())
 }
 
-// ── 打印 helpers ──
-fn banner() {
-    println!();
-    println!("  ============================================================");
-    println!("  VIGIL DEMO - in-memory, planted scenario, NOT guarding real yet");
-    println!("  ============================================================");
-    println!("  Real Vigil runtime code paths (firewall / redaction / audit).");
-    println!("  Only the external model/tool provider is simulated - no LLM is contacted.\n");
+// ── 按语言取文案 / YES-NO ──
+/// 静态文案中 / 英并排(无插值的行用它)。
+fn tr<'a>(lang: Lang, en: &'a str, zh: &'a str) -> &'a str {
+    match lang {
+        Lang::En => en,
+        Lang::Zh => zh,
+    }
 }
 
-fn teaching_moment(secret: &str) {
-    println!(
-        "  A demo secret - freshly generated locally for this run (never leaves this process):"
-    );
-    println!("    github_pat = {}", secret);
-    println!("  Watch: it reaches the tool, but the model & audit never see it.\n");
+/// 是/否展示词(YES/NO ↔ 是/否)。
+fn yn(lang: Lang, yes: bool) -> &'static str {
+    match (lang, yes) {
+        (Lang::En, true) => "YES",
+        (Lang::En, false) => "NO",
+        (Lang::Zh, true) => "是",
+        (Lang::Zh, false) => "否",
+    }
+}
+
+// ── 打印 helpers ──
+fn banner(lang: Lang) {
+    println!();
+    println!("  ============================================================");
+    match lang {
+        Lang::En => {
+            println!("  VIGIL DEMO - in-memory, planted scenario, NOT guarding real yet");
+            println!("  ============================================================");
+            println!("  Real Vigil runtime code paths (firewall / redaction / audit).");
+            println!(
+                "  Only the external model/tool provider is simulated - no LLM is contacted.\n"
+            );
+        }
+        Lang::Zh => {
+            println!("  VIGIL 演示 —— 内存中、预置场景,尚未守护真实流量");
+            println!("  ============================================================");
+            println!("  跑的是 Vigil 真实运行时代码路径(防火墙 / 脱敏 / 审计)。");
+            println!("  只有外部的模型 / 工具被模拟 —— 全程不联系任何 LLM。\n");
+        }
+    }
+}
+
+fn teaching_moment(lang: Lang, secret: &str) {
+    match lang {
+        Lang::En => {
+            println!(
+                "  A demo secret - freshly generated locally for this run (never leaves this process):"
+            );
+            println!("    github_pat = {}", secret);
+            println!("  Watch: it reaches the tool, but the model & audit never see it.\n");
+        }
+        Lang::Zh => {
+            println!("  一个 demo 密钥 —— 本次运行在本地新生成(绝不离开本进程):");
+            println!("    github_pat = {}", secret);
+            println!("  注意:它会抵达工具,但模型与审计始终看不到它。\n");
+        }
+    }
 }
 
 fn section(title: &str) {
     println!("  {}", title);
 }
 
-fn print_decision(resp: &JsonRpcResponse, label: &str, _secret: &str) -> Result<(), DemoError> {
+fn print_decision(lang: Lang, resp: &JsonRpcResponse, label: &str) -> Result<(), DemoError> {
     match &resp.error {
         Some(e) => {
             let decision_id = e
@@ -455,8 +583,9 @@ fn print_decision(resp: &JsonRpcResponse, label: &str, _secret: &str) -> Result<
                 .and_then(Value::as_str)
                 .unwrap_or("-");
             println!(
-                "    tool={}  -> Vigil firewall: DENY  (rule={})  decision_id={}",
+                "    tool={}  -> {}: DENY  (rule={})  decision_id={}",
                 label,
+                tr(lang, "Vigil firewall", "Vigil 防火墙"),
                 rule,
                 short(decision_id)
             );
@@ -466,9 +595,9 @@ fn print_decision(resp: &JsonRpcResponse, label: &str, _secret: &str) -> Result<
     Ok(())
 }
 
-fn print_scan(label: &str, v: &Value, needle: &str) {
+fn print_scan(lang: Lang, label: &str, v: &Value, needle: &str) {
     let present = value_contains(v, needle);
-    println!("    {} {}", label, if present { "YES" } else { "NO" });
+    println!("    {} {}", label, yn(lang, present));
 }
 
 fn print_ledger(events: &[ReplayEvent]) {
@@ -482,29 +611,61 @@ fn print_ledger(events: &[ReplayEvent]) {
     }
 }
 
-fn ending_screen() {
+fn ending_screen(lang: Lang) {
     println!("  ============================================================");
-    println!("  What just happened");
-    println!("  ============================================================");
-    println!("    Remote model saw:     secret://github_pat");
-    println!("    Local tool received:  the real secret, only at the execution boundary");
-    println!("    Tool result returned: re-redacted (no secret back to the model)");
-    println!("    Firewall:             default-deny + explicit approval");
-    println!("    Audit ledger:         hash-chain valid, no plaintext secrets");
-    println!();
-    println!("    The agent did useful work with a real secret - while the model,");
-    println!("    logs, and audit never received the real value.");
-    println!();
-    println!("    Philosophy:  local control plane / no token passthrough / fail-closed");
-    println!("                 / audit everything / you stay in control");
-    println!();
-    println!("    This was a planted scenario with a locally-generated fixture. The redaction,");
-    println!("    firewall, and audit above are Vigil's real runtime code - only the model/tool");
-    println!("    provider was simulated.");
-    println!();
-    println!("    Protect your real agent:");
-    println!("      vigil-hub serve --stdio      # point Claude Code / Codex / Cursor at it");
-    println!();
+    match lang {
+        Lang::En => {
+            println!("  What just happened");
+            println!("  ============================================================");
+            println!("    Remote model saw:     secret://github_pat");
+            println!("    Local tool received:  the real secret, only when the tool actually runs");
+            println!("    Tool result returned: caught before reaching the model (none sent back)");
+            println!("    Firewall:             default-deny + explicit approval");
+            println!("    Audit ledger:         hash-chain valid, no plaintext secrets");
+            println!();
+            println!("    The agent did useful work with a real secret - while the model,");
+            println!("    logs, and audit never received the real value.");
+            println!();
+            println!("    Philosophy:  local control plane / no token passthrough / fail-closed");
+            println!("                 / audit everything / you stay in control");
+            println!();
+            println!(
+                "    This was a planted scenario with a locally-generated fixture. The redaction,"
+            );
+            println!(
+                "    firewall, and audit above are Vigil's real runtime code - only the model/tool"
+            );
+            println!("    provider was simulated.");
+            println!();
+            println!("    Protect your real agent:");
+            println!(
+                "      vigil-hub serve --stdio      # point Claude Code / Codex / Cursor at it"
+            );
+            println!();
+        }
+        Lang::Zh => {
+            println!("  刚刚发生了什么");
+            println!("  ============================================================");
+            println!("    远端模型看到的:     secret://github_pat");
+            println!("    本地工具收到的:     真实密钥,只在工具实际执行时出现");
+            println!("    工具结果返回:       回传前已拦下(没有密钥回流到模型)");
+            println!("    防火墙:             默认拒绝 + 显式审批");
+            println!("    审计账本:           哈希链有效,无任何明文密钥");
+            println!();
+            println!("    agent 用真实密钥完成了有用的工作 —— 而模型、日志、审计");
+            println!("    始终没拿到那个真值。");
+            println!();
+            println!("    理念:  本地控制平面 / 不透传 token / fail-closed");
+            println!("           / 一切皆审计 / 你始终掌控");
+            println!();
+            println!("    这是一个用本地生成的样本演的预置场景。上面的脱敏、防火墙与审计");
+            println!("    都是 Vigil 真实的运行时代码 —— 只有模型 / 工具一侧是模拟的。");
+            println!();
+            println!("    保护你真实的 agent:");
+            println!("      vigil-hub serve --stdio      # 把 Claude Code / Codex / Cursor 指向它");
+            println!();
+        }
+    }
 }
 
 // ── 小工具 ──
@@ -526,14 +687,6 @@ fn event_contains(e: &ReplayEvent, needle: &str) -> bool {
             .map(|t| t.contains(needle))
             .unwrap_or(false)
 }
-/// good_is=false 时,`ok=true`(无明文)显示绿色语义 "NO"。这里只返回展示串。
-fn yes_no(ok: bool, _good_is: bool) -> &'static str {
-    if ok {
-        "NO"
-    } else {
-        "YES"
-    }
-}
 
 #[cfg(test)]
 mod tests {
@@ -543,15 +696,17 @@ mod tests {
     // demo 内置 self_check 在任一不变量被破坏时 fail-closed(SelfCheck error):
     // remote payload 泄漏真值 / local 没拿到真值 / 结果未脱敏 / 账本含明文 → run() 返 Err。
     // 故 run() 返 Ok 即**证明**整条可逆脱敏往返 + no-plaintext 不变量在真代码路径上成立。
+    // 语言无关(两语言走同一逻辑);用 En 跑。
     #[test]
     fn demo_round_trip_and_invariants_hold() {
-        run(&DemoArgs { tamper: false })
+        run(&DemoArgs { tamper: false }, Lang::En)
             .expect("demo round-trip + no-plaintext invariants must hold");
     }
 
     // run(tamper) 仅当账本篡改被 verify_chain **检测到**才返 Ok(否则 SelfCheck error)。
     #[test]
     fn demo_tamper_is_detected() {
-        run(&DemoArgs { tamper: true }).expect("ledger tamper must be detected by verify_chain");
+        run(&DemoArgs { tamper: true }, Lang::Zh)
+            .expect("ledger tamper must be detected by verify_chain");
     }
 }

--- a/apps/vigil-hub-cli/src/i18n/help.rs
+++ b/apps/vigil-hub-cli/src/i18n/help.rs
@@ -1,0 +1,1121 @@
+//! 命令帮助文本本地化:运行时把 clap [`Command`] 树的 about / long_about / arg-help
+//! 改写为目标语言、且**贴切**(以用户收益为先、去内部黑话)的文案。
+//!
+//! # 为什么在运行时改写,而非 derive doc 注释
+//! clap derive 把 `///` doc 注释在**编译期**烘进帮助文本,无法按运行时 locale 切换。
+//! 故源码里的 `///` 仍是面向开发者的中文实现注释(密集、含 ADR / 内部术语),而**用户**
+//! 看到的帮助由本模块在 `parse` 前用 builder API 整体覆盖 —— 实现注释与用户文案彻底分离。
+//!
+//! # 安全契约
+//! 本模块**只**改展示文本([`Command::about`] / [`Command::long_about`] /
+//! [`Arg::help`](clap::Arg::help)),**绝不**改子命令名、flag 名、arg id、value 解析 ——
+//! 那些是 hook / setup / agent 注册依赖的稳定契约。`localize` 末尾的测试用
+//! [`Command::debug_assert`] + 渲染断言守住"改写后命令结构不变、且文案确实生效"。
+//!
+//! # 维护
+//! 每个命令一个 `localize_*` 函数,中 / 英文案经 [`s`] 内联并排,便于对照与同步。
+//! 多行 long_about 用 [`concat!`] 拼接,保持源码可读。
+
+use clap::{Arg, Command};
+
+use super::Lang;
+
+/// 按语言取文案(把中 / 英并排写在调用点)。
+fn s(lang: Lang, en: &'static str, zh: &'static str) -> String {
+    match lang {
+        Lang::En => en.to_string(),
+        Lang::Zh => zh.to_string(),
+    }
+}
+
+/// 给某命令的一个 arg 覆盖 help 文本(arg id = derive 字段名)。
+fn arg_help(cmd: Command, id: &str, lang: Lang, en: &'static str, zh: &'static str) -> Command {
+    cmd.mut_arg(id, |a: Arg| a.help(s(lang, en, zh)))
+}
+
+/// 同 [`arg_help`],但额外隐藏 clap 为 ValueEnum 自动展示的「Possible values」块 —— 那些块取自
+/// enum 变体的开发者 doc 注释(密集、含内部术语、且未本地化,EN 下会泄漏中文,且正是用户嫌"太
+/// 抽象"的文本)。arg help 本身已含简洁取值说明;隐藏只影响 `--help` 展示,**不**影响解析,也**不**
+/// 影响非法值报错(clap 报错仍会列出合法取值)。
+fn arg_help_enum(
+    cmd: Command,
+    id: &str,
+    lang: Lang,
+    en: &'static str,
+    zh: &'static str,
+) -> Command {
+    cmd.mut_arg(id, |a: Arg| {
+        a.help(s(lang, en, zh)).hide_possible_values(true)
+    })
+}
+
+/// 本地化整棵 `vigil-hub` 命令树(root + 子命令 + 嵌套子命令 + 各 arg)。
+/// 在 `Cli::parse` 前对 `Cli::command()` 调用一次。
+pub fn localize(cmd: Command, lang: Lang) -> Command {
+    let cmd = cmd
+        .about(s(
+            lang,
+            "A local security gateway that keeps secrets & private data out of your AI agents",
+            "把密钥与隐私数据挡在 AI agent 之外的本地安全网关",
+        ))
+        .long_about(s(
+            lang,
+            concat!(
+                "Vigil sits between your AI coding agents (Claude Code, Codex, Cursor, ...) and the\n",
+                "tools and servers they call. It blocks raw secrets, redacts private data before it\n",
+                "can reach a model, and records everything in a tamper-evident local audit trail --\n",
+                "all on your machine, nothing leaves it.\n",
+                "\n",
+                "First time here? Run `vigil-hub quickstart` for a read-only tour of this machine,\n",
+                "or `vigil-hub demo` to watch Vigil catch a leaking secret in about 30 seconds.",
+            ),
+            concat!(
+                "Vigil 位于你的 AI 编码 agent(Claude Code、Codex、Cursor 等)与它们调用的工具 /\n",
+                "服务器之间:拦下明文密钥,在数据抵达模型前脱敏隐私信息,并把一切记入防篡改的\n",
+                "本地审计链 —— 全程在本机,数据不外泄。\n",
+                "\n",
+                "第一次用?运行 `vigil-hub quickstart` 对本机做一次只读巡检,或 `vigil-hub demo`\n",
+                "约 30 秒看 Vigil 当场拦下一次密钥外泄。",
+            ),
+        ));
+
+    cmd.mut_subcommand("add-remote-mcp", |c| localize_add_remote(c, lang))
+        .mut_subcommand("serve", |c| localize_serve(c, lang))
+        .mut_subcommand("demo", |c| localize_demo(c, lang))
+        .mut_subcommand("hook", |c| localize_hook(c, lang))
+        .mut_subcommand("setup", |c| localize_setup(c, lang))
+        .mut_subcommand("wrap", |c| localize_wrap(c, lang))
+        .mut_subcommand("checkpoint", |c| localize_checkpoint(c, lang))
+        .mut_subcommand("verify", |c| localize_verify(c, lang))
+        .mut_subcommand("quickstart", |c| localize_quickstart(c, lang))
+        .mut_subcommand("posture", |c| localize_posture(c, lang))
+        .mut_subcommand("engine", |c| localize_engine(c, lang))
+        .mut_subcommand("daemon", |c| localize_daemon(c, lang))
+        .mut_subcommand("model", |c| localize_model(c, lang))
+        .mut_subcommand("inspect", |c| localize_inspect(c, lang))
+}
+
+/// `inspect`(只读审计查看;公开仓独有命令)。仅本地化顶层 about / long_about —— 子命令
+/// (activity / search / approvals / verify-chain / protection 等)与其参数的深度本地化为
+/// 后续增量(inspect 是 advanced 审计面,非首跑 onboarding 路径)。
+fn localize_inspect(c: Command, lang: Lang) -> Command {
+    c.about(s(
+        lang,
+        "Read-only view of what Vigil caught -- aggregated from the persisted audit ledger",
+        "只读查看 Vigil 拦了什么 —— 基于已持久化的审计账本聚合",
+    ))
+    .long_about(s(
+        lang,
+        concat!(
+            "Read-only inspection of the persisted audit ledger -- \"see your protection\"\n",
+            "after an agent has run:\n",
+            "  protection    summary: raw secrets blocked / leaks re-redacted / chain health\n",
+            "  activity      recent event stream\n",
+            "  search        full-text search over events\n",
+            "  approvals     the approval queue\n",
+            "  verify-chain  validate the audit hash chain\n",
+            "\n",
+            "Reads the same shared ledger as `vigil-hub setup` / `hook` (override with --db-path).",
+        ),
+        concat!(
+            "对已持久化审计账本的只读查看 —— 用过 agent 后\"看见保护\":\n",
+            "  protection    汇总:拦了多少裸 secret / 脱敏了多少泄漏 / 哈希链是否完整\n",
+            "  activity      最近事件流\n",
+            "  search        事件全文检索\n",
+            "  approvals     审批队列\n",
+            "  verify-chain  校验审计哈希链\n",
+            "\n",
+            "读取与 `vigil-hub setup` / `hook` 同一个共享账本(可用 --db-path 覆盖)。",
+        ),
+    ))
+}
+
+fn localize_add_remote(c: Command, lang: Lang) -> Command {
+    let c = c
+        .about(s(
+            lang,
+            "Connect a remote (HTTP) MCP server and sign in with OAuth in your browser",
+            "接入一个远程(HTTP)MCP 服务器,并在浏览器里用 OAuth 完成登录授权",
+        ))
+        .long_about(s(
+            lang,
+            concat!(
+                "Registers a remote MCP server and runs the OAuth sign-in for you: Vigil opens your\n",
+                "browser, catches the redirect on a loopback port, and stores the token securely in\n",
+                "the OS keychain -- so your agent can use the server without you pasting any keys.\n",
+                "\n",
+                "Example:\n",
+                "  vigil-hub add-remote-mcp --url https://mcp.example.com/ \\\n",
+                "    --client-id my-app --scopes mcp:tools.read,mcp:tools.write",
+            ),
+            concat!(
+                "注册一个远程 MCP 服务器,并替你完成 OAuth 登录:Vigil 打开你的浏览器,在 loopback\n",
+                "端口接住回调,并把 token 安全存入操作系统钥匙串 —— 这样 agent 就能用上该服务器,\n",
+                "你无需手动粘贴任何密钥。\n",
+                "\n",
+                "示例:\n",
+                "  vigil-hub add-remote-mcp --url https://mcp.example.com/ \\\n",
+                "    --client-id my-app --scopes mcp:tools.read,mcp:tools.write",
+            ),
+        ));
+    let c = arg_help(
+        c,
+        "url",
+        lang,
+        "Base URL of the remote MCP server, e.g. https://mcp.example.com/",
+        "远程 MCP 服务器的 base URL,例如 https://mcp.example.com/",
+    );
+    let c = arg_help(
+        c,
+        "client_id",
+        lang,
+        "OAuth client id (a public client -- no secret)",
+        "OAuth client_id(公共 client,无 secret)",
+    );
+    let c = arg_help(
+        c,
+        "scopes",
+        lang,
+        "Comma-separated scopes to request, e.g. mcp:tools.read,mcp:tools.write",
+        "请求的 scope 列表,逗号分隔,例如 mcp:tools.read,mcp:tools.write",
+    );
+    let c = arg_help(
+        c,
+        "ledger",
+        lang,
+        "Where to store the audit ledger (default: ./vigil.db)",
+        "审计账本(SQLite)存放路径(默认 ./vigil.db)",
+    );
+    arg_help(
+        c,
+        "timeout_secs",
+        lang,
+        "Seconds to wait for the browser sign-in to complete (default: 60)",
+        "等待浏览器登录回调的超时秒数(默认 60)",
+    )
+}
+
+fn localize_serve(c: Command, lang: Lang) -> Command {
+    let c = c
+        .about(s(
+            lang,
+            "Run Vigil as a local MCP server your agent connects to (Claude Code, Codex, Cursor...)",
+            "把 Vigil 作为本地 MCP 服务器运行,供 agent 连接(Claude Code、Codex、Cursor 等)",
+        ))
+        .long_about(s(
+            lang,
+            concat!(
+                "Exposes Vigil as an MCP server over stdio. Point your agent's MCP config at it and\n",
+                "every tool call flows through Vigil's firewall, redaction, approval and audit.\n",
+                "\n",
+                "Example entry in your agent's MCP config:\n",
+                "  {\"vigil\": {\"command\": \"vigil-hub\",\n",
+                "             \"args\": [\"serve\", \"--stdio\", \"--ledger\", \"C:\\\\Vigil\\\\ledger.sqlite\"]}}",
+            ),
+            concat!(
+                "把 Vigil 作为 MCP 服务器经 stdio 暴露出来。把你的 agent 的 MCP 配置指向它,之后\n",
+                "每一次工具调用都会先经过 Vigil 的防火墙、脱敏、审批、审计这几道处理。\n",
+                "\n",
+                "在 agent 的 MCP 配置里的示例条目:\n",
+                "  {\"vigil\": {\"command\": \"vigil-hub\",\n",
+                "             \"args\": [\"serve\", \"--stdio\", \"--ledger\", \"C:\\\\Vigil\\\\ledger.sqlite\"]}}",
+            ),
+        ));
+    let c = arg_help(
+        c,
+        "stdio",
+        lang,
+        "Use the stdio transport (required -- the only transport for now)",
+        "使用 stdio 通道(必需 —— 目前唯一支持的通道)",
+    );
+    let c = arg_help(
+        c,
+        "ledger",
+        lang,
+        "Persist the audit trail to this SQLite file (omit = in-memory, smoke-test only)",
+        "把审计链持久化到该 SQLite 文件(省略 = 内存账本,仅供冒烟测试)",
+    );
+    let c = arg_help(
+        c,
+        "upstream_config",
+        lang,
+        "JSON file describing the upstream MCP servers to attach",
+        "描述要挂载的上游 MCP 服务器的 JSON 配置文件",
+    );
+    let c = arg_help(
+        c,
+        "auto_approve_first_seen",
+        lang,
+        "Dev only: auto-approve the first descriptor seen (never use in production)",
+        "仅开发:自动批准首次出现的工具描述符(descriptor)(生产务必关闭)",
+    );
+    let c = arg_help(
+        c,
+        "dev_permissive_firewall",
+        lang,
+        "Dev only: let unmatched compute-only tools through instead of default-deny (never in production)",
+        "仅开发:对未命中规则的纯计算类工具予以放行,而非默认拒绝(生产务必关闭)",
+    );
+    let c = arg_help(
+        c,
+        "enable_privacy_filter",
+        lang,
+        "Turn on the ML private-data filter (needs an ML build + an installed model)",
+        "开启 ML 隐私数据过滤器(需 ML 构建变体 + 已安装模型)",
+    );
+    let c = arg_help(
+        c,
+        "redact_tool_results",
+        lang,
+        "Redact secrets found in a tool's response before returning it to the model",
+        "把工具响应里命中的密钥脱敏后,再返回给模型",
+    );
+    let c = arg_help(
+        c,
+        "project_root",
+        lang,
+        "Project boundary root(s) for file-access rules (repeatable; default: current directory)",
+        "项目根目录,作为文件访问规则的边界(可多次指定;默认当前目录)",
+    );
+    let c = arg_help(
+        c,
+        "enable_injection_classifier",
+        lang,
+        "Turn on the ML prompt-injection detector (needs an ML build; it flags risk, never blocks)",
+        "开启 ML 提示注入检测器(需 ML 构建;只标记风险,绝不拦截)",
+    );
+    arg_help_enum(
+        c,
+        "engine",
+        lang,
+        "Detection engine: hardfp (rules only) | ml (require ML) | auto (ML if ready, else rules)",
+        "检测引擎:hardfp(仅硬规则)| ml(强制 ML)| auto(就绪则用 ML,否则降级规则)",
+    )
+}
+
+fn localize_demo(c: Command, lang: Lang) -> Command {
+    let c = c
+        .about(s(
+            lang,
+            "See Vigil block a leaking secret in ~30s -- no account, no network, nothing to set up",
+            "约 30 秒看 Vigil 当场拦下一次密钥外泄 —— 无需账号、不联网、零配置",
+        ))
+        .long_about(s(
+            lang,
+            concat!(
+                "A guided, self-contained walkthrough. It runs Vigil's real firewall, redaction and\n",
+                "audit code against a planted scenario, simulating only the model/tool on the other\n",
+                "end -- no LLM is ever contacted and no real credentials are used.\n",
+                "\n",
+                "Add --tamper to also alter an audit row and watch verification FAIL (proof it's real).",
+            ),
+            concat!(
+                "一段有引导、自包含的演示。它对一个预置场景跑 Vigil 真实的防火墙、脱敏与审计代码,\n",
+                "只模拟另一端的模型 / 工具 —— 全程不联系任何 LLM,也不使用任何真实凭据。\n",
+                "\n",
+                "加 --tamper 还会篡改一条账本行,让你看到校验失败(证明它是真的、可证伪)。",
+            ),
+        ));
+    arg_help(
+        c,
+        "tamper",
+        lang,
+        "Also alter one audit row and re-verify, proving tampering is detected",
+        "额外篡改一条账本行并重新校验,证明篡改会被检测到(可证伪)",
+    )
+}
+
+fn localize_hook(c: Command, lang: Lang) -> Command {
+    let c = c
+        .about(s(
+            lang,
+            "Guard an agent's tool calls (PreToolUse): block any that carry a raw secret",
+            "守护 agent 的工具调用(PreToolUse):拦下任何夹带明文密钥的调用",
+        ))
+        .long_about(s(
+            lang,
+            concat!(
+                "A PreToolUse hook for agent CLIs. It reads one tool-call event from stdin and, if the\n",
+                "call carries a raw secret, blocks it (fail-closed) and records it; clean calls pass\n",
+                "through with near-zero overhead.\n",
+                "\n",
+                "Usually registered for you by `vigil-hub setup`. Supports Claude Code (the default)\n",
+                "and Codex / Gemini / Cursor via --cli.",
+            ),
+            concat!(
+                "agent CLI 的 PreToolUse 钩子(hook):在每次工具调用前触发。它从 stdin 读取该次调用,\n",
+                "若其中夹带明文密钥,就 fail-closed 拦下并记录;干净的调用以近乎零开销放行。\n",
+                "\n",
+                "通常由 `vigil-hub setup` 替你注册。支持 Claude Code(默认),以及经 --cli 指定的\n",
+                "Codex / Gemini / Cursor。",
+            ),
+        ));
+    let c = arg_help(
+        c,
+        "ledger",
+        lang,
+        "Audit ledger path (same file as serve, to keep one continuous trail; omit = no audit)",
+        "审计账本路径(与 serve 同一文件以保持审计链连续;省略 = 不审计)",
+    );
+    let c = arg_help_enum(
+        c,
+        "cli",
+        lang,
+        "Which agent CLI sent the event (shapes the deny output): claude (default) | codex | gemini | cursor",
+        "事件来自哪个 agent CLI(决定 deny 输出形状):claude(默认)| codex | gemini | cursor",
+    );
+    let c = arg_help(
+        c,
+        "inject",
+        lang,
+        "Resolve `secret://<alias>` placeholders to real values at the execution boundary (Claude only)",
+        "在执行边界把 `secret://<alias>` 占位符解析为真值(仅 Claude 支持)",
+    );
+    let c = arg_help(
+        c,
+        "secrets",
+        lang,
+        "JSON map of alias -> secret reference for --inject (contains no real values)",
+        "--inject 用的 alias→secret 引用映射(JSON;不含任何真值)",
+    );
+    let c = arg_help(
+        c,
+        "inject_ttl_secs",
+        lang,
+        "TTL (seconds) for the one-shot injection lease (default: 300)",
+        "一次性注入租约的 TTL 秒数(默认 300)",
+    );
+    arg_help(
+        c,
+        "redact_results",
+        lang,
+        "Redact hard-fingerprint secrets in a tool's result before the model sees it (Claude only)",
+        "在模型看到前,把工具结果里能识别出的密钥脱敏(仅 Claude 生效)",
+    )
+}
+
+fn localize_setup(c: Command, lang: Lang) -> Command {
+    let c = c
+        .about(s(
+            lang,
+            "Turn on protection: wire Vigil into your installed AI agents (download -> run -> protected)",
+            "一键开启防护:把 Vigil 接入你已装的 AI agent(下载 → 运行一次 → 直接受保护)",
+        ))
+        .long_about(s(
+            lang,
+            concat!(
+                "Wires Vigil into the AI agents already on this machine, so protection is on without\n",
+                "hand-editing any config files.\n",
+                "\n",
+                "  vigil-hub setup              register the native-tool secret guard (Claude Code)\n",
+                "  vigil-hub setup --all        also put your MCP servers behind the Vigil gateway\n",
+                "  vigil-hub setup --mcp        preview the MCP changes first (writes nothing)\n",
+                "  vigil-hub setup --status     report what's protected + run a self-test\n",
+                "  vigil-hub setup --uninstall  cleanly remove everything Vigil added",
+            ),
+            concat!(
+                "把 Vigil 接入本机已安装的 AI agent,无需手改任何配置文件即可开启防护。\n",
+                "\n",
+                "  vigil-hub setup              注册原生工具的密钥守卫(Claude Code)\n",
+                "  vigil-hub setup --all        再把你的 MCP 服务器也纳入 Vigil 网关防护\n",
+                "  vigil-hub setup --mcp        先预览 MCP 改动(不写任何文件)\n",
+                "  vigil-hub setup --status     报告哪些已受保护 + 跑一次自检\n",
+                "  vigil-hub setup --uninstall  干净移除 Vigil 添加的一切",
+            ),
+        ));
+    let c = arg_help(
+        c,
+        "uninstall",
+        lang,
+        "Remove the protection Vigil added (only Vigil's own entries)",
+        "移除 Vigil 添加的防护(仅 Vigil 自己的条目,不动你其它配置)",
+    );
+    let c = arg_help(
+        c,
+        "status",
+        lang,
+        "Report current protection + run a self-test (a fake credential is blocked)",
+        "报告当前防护状态,并跑一次自检(用一个假凭据验证它确实被拦)",
+    );
+    let c = arg_help(
+        c,
+        "dry_run",
+        lang,
+        "Show the changes without writing anything",
+        "只展示将做的改动,不写盘",
+    );
+    let c = arg_help(
+        c,
+        "ledger",
+        lang,
+        "Override the audit ledger path",
+        "覆盖审计账本路径",
+    );
+    let c = arg_help(
+        c,
+        "mcp",
+        lang,
+        "Act on MCP servers: put them behind the Vigil gateway (preview unless --apply)",
+        "作用于 MCP 服务器:把它们纳入 Vigil 网关防护(默认预览,除非加 --apply)",
+    );
+    let c = arg_help(
+        c,
+        "apply",
+        lang,
+        "With --mcp: actually write the changes (atomic, backed up, reversible)",
+        "配合 --mcp:真正写入改动(原子写 + 备份 + 可逆)",
+    );
+    let c = arg_help(
+        c,
+        "user_scope_only",
+        lang,
+        "With --mcp --apply: protect only user-scope servers, skip per-project ones",
+        "配合 --mcp --apply:只保护用户级(user)服务器,跳过各项目本地(local)的服务器",
+    );
+    let c = arg_help(
+        c,
+        "enforce",
+        lang,
+        "With --mcp: hard-block (default-deny) instead of the default monitor posture",
+        "配合 --mcp:改用严格模式(默认拒绝放行),取代默认的观察模式(monitor)",
+    );
+    let c = arg_help(
+        c,
+        "doctor",
+        lang,
+        "With --mcp: health-check that each server's program can actually launch",
+        "配合 --mcp:逐个检查每个 server 的底层程序是否确实能启动",
+    );
+    let c = arg_help(
+        c,
+        "probe",
+        lang,
+        "With --doctor: also start each server briefly to test a real MCP handshake (has side effects)",
+        "配合 --doctor:再短暂启动每个 server 测真 MCP 握手(有副作用)",
+    );
+    arg_help(
+        c,
+        "all",
+        lang,
+        "Protect everything in one shot: the native-tool hook + the MCP gateway",
+        "一条命令全保护:原生工具 hook + MCP 网关一次完成",
+    )
+}
+
+fn localize_wrap(c: Command, lang: Lang) -> Command {
+    let c = c
+        .about(s(
+            lang,
+            "Put an existing MCP server behind Vigil, transparently (redaction + approval + audit)",
+            "把一个现有 MCP 服务器透明地纳入 Vigil 防护(脱敏 + 审批 + 审计)",
+        ))
+        .long_about(s(
+            lang,
+            concat!(
+                "A transparent stdio shim. Your agent connects to `vigil-hub wrap` exactly as if it\n",
+                "were the original server, while Vigil guards every call in between.\n",
+                "\n",
+                "Example (in your agent's MCP config, set command=vigil-hub and prefix the args):\n",
+                "  vigil-hub wrap -- npx -y @modelcontextprotocol/server-filesystem /data\n",
+                "\n",
+                "Usually set up for you by `vigil-hub setup --mcp`.",
+            ),
+            concat!(
+                "一个透明的 stdio 垫片。你的 agent 连到 `vigil-hub wrap`,就像直连原始服务器一样,\n",
+                "而中间的每一次调用都被 Vigil 守护。\n",
+                "\n",
+                "示例(在 agent 的 MCP 配置里把 command 改为 vigil-hub,并给原命令加前缀):\n",
+                "  vigil-hub wrap -- npx -y @modelcontextprotocol/server-filesystem /data\n",
+                "\n",
+                "通常由 `vigil-hub setup --mcp` 替你配置好。",
+            ),
+        ));
+    let c = arg_help(
+        c,
+        "ledger",
+        lang,
+        "Audit ledger path (default: <data dir>/Vigil/ledger.sqlite3)",
+        "审计账本路径(默认 <本机数据目录>/Vigil/ledger.sqlite3)",
+    );
+    let c = arg_help(
+        c,
+        "server_id",
+        lang,
+        "Stable identity for the wrapped server (= its name in the agent config)",
+        "被防护 server 的稳定身份 id(= agent 配置里的 server 名)",
+    );
+    let c = arg_help(
+        c,
+        "env_key",
+        lang,
+        "Env var name to forward to the server (repeatable; nothing is forwarded by default)",
+        "要转发给 server 的环境变量名(可重复;默认不转发任何变量)",
+    );
+    let c = arg_help(
+        c,
+        "inherit_env",
+        lang,
+        "Forward ALL of this process's environment to the server (only when it truly needs it)",
+        "把本进程的全部环境变量转发给 server(仅在确需全量继承时使用)",
+    );
+    let c = arg_help(
+        c,
+        "monitor",
+        lang,
+        "Monitor posture: allow + audit risky calls instead of blocking (recommended for turnkey)",
+        "观察模式(monitor):风险调用放行 + 记入审计而不阻断(开箱即用接入时推荐)",
+    );
+    let c = arg_help(
+        c,
+        "project_root",
+        lang,
+        "Project boundary root(s) for file-access rules (repeatable; default: current directory)",
+        "项目根目录,作为文件访问规则的边界(可多次指定;默认当前目录)",
+    );
+    arg_help(
+        c,
+        "command",
+        lang,
+        "The MCP server command to wrap, after `--` (e.g. -- npx -y <pkg> /data)",
+        "要加 Vigil 防护的 MCP server 命令,放在 `--` 之后(例:-- npx -y <pkg> /data)",
+    )
+}
+
+fn localize_checkpoint(c: Command, lang: Lang) -> Command {
+    let c = c
+        .about(s(
+            lang,
+            "Anchor the audit trail so a full-history rewrite can't go unnoticed",
+            "为审计链打锚点,让有人整体改写历史也无所遁形",
+        ))
+        .long_about(s(
+            lang,
+            concat!(
+                "Writes a snapshot of the current audit-chain head into a separate append-only file\n",
+                "(<ledger>.checkpoints). Run it periodically (or from cron): the hash chain alone\n",
+                "can't detect a rewrite of the whole history, but these anchors can.\n",
+                "\n",
+                "Tip: keep the .checkpoints file append-only (chattr +a) or synced offsite.",
+            ),
+            concat!(
+                "把当前审计链链头的快照写入一个独立的 append-only 文件(<ledger>.checkpoints)。\n",
+                "周期运行(或用 cron):仅靠哈希链检不出「整条历史被重写」,但这些锚点可以。\n",
+                "\n",
+                "提示:把 .checkpoints 文件设为 append-only(chattr +a)或异地同步。",
+            ),
+        ));
+    arg_help(
+        c,
+        "ledger",
+        lang,
+        "Audit ledger path (default: <data dir>/Vigil/ledger.sqlite3)",
+        "审计账本路径(默认 <本机数据目录>/Vigil/ledger.sqlite3)",
+    )
+}
+
+fn localize_verify(c: Command, lang: Lang) -> Command {
+    let c = c
+        .about(s(
+            lang,
+            "Check the audit trail for tampering and confirm it matches its anchors",
+            "校验审计链是否被篡改,并比对锚点确认一致",
+        ))
+        .long_about(s(
+            lang,
+            concat!(
+                "Two checks, reported honestly: first the chain's internal consistency (catches an\n",
+                "edited row), then the checkpoint anchors (catches a full-history rewrite). Any\n",
+                "tampering or corruption exits non-zero, so you can script it. It never creates a\n",
+                "ledger -- a missing file is reported, not silently made.",
+            ),
+            concat!(
+                "两道检查、如实汇报:先查链内部一致性(抓「某行被改」),再比对锚点(抓「整条历史\n",
+                "被重写」)。任何篡改 / 损坏都以非零码退出,便于脚本化。它绝不创建账本 —— 文件\n",
+                "缺失会如实报告,而非悄悄造一个空账本。",
+            ),
+        ));
+    arg_help(
+        c,
+        "ledger",
+        lang,
+        "Audit ledger path (default: <data dir>/Vigil/ledger.sqlite3)",
+        "审计账本路径(默认 <本机数据目录>/Vigil/ledger.sqlite3)",
+    )
+}
+
+fn localize_quickstart(c: Command, lang: Lang) -> Command {
+    c.about(s(
+        lang,
+        "New here? See what's protected on this machine and the 3 steps to lock it down (read-only)",
+        "第一次用?看看本机哪些已受保护,以及锁紧防护的三步(只读,不改配置)",
+    ))
+    .long_about(s(
+        lang,
+        concat!(
+            "A read-only tour for first-timers. It detects the AI agents and MCP servers on this\n",
+            "machine, shows how many are already behind Vigil, and lays out the next steps: see the\n",
+            "demo -> protect everything -> verify. It changes nothing.",
+        ),
+        concat!(
+            "面向新手的只读巡检。它检测本机的 AI agent 与 MCP 服务器,告诉你有多少已经在 Vigil\n",
+            "之后,并给出接下来的三步:看 demo → 一键全保护 → 验证。全程不改动任何东西。",
+        ),
+    ))
+}
+
+fn localize_posture(c: Command, lang: Lang) -> Command {
+    let c = c
+        .about(s(
+            lang,
+            "View or switch the security posture (low / medium / high)",
+            "查看或切换安全姿态(低 / 中 / 高)—— 即对 `secret://` 占位符的拦截力度",
+        ))
+        .long_about(s(
+            lang,
+            concat!(
+                "Controls how strictly Vigil handles `secret://` placeholders in native tools:\n",
+                "  low     let them through (default -- zero friction)\n",
+                "  medium  ask you to confirm\n",
+                "  high    block them\n",
+                "Raw secrets are ALWAYS blocked at every level -- that hard floor can't be lowered.\n",
+                "\n",
+                "  vigil-hub posture show\n",
+                "  vigil-hub posture set medium",
+            ),
+            concat!(
+                "控制 Vigil 对原生工具里 `secret://` 占位符的处置力度:\n",
+                "  low     放行(默认 —— 零摩擦)\n",
+                "  medium  交你确认\n",
+                "  high    拦截\n",
+                "明文密钥在**任何**档位都恒被拦 —— 这条硬底线不可降级。\n",
+                "\n",
+                "  vigil-hub posture show\n",
+                "  vigil-hub posture set medium",
+            ),
+        ));
+    let c = c.mut_subcommand("show", |sc| {
+        sc.about(s(lang, "Show the current posture", "显示当前姿态档位"))
+    });
+    c.mut_subcommand("set", |sc| {
+        let sc = sc.about(s(
+            lang,
+            "Switch to a posture (low / medium / high)",
+            "切换到指定姿态档位(低 / 中 / 高)",
+        ));
+        let sc = arg_help_enum(
+            sc,
+            "profile",
+            lang,
+            "Target posture: low | medium | high",
+            "目标档位:low | medium | high",
+        );
+        arg_help(
+            sc,
+            "ledger",
+            lang,
+            "Audit ledger to record the change (default: the shared Vigil ledger)",
+            "记录本次变更的审计账本(默认共享的 Vigil 账本)",
+        )
+    })
+}
+
+fn localize_engine(c: Command, lang: Lang) -> Command {
+    let c = c
+        .about(s(
+            lang,
+            "View or switch the detection engine (hardfp / ml / auto)",
+            "查看或切换检测引擎(hardfp / ml / auto)",
+        ))
+        .long_about(s(
+            lang,
+            concat!(
+                "Selects which detector Vigil uses and persists it for serve / wrap / hook to pick up:\n",
+                "  hardfp  fixed-fingerprint rules only (default; what shipped binaries do)\n",
+                "  ml      require the ML models (refuses to start if they're missing)\n",
+                "  auto    use ML when it's ready, else fall back to rules (never downloads)\n",
+                "Actually running ML also needs an ML build (--features ort) + installed models.\n",
+                "\n",
+                "  vigil-hub engine show\n",
+                "  vigil-hub engine set ml",
+            ),
+            concat!(
+                "选择 Vigil 使用哪种检测器并保存,供 serve / wrap / hook 启动时读取生效:\n",
+                "  hardfp  仅固定指纹规则(默认;发行二进制的实际行为)\n",
+                "  ml      强制使用 ML 模型(缺失则拒绝启动)\n",
+                "  auto    就绪时用 ML,否则降级到规则(绝不触发下载)\n",
+                "真正跑 ML 还需 ML 构建变体(--features ort)+ 已安装模型。\n",
+                "\n",
+                "  vigil-hub engine show\n",
+                "  vigil-hub engine set ml",
+            ),
+        ));
+    let c = c.mut_subcommand("show", |sc| {
+        sc.about(s(lang, "Show the current engine mode", "显示当前引擎模式"))
+    });
+    c.mut_subcommand("set", |sc| {
+        let sc = sc.about(s(
+            lang,
+            "Switch the engine mode (hardfp / ml / auto)",
+            "切换引擎模式(hardfp / ml / auto)",
+        ));
+        arg_help_enum(
+            sc,
+            "mode",
+            lang,
+            "Target mode: hardfp | ml | auto",
+            "目标模式:hardfp | ml | auto",
+        )
+    })
+}
+
+fn localize_daemon(c: Command, lang: Lang) -> Command {
+    let c = c
+        .about(s(
+            lang,
+            "Start or check the background service that keeps ML models warm for fast checks",
+            "启动或查看后台常驻服务 —— 暖载 ML 模型,让检查保持低延迟",
+        ))
+        .long_about(s(
+            lang,
+            concat!(
+                "Runs a small resident service that pre-loads the ML models so the hook can query\n",
+                "them with low latency over a local socket.\n",
+                "  start   run it in the foreground (single instance -- exits if already running)\n",
+                "  status  check whether it's running\n",
+                "  stop    stop it\n",
+                "With an ML build + cached models it warms a real scanner; otherwise it runs\n",
+                "model-less (the hook falls back to fixed-fingerprint rules).",
+            ),
+            concat!(
+                "运行一个小型常驻服务,预先载入 ML 模型,让 hook 可经本地 socket 低延迟查询。\n",
+                "  start   前台运行(单实例 —— 已在运行则退出)\n",
+                "  status  查看是否在运行\n",
+                "  stop    停止它\n",
+                "在 ML 构建 + 模型已缓存时暖载真实扫描器;否则以无模型方式运行\n",
+                "(hook 退回固定指纹规则)。",
+            ),
+        ));
+    let c = c.mut_subcommand("start", |sc| {
+        sc.about(s(
+            lang,
+            "Run the daemon in the foreground (single instance)",
+            "前台启动 daemon(单实例)",
+        ))
+    });
+    let c = c.mut_subcommand("status", |sc| {
+        sc.about(s(
+            lang,
+            "Check whether the daemon is running",
+            "查看 daemon 是否在运行",
+        ))
+    });
+    c.mut_subcommand("stop", |sc| {
+        sc.about(s(lang, "Stop the running daemon", "停止正在运行的 daemon"))
+    })
+}
+
+fn localize_model(c: Command, lang: Lang) -> Command {
+    let c = c
+        .about(s(
+            lang,
+            "Download or check the ML models (private-data + injection detectors, ~700MB each)",
+            "下载或查看 ML 模型(隐私数据 + 注入检测器,各约 700MB)",
+        ))
+        .long_about(s(
+            lang,
+            concat!(
+                "Manages the optional ML models. The turnkey path is:\n",
+                "  vigil-hub model install  ->  vigil-hub daemon start  ->  vigil-hub engine set ml\n",
+                "\n",
+                "  install  download the models (--privacy / --injection to pick one; default both)\n",
+                "  status   show whether each model is cached locally\n",
+                "Needs an ML build (--features ort); a non-ML binary points you to the ML variant.",
+            ),
+            concat!(
+                "管理可选的 ML 模型。开箱即用的完整流程为:\n",
+                "  vigil-hub model install  →  vigil-hub daemon start  →  vigil-hub engine set ml\n",
+                "\n",
+                "  install  下载模型(--privacy / --injection 只装其一;默认两个都装)\n",
+                "  status   查看每个模型是否已在本地缓存\n",
+                "需 ML 构建变体(--features ort);非 ML 二进制会提示你改用 ML 变体。",
+            ),
+        ));
+    let c = c.mut_subcommand("install", |sc| {
+        let sc = sc.about(s(
+            lang,
+            "Download the ML models (idempotent -- cached models return instantly)",
+            "下载 ML 模型(幂等:已缓存则秒回)",
+        ));
+        let sc = arg_help(
+            sc,
+            "privacy",
+            lang,
+            "Install only the private-data (PII) model",
+            "只安装隐私数据(PII)模型",
+        );
+        arg_help(
+            sc,
+            "injection",
+            lang,
+            "Install only the prompt-injection model",
+            "只安装提示注入模型",
+        )
+    });
+    c.mut_subcommand("status", |sc| {
+        sc.about(s(
+            lang,
+            "Show whether each model is cached locally",
+            "查看每个模型是否已在本地缓存",
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use clap::{CommandFactory, Parser, Subcommand};
+    use std::path::PathBuf;
+
+    /// 最小可解析的镜像 CLI:复刻 `main.rs` 真实命令树的**子命令名 / flag / arg id**
+    /// (本测试只验证 `localize` 能命中每个 mut_subcommand / mut_arg —— id 写错会在
+    /// `localize` 内 panic,从而被 [`localize_hits_every_subcommand_and_arg`] 抓住)。
+    /// 文案内容与真实结构在 main.rs;此处刻意只保留结构以免与生产命令双份维护漂移。
+    #[derive(Parser, Debug)]
+    #[command(name = "vigil-hub")]
+    struct MirrorCli {
+        #[command(subcommand)]
+        command: Option<MirrorCmd>,
+    }
+
+    #[derive(Subcommand, Debug)]
+    enum MirrorCmd {
+        AddRemoteMcp {
+            #[arg(long)]
+            url: String,
+            #[arg(long)]
+            client_id: String,
+            #[arg(long, value_delimiter = ',')]
+            scopes: Vec<String>,
+            #[arg(long, default_value = "vigil.db")]
+            ledger: PathBuf,
+            #[arg(long, default_value_t = 60u64)]
+            timeout_secs: u64,
+        },
+        Serve {
+            #[arg(long)]
+            stdio: bool,
+            #[arg(long)]
+            ledger: Option<PathBuf>,
+            #[arg(long = "upstream-config")]
+            upstream_config: Option<PathBuf>,
+            #[arg(long)]
+            auto_approve_first_seen: bool,
+            #[arg(long)]
+            dev_permissive_firewall: bool,
+            #[arg(long = "enable-privacy-filter")]
+            enable_privacy_filter: bool,
+            #[arg(long = "redact-tool-results")]
+            redact_tool_results: bool,
+            #[arg(long = "project-root")]
+            project_root: Vec<PathBuf>,
+            #[arg(long = "enable-injection-classifier")]
+            enable_injection_classifier: bool,
+            #[arg(long)]
+            engine: Option<String>,
+        },
+        Demo {
+            #[arg(long)]
+            tamper: bool,
+        },
+        Hook {
+            #[arg(long)]
+            ledger: Option<PathBuf>,
+            #[arg(long)]
+            cli: Option<String>,
+            #[arg(long)]
+            inject: bool,
+            #[arg(long = "secrets")]
+            secrets: Option<PathBuf>,
+            #[arg(long = "inject-ttl-secs", default_value_t = 300)]
+            inject_ttl_secs: i64,
+            #[arg(long = "redact-results")]
+            redact_results: bool,
+        },
+        Setup {
+            #[arg(long)]
+            uninstall: bool,
+            #[arg(long)]
+            status: bool,
+            #[arg(long)]
+            dry_run: bool,
+            #[arg(long)]
+            ledger: Option<PathBuf>,
+            #[arg(long = "hook-exe")]
+            hook_exe: Option<PathBuf>,
+            #[arg(long)]
+            json: bool,
+            #[arg(long)]
+            mcp: bool,
+            #[arg(long)]
+            apply: bool,
+            #[arg(long = "user-scope-only")]
+            user_scope_only: bool,
+            #[arg(long)]
+            enforce: bool,
+            #[arg(long)]
+            doctor: bool,
+            #[arg(long)]
+            probe: bool,
+            #[arg(long)]
+            all: bool,
+        },
+        Wrap {
+            #[arg(long)]
+            ledger: Option<PathBuf>,
+            #[arg(long = "server-id")]
+            server_id: Option<String>,
+            #[arg(long = "env-key")]
+            env_key: Vec<String>,
+            #[arg(long = "inherit-env")]
+            inherit_env: bool,
+            #[arg(long)]
+            monitor: bool,
+            #[arg(long = "project-root")]
+            project_root: Vec<PathBuf>,
+            #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+            command: Vec<String>,
+        },
+        Checkpoint {
+            #[arg(long)]
+            ledger: Option<PathBuf>,
+        },
+        Verify {
+            #[arg(long)]
+            ledger: Option<PathBuf>,
+        },
+        Quickstart,
+        Posture {
+            #[command(subcommand)]
+            command: MirrorPosture,
+        },
+        Engine {
+            #[command(subcommand)]
+            command: MirrorEngine,
+        },
+        Daemon {
+            #[command(subcommand)]
+            command: MirrorDaemon,
+        },
+        Model {
+            #[command(subcommand)]
+            command: MirrorModel,
+        },
+        Inspect,
+    }
+
+    #[derive(Subcommand, Debug)]
+    enum MirrorPosture {
+        Show,
+        Set {
+            #[arg(value_enum)]
+            profile: MirrorEnum,
+            #[arg(long)]
+            ledger: Option<PathBuf>,
+        },
+    }
+    #[derive(Subcommand, Debug)]
+    enum MirrorEngine {
+        Show,
+        Set {
+            #[arg(value_enum)]
+            mode: MirrorEnum,
+        },
+    }
+    #[derive(Subcommand, Debug)]
+    enum MirrorDaemon {
+        Start,
+        Status,
+        Stop,
+    }
+    #[derive(Subcommand, Debug)]
+    enum MirrorModel {
+        Install {
+            #[arg(long)]
+            privacy: bool,
+            #[arg(long)]
+            injection: bool,
+        },
+        Status,
+    }
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+    enum MirrorEnum {
+        Low,
+        Medium,
+        High,
+    }
+
+    /// `localize` 命中每个 mut_subcommand / mut_arg —— 任一 id 写错都会在此 panic;
+    /// `debug_assert` 再校验改写后命令结构自洽。两语言各跑一遍。
+    #[test]
+    fn localize_hits_every_subcommand_and_arg() {
+        for lang in [Lang::En, Lang::Zh] {
+            let cmd = localize(MirrorCli::command(), lang);
+            cmd.debug_assert();
+        }
+    }
+
+    /// 端到端:改写确实生效(渲染帮助里出现目标语言的标志性短语),且不同语言不同。
+    /// 渲染前把 term_width 调到很大,关闭自动折行,保证目标短语逐字出现(尤其无空格的
+    /// 中文不会被折行拆断)。
+    #[test]
+    fn rendered_help_reflects_language() {
+        // root long help 展示的是 long_about(非 about),故断言取自 long_about 首句。
+        let en_root = render_long(localize(MirrorCli::command(), Lang::En));
+        let zh_root = render_long(localize(MirrorCli::command(), Lang::Zh));
+        assert!(
+            en_root.contains("Vigil sits between your AI coding agents"),
+            "EN root long_about missing:\n{en_root}"
+        );
+        assert!(
+            zh_root.contains("Vigil 位于你的 AI 编码 agent"),
+            "ZH root long_about missing:\n{zh_root}"
+        );
+        assert_ne!(en_root, zh_root);
+
+        // 子命令 about 进入 root 帮助的子命令清单(验证 mut_subcommand 生效)。
+        assert!(
+            en_root.contains("block a leaking secret"),
+            "EN root help should list the rewritten demo about:\n{en_root}"
+        );
+        assert!(
+            zh_root.contains("当场拦下一次密钥外泄"),
+            "ZH root help should list the rewritten demo about:\n{zh_root}"
+        );
+    }
+
+    /// 一个子命令的 long_about + arg help 双语生效。
+    #[test]
+    fn subcommand_long_help_is_localized() {
+        let cmd = localize(MirrorCli::command(), Lang::Zh);
+        let serve = cmd
+            .find_subcommand("serve")
+            .expect("serve subcommand exists")
+            .clone();
+        let help = render_long(serve);
+        assert!(
+            help.contains("经过 Vigil 的防火墙"),
+            "serve ZH long_about missing:\n{help}"
+        );
+        assert!(
+            help.contains("仅供冒烟测试"),
+            "serve ZH --ledger arg help missing:\n{help}"
+        );
+    }
+
+    /// 渲染长帮助;term_width 调大以**关闭折行**,使断言短语逐字保留。
+    fn render_long(cmd: Command) -> String {
+        let mut cmd = cmd.term_width(10_000);
+        cmd.render_long_help().to_string()
+    }
+}

--- a/apps/vigil-hub-cli/src/i18n/mod.rs
+++ b/apps/vigil-hub-cli/src/i18n/mod.rs
@@ -1,0 +1,423 @@
+//! CLI 输出国际化(i18n):按系统语言选择中 / 英文案。
+//!
+//! # 为什么需要
+//! `vigil-hub` 的帮助 / 提示原先中英混杂且面向开发者(满是 ADR 引用、`fail-closed`、
+//! `default-deny` 等内部黑话),终端用户难以"感受到命令的意义"。本模块按**系统语言**
+//! (Windows 用户默认 UI 语言 / Unix `LANG` 等)选择更贴切的中 / 英输出,并集中管理文案。
+//!
+//! # 结构(三类文案各取所宜)
+//! - **命令帮助**([`help`] 子模块):整段、随命令演进 —— 每命令把中 / 英 about /
+//!   long_about / arg-help 内联并排,便于对照与同步;运行时 [`help::localize`] 改写
+//!   clap [`Command`](clap::Command),**绝不**改子命令名 / flag(那是解析契约)。
+//! - **零散运行时短消息**(本模块 [`Msg`] + [`t`]):跨多处复用的提示 / 结果 / 错误 ——
+//!   用穷举目录集中,编译器守门(新增 [`Msg`] variant 必补全两语言,否则不编译)。
+//! - **整屏首跑界面**([`crate::quickstart`] / [`crate::demo`]):每屏中 / 英整段并排,
+//!   内联在各自模块(随屏演进,内联比拆散成几十个 key 更易保持同步)。
+//!
+//! # 语言选择
+//! [`Lang::detect`]:`VIGIL_LANG` 环境变量(`en` / `zh` / `auto`)覆盖 → 系统 locale
+//! (`sys-locale`)→ 回落 [`Lang::En`]。纯解析逻辑在 [`Lang::from_tag`] / [`resolve_lang`],
+//! 与 IO 分离以便测试。
+
+pub mod help;
+
+/// 受支持的输出语言。
+///
+/// 新增语言:加 variant,编译器会在 [`t`]、[`help`]、`quickstart`、`demo` 各处的穷举
+/// `match lang` 强制提示需补全文案。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Lang {
+    /// 英文(默认 / 回落)。
+    #[default]
+    En,
+    /// 简体中文。
+    Zh,
+}
+
+impl Lang {
+    /// 从 BCP-47 风格 locale 串解析语言:`zh-CN` / `zh_CN` / `zh` / `en-US` / `en` …
+    ///
+    /// 只看**主语言子标签**(`-` / `_` 之前),大小写不敏感;不识别 → `None`
+    /// (交由调用方回落)。
+    pub fn from_tag(tag: &str) -> Option<Lang> {
+        let primary = tag
+            .split(['-', '_'])
+            .next()
+            .unwrap_or("")
+            .to_ascii_lowercase();
+        match primary.as_str() {
+            "zh" => Some(Lang::Zh),
+            "en" => Some(Lang::En),
+            _ => None,
+        }
+    }
+
+    /// 检测有效输出语言:`VIGIL_LANG` 覆盖 → 系统 locale → [`Lang::En`] 回落。
+    ///
+    /// 副作用(读环境变量 / 探测系统 locale)隔离在此;纯决议逻辑见 [`resolve_lang`]。
+    pub fn detect() -> Lang {
+        let override_ = std::env::var("VIGIL_LANG").ok();
+        let system = sys_locale::get_locale();
+        resolve_lang(override_.as_deref(), system.as_deref())
+    }
+}
+
+/// 纯函数语言决议(无 IO,便于测试)。
+///
+/// - `override_`:`VIGIL_LANG` 值。`en` / `zh` 强制对应语言;`auto` / 空 / 仅空白 →
+///   回落系统检测。**显式但不识别**的覆盖(如 `fr`)→ [`Lang::En`](尊重"我要覆盖"
+///   的意图,绝不再回落系统 —— 否则"我设了 en 却因系统中文出中文"会很意外)。
+/// - `system`:系统 locale 串(如 `zh-CN`)。识别失败 / 缺失 → [`Lang::En`]。
+pub fn resolve_lang(override_: Option<&str>, system: Option<&str>) -> Lang {
+    if let Some(o) = override_ {
+        let o = o.trim();
+        if !o.is_empty() && !o.eq_ignore_ascii_case("auto") {
+            return Lang::from_tag(o).unwrap_or(Lang::En);
+        }
+    }
+    system.and_then(Lang::from_tag).unwrap_or(Lang::En)
+}
+
+/// 零散运行时短消息目录(结果 / 提示 / 错误)。借用字段避免复制调用方数据;
+/// 渲染见 [`t`]。新增 variant 必在 [`t`] 的穷举 match 补全两语言。
+#[derive(Debug)]
+pub enum Msg<'a> {
+    /// 无子命令时的欢迎 + 引导(`version` = 真实发布版本号,如 `v0.1.7`)。
+    NoCommandHint {
+        /// 发布版本号(含前缀 `v`)。
+        version: &'a str,
+    },
+    /// 统一的"某子命令失败"前缀 + 错误体。
+    CommandFailed {
+        /// 子命令展示名(如 `serve` / `setup --all`)。
+        command: &'a str,
+        /// 底层错误文本。
+        error: &'a str,
+    },
+    /// `serve` 缺少必需的 `--stdio`。
+    ServeNeedsStdio,
+    /// `serve` 已作为 stdio MCP server 启动(`pid` = 进程号)。
+    ServeStarted {
+        /// 本进程 PID。
+        pid: u32,
+    },
+    /// `serve` 检测到 stdin 关闭,正常退出。
+    ServeStopped,
+    /// `quickstart` 无法定位用户主目录。
+    QuickstartNoHome,
+    /// 无法定位某组件的配置目录(`component` = `posture` / `engine`)。
+    ConfigDirNotFound {
+        /// 组件名。
+        component: &'a str,
+    },
+    /// 写配置失败(`component` = `posture` / `engine`)。
+    ConfigStoreFailed {
+        /// 组件名。
+        component: &'a str,
+        /// 底层错误文本。
+        error: &'a str,
+    },
+    /// 姿态档已切换(`old`→`new`,均为 `low` / `medium` / `high`)。
+    PostureChanged {
+        /// 原档位。
+        old: &'a str,
+        /// 新档位。
+        new: &'a str,
+    },
+    /// 引擎模式已切换(`old`→`new`,均为 `hardfp` / `ml` / `auto`)。
+    EngineChanged {
+        /// 原模式。
+        old: &'a str,
+        /// 新模式。
+        new: &'a str,
+    },
+    /// 无法定位审计账本(给 `--ledger` 或设 `VIGIL_LEDGER_PATH`)。
+    LedgerNotFound,
+    /// 打开审计账本失败。
+    LedgerOpenFailed {
+        /// 底层错误文本。
+        error: &'a str,
+    },
+    /// `verify`:账本文件不存在(只读,绝不创建)。
+    LedgerMissingForVerify {
+        /// 期望的账本路径。
+        path: &'a str,
+    },
+    /// `checkpoint`:已锚定链头(`event_id` 事件号,`head` 哈希前缀,`path` sidecar 路径)。
+    CheckpointAnchored {
+        /// 锚定到的事件号。
+        event_id: i64,
+        /// 链头哈希前缀(展示用)。
+        head: &'a str,
+        /// 锚点 sidecar 文件路径。
+        path: &'a str,
+    },
+    /// `checkpoint`:把锚点文件设为 append-only / 异地同步的安全建议。
+    CheckpointTip,
+    /// `checkpoint`:无新事件可锚定(账本空 / 自上次锚点无新增)。
+    CheckpointNothing,
+    /// `verify`:链内一致且已锚定(`checkpoints` 锚点数,`through` 覆盖到的事件号)。
+    VerifyValidAnchored {
+        /// 锚点数量。
+        checkpoints: usize,
+        /// 已覆盖到的事件号。
+        through: i64,
+    },
+    /// `verify`:对锚点能力的诚实框定(非 tamper-proof)。
+    VerifyAnchorNote,
+    /// `verify`:链内一致但尚无锚点。
+    VerifyValidUnanchored,
+    /// `verify`:提示运行 `checkpoint` 以防整链重写。
+    VerifyRunCheckpointHint,
+    /// `verify`:链在某事件号断裂(内部篡改)。
+    VerifyChainBroken {
+        /// 断裂处事件号。
+        event_id: i64,
+    },
+    /// `verify`:锚点比对不匹配(链前缀可能被重写)。
+    VerifyCheckpointMismatch {
+        /// 不匹配处事件号。
+        event_id: i64,
+    },
+    /// `verify`:锚点存储损坏。
+    VerifyStoreCorrupt {
+        /// 损坏原因。
+        reason: &'a str,
+    },
+}
+
+/// 渲染一条 [`Msg`] 为目标语言的整行文本(供 `println!` / `eprintln!` 直接输出)。
+///
+/// 外层 match `msg`、内层 match `lang`:每 variant 的中 / 英并排,便于对照与同步。
+pub fn t(lang: Lang, msg: Msg<'_>) -> String {
+    match msg {
+        Msg::NoCommandHint { version } => match lang {
+            Lang::En => format!(
+                "vigil-hub {version} — a local security gateway for your AI agents.\n\
+                 New here? Run `vigil-hub quickstart` to see what's protected on this\n\
+                 machine, or `vigil-hub --help` to list every command."
+            ),
+            Lang::Zh => format!(
+                "vigil-hub {version} —— 守护 AI agent 的本地安全网关。\n\
+                 第一次用?运行 `vigil-hub quickstart` 看看本机的防护现状,\n\
+                 或用 `vigil-hub --help` 查看全部命令。"
+            ),
+        },
+        Msg::CommandFailed { command, error } => match lang {
+            Lang::En => format!("vigil-hub {command} failed: {error}"),
+            Lang::Zh => format!("vigil-hub {command} 执行失败:{error}"),
+        },
+        Msg::ServeNeedsStdio => match lang {
+            Lang::En => {
+                "vigil-hub serve: --stdio is required (stdio is the only transport for now)".into()
+            }
+            Lang::Zh => "vigil-hub serve:必须显式加 --stdio(目前仅支持 stdio 通道)".into(),
+        },
+        Msg::ServeStarted { pid } => match lang {
+            Lang::En => format!(
+                "vigil-hub serve: listening as a stdio MCP server (PID {pid}). \
+                 Point your agent at it; press Ctrl-C or close stdin to stop."
+            ),
+            Lang::Zh => format!(
+                "vigil-hub serve:已作为 stdio MCP server 启动(PID {pid})。\
+                 把你的 agent 指向它即可;Ctrl-C 或关闭 stdin 即停止。"
+            ),
+        },
+        Msg::ServeStopped => match lang {
+            Lang::En => "vigil-hub serve: stdin closed, shutting down.".into(),
+            Lang::Zh => "vigil-hub serve:stdin 已关闭,正在退出。".into(),
+        },
+        Msg::QuickstartNoHome => match lang {
+            Lang::En => "vigil-hub quickstart: cannot locate your home directory.".into(),
+            Lang::Zh => "vigil-hub quickstart:无法定位你的用户主目录。".into(),
+        },
+        Msg::ConfigDirNotFound { component } => match lang {
+            Lang::En => {
+                format!("vigil-hub {component}: cannot locate the {component} config directory.")
+            }
+            Lang::Zh => format!("vigil-hub {component}:无法定位 {component} 配置目录。"),
+        },
+        Msg::ConfigStoreFailed { component, error } => match lang {
+            Lang::En => format!("vigil-hub {component}: failed to save the config ({error})."),
+            Lang::Zh => format!("vigil-hub {component}:写入配置失败({error})。"),
+        },
+        Msg::PostureChanged { old, new } => match lang {
+            Lang::En => format!("Security posture: {old} -> {new}"),
+            Lang::Zh => format!("安全姿态:{old} -> {new}"),
+        },
+        Msg::EngineChanged { old, new } => match lang {
+            Lang::En => format!("Detection engine: {old} -> {new}"),
+            Lang::Zh => format!("检测引擎:{old} -> {new}"),
+        },
+        Msg::LedgerNotFound => match lang {
+            Lang::En => {
+                "Cannot locate the audit ledger (pass --ledger or set VIGIL_LEDGER_PATH).".into()
+            }
+            Lang::Zh => "无法定位审计账本(请给 --ledger,或设置 VIGIL_LEDGER_PATH)。".into(),
+        },
+        Msg::LedgerOpenFailed { error } => match lang {
+            Lang::En => format!("Failed to open the audit ledger: {error}"),
+            Lang::Zh => format!("打开审计账本失败:{error}"),
+        },
+        Msg::LedgerMissingForVerify { path } => match lang {
+            Lang::En => format!(
+                "Audit ledger not found: {path} — check the --ledger path \
+                 (verify is read-only and never creates a ledger)."
+            ),
+            Lang::Zh => format!(
+                "审计账本不存在:{path} —— 请核对 --ledger 路径\
+                 (verify 只读,绝不会凭空创建账本)。"
+            ),
+        },
+        Msg::CheckpointAnchored {
+            event_id,
+            head,
+            path,
+        } => match lang {
+            Lang::En => {
+                format!("✓ anchored a checkpoint at event #{event_id} (head {head}…) → {path}")
+            }
+            Lang::Zh => format!("✓ 已在事件 #{event_id} 处锚定链头(head {head}…)→ {path}"),
+        },
+        Msg::CheckpointTip => match lang {
+            Lang::En => "  tip: keep that file append-only (chattr +a) or synced offsite, so a \
+                 full-history rewrite can't also forge the anchor."
+                .into(),
+            Lang::Zh => "  提示:把锚点文件设为 append-only(chattr +a)或异地同步,\
+                 这样即便有人整体重写历史,也伪造不了锚点。"
+                .into(),
+        },
+        Msg::CheckpointNothing => match lang {
+            Lang::En => {
+                "Nothing to anchor (the ledger is empty, or there are no new events since the last \
+                 checkpoint)."
+                    .into()
+            }
+            Lang::Zh => "无需锚定(账本为空,或自上次锚点以来没有新事件)。".into(),
+        },
+        Msg::VerifyValidAnchored {
+            checkpoints,
+            through,
+        } => match lang {
+            Lang::En => format!(
+                "✓ the audit chain is internally consistent AND anchored: {checkpoints} \
+                 checkpoint(s), through event #{through}."
+            ),
+            Lang::Zh => {
+                format!("✓ 审计链内部一致,且已锚定:{checkpoints} 个锚点,覆盖到事件 #{through}。")
+            }
+        },
+        Msg::VerifyAnchorNote => match lang {
+            Lang::En => "  (the anchor catches a database-only full-history rewrite while the \
+                 checkpoint file is intact — it is not a tamper-proof guarantee.)"
+                .into(),
+            Lang::Zh => "  (锚点能在锚点文件完好时,检出仅针对数据库的整链重写 —— \
+                 但这不是绝对防篡改的保证。)"
+                .into(),
+        },
+        Msg::VerifyValidUnanchored => match lang {
+            Lang::En => {
+                "✓ the audit chain is internally consistent; ⚠ no checkpoints found.".into()
+            }
+            Lang::Zh => "✓ 审计链内部一致;⚠ 但尚未找到任何锚点。".into(),
+        },
+        Msg::VerifyRunCheckpointHint => match lang {
+            Lang::En => {
+                "  run `vigil-hub checkpoint` to anchor against a full-history rewrite.".into()
+            }
+            Lang::Zh => "  运行 `vigil-hub checkpoint` 打锚点,以防整链重写。".into(),
+        },
+        Msg::VerifyChainBroken { event_id } => match lang {
+            Lang::En => {
+                format!("✗ the audit chain is BROKEN at event #{event_id} — tampering detected.")
+            }
+            Lang::Zh => format!("✗ 审计链在事件 #{event_id} 处断裂 —— 检测到篡改。"),
+        },
+        Msg::VerifyCheckpointMismatch { event_id } => match lang {
+            Lang::En => format!(
+                "✗ checkpoint MISMATCH at event #{event_id} — the chain prefix may have been \
+                 rewritten."
+            ),
+            Lang::Zh => format!("✗ 锚点在事件 #{event_id} 处不匹配 —— 链前缀可能已被重写。"),
+        },
+        Msg::VerifyStoreCorrupt { reason } => match lang {
+            Lang::En => format!("✗ the checkpoint store is corrupt: {reason}"),
+            Lang::Zh => format!("✗ 锚点存储已损坏:{reason}"),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_tag_parses_primary_subtag_case_insensitively() {
+        for t in ["zh", "zh-CN", "zh_CN", "ZH-Hans-CN", "zh-Hant"] {
+            assert_eq!(Lang::from_tag(t), Some(Lang::Zh), "tag {t} should be Zh");
+        }
+        for t in ["en", "en-US", "en_GB", "EN", "en-Latn-US"] {
+            assert_eq!(Lang::from_tag(t), Some(Lang::En), "tag {t} should be En");
+        }
+        for t in ["fr", "de-DE", "ja_JP", "", "x"] {
+            assert_eq!(Lang::from_tag(t), None, "tag {t} should be unrecognized");
+        }
+    }
+
+    #[test]
+    fn resolve_lang_override_beats_system() {
+        // 显式 en/zh 覆盖系统。
+        assert_eq!(resolve_lang(Some("zh"), Some("en-US")), Lang::Zh);
+        assert_eq!(resolve_lang(Some("en"), Some("zh-CN")), Lang::En);
+        // 大小写 / 带区域子标签同样识别。
+        assert_eq!(resolve_lang(Some("ZH-cn"), Some("en-US")), Lang::Zh);
+    }
+
+    #[test]
+    fn resolve_lang_auto_or_empty_falls_back_to_system() {
+        assert_eq!(resolve_lang(Some("auto"), Some("zh-CN")), Lang::Zh);
+        assert_eq!(resolve_lang(Some(""), Some("zh-CN")), Lang::Zh);
+        assert_eq!(resolve_lang(Some("  "), Some("zh-CN")), Lang::Zh);
+        assert_eq!(resolve_lang(None, Some("zh-CN")), Lang::Zh);
+    }
+
+    #[test]
+    fn resolve_lang_unrecognized_override_pins_english_not_system() {
+        // 显式但不识别的覆盖 → En,**不**回落系统中文(尊重"我要覆盖"的意图)。
+        assert_eq!(resolve_lang(Some("fr"), Some("zh-CN")), Lang::En);
+    }
+
+    #[test]
+    fn resolve_lang_defaults_to_english_when_nothing_known() {
+        assert_eq!(resolve_lang(None, None), Lang::En);
+        assert_eq!(resolve_lang(None, Some("ja-JP")), Lang::En);
+        assert_eq!(resolve_lang(Some("auto"), Some("ja-JP")), Lang::En);
+    }
+
+    /// 代表性 [`Msg`] 在两语言都渲染出非空、且中 ≠ 英(防漏译 / 复制粘贴遗漏)。
+    /// 穷举完整性已由 [`t`] 的 match 编译期强制;此处做内容 sanity。
+    #[test]
+    fn representative_messages_render_nonempty_and_differ_per_lang() {
+        // [`Msg`] 借用字段、无 `Clone`,而 [`t`] 会消费它;用工厂闭包为两语言各现造一次
+        //(字符串字面量是 `'static`,故 `Msg<'static>` 成立)。
+        let cases: [fn() -> Msg<'static>; 4] = [
+            || Msg::NoCommandHint { version: "v9.9.9" },
+            || Msg::CommandFailed {
+                command: "serve",
+                error: "boom",
+            },
+            || Msg::PostureChanged {
+                old: "low",
+                new: "high",
+            },
+            || Msg::VerifyChainBroken { event_id: 7 },
+        ];
+        for make in cases {
+            let en = t(Lang::En, make());
+            let zh = t(Lang::Zh, make());
+            assert!(!en.trim().is_empty(), "EN render must be non-empty");
+            assert!(!zh.trim().is_empty(), "ZH render must be non-empty");
+            assert_ne!(en, zh, "EN and ZH must differ for the same message");
+        }
+    }
+}

--- a/apps/vigil-hub-cli/src/lib.rs
+++ b/apps/vigil-hub-cli/src/lib.rs
@@ -13,6 +13,7 @@ pub mod daemon;
 pub mod demo;
 pub mod engine_config;
 pub mod hook;
+pub mod i18n;
 pub mod inspect;
 pub mod model;
 pub mod posture;

--- a/apps/vigil-hub-cli/src/main.rs
+++ b/apps/vigil-hub-cli/src/main.rs
@@ -7,11 +7,12 @@
 
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 use vigil_hub_cli::daemon;
 use vigil_hub_cli::demo::{self, DemoArgs};
 use vigil_hub_cli::engine_config;
 use vigil_hub_cli::hook::{self, HookArgs};
+use vigil_hub_cli::i18n::{self, Lang};
 use vigil_hub_cli::inspect::{self, InspectArgs};
 use vigil_hub_cli::model;
 use vigil_hub_cli::posture;
@@ -446,14 +447,26 @@ impl From<CliServeArgs> for ServeArgs {
 }
 
 fn main() -> std::process::ExitCode {
-    let cli = Cli::parse();
+    // i18n:按系统语言(VIGIL_LANG 覆盖 → 系统 locale → En 回落)选择输出语言;在 parse 前用
+    // builder 把帮助文案整体改写为贴切、本地化文本 —— **只改展示**,绝不动子命令名 / flag 解析契约。
+    let lang = Lang::detect();
+    let matches = i18n::help::localize(Cli::command(), lang).get_matches();
+    let cli = match Cli::from_arg_matches(&matches) {
+        Ok(c) => c,
+        Err(e) => e.exit(),
+    };
     match cli.command {
         None => {
             // 真实 crate 版本(编译期 CARGO_PKG_VERSION),非内部迭代标记 —— 用户看到的是
-            // 发布版本号(如 v0.1.15),既不误导也不泄漏内部 `I0x` 迭代术语。
+            // 发布版本号(如 v0.1.15),既不误导也不泄漏内部 `I0x` 迭代术语。文案按系统语言本地化。
             eprintln!(
-                "vigil-hub {} — MCP proxy + CLI. Use --help for subcommands.",
-                concat!("v", env!("CARGO_PKG_VERSION"))
+                "{}",
+                i18n::t(
+                    lang,
+                    i18n::Msg::NoCommandHint {
+                        version: concat!("v", env!("CARGO_PKG_VERSION")),
+                    },
+                )
             );
             std::process::ExitCode::SUCCESS
         }
@@ -461,10 +474,7 @@ fn main() -> std::process::ExitCode {
             let args: AddRemoteArgs = args.into();
             match add_remote::run(args) {
                 Ok(()) => std::process::ExitCode::SUCCESS,
-                Err(e) => {
-                    eprintln!("vigil-hub add-remote-mcp failed: {e}");
-                    std::process::ExitCode::FAILURE
-                }
+                Err(e) => fail_cmd(lang, "add-remote-mcp", e),
             }
         }
         // 还原 v0.1.31 误删的 inspect 接线(`feat(audit): checkpoint anchor` 从无 inspect 的内部仓
@@ -473,38 +483,35 @@ fn main() -> std::process::ExitCode {
         Some(Command::Serve(args)) => {
             // stdio flag 必须显式给,防止用户误以为能默认启 HTTP
             if !args.stdio {
-                eprintln!(
-                    "vigil-hub serve: --stdio is required (v0.3 Stage 1 仅支持 stdio transport)"
-                );
+                eprintln!("{}", i18n::t(lang, i18n::Msg::ServeNeedsStdio));
                 return std::process::ExitCode::FAILURE;
             }
             let args: ServeArgs = args.into();
             // NOTE:stderr 打印启动提示;stdout 交给 MCP 协议,**不得污染**
             eprintln!(
-                "vigil-hub serve: started stdio MCP server (PID {})",
-                std::process::id()
+                "{}",
+                i18n::t(
+                    lang,
+                    i18n::Msg::ServeStarted {
+                        pid: std::process::id(),
+                    },
+                )
             );
             match serve::run(args) {
                 Ok(()) => {
-                    eprintln!("vigil-hub serve: stdin closed, shutting down");
+                    eprintln!("{}", i18n::t(lang, i18n::Msg::ServeStopped));
                     std::process::ExitCode::SUCCESS
                 }
-                Err(e) => {
-                    eprintln!("vigil-hub serve failed: {e}");
-                    std::process::ExitCode::FAILURE
-                }
+                Err(e) => fail_cmd(lang, "serve", e),
             }
         }
         Some(Command::Demo(args)) => {
             let demo_args = DemoArgs {
                 tamper: args.tamper,
             };
-            match demo::run(&demo_args) {
+            match demo::run(&demo_args, lang) {
                 Ok(()) => std::process::ExitCode::SUCCESS,
-                Err(e) => {
-                    eprintln!("vigil-hub demo failed: {e}");
-                    std::process::ExitCode::FAILURE
-                }
+                Err(e) => fail_cmd(lang, "demo", e),
             }
         }
         Some(Command::Hook(args)) => {
@@ -549,21 +556,15 @@ fn main() -> std::process::ExitCode {
         Some(Command::Setup(args)) => {
             if args.all {
                 // 一条命令全保护:hook + MCP wrap 一次完成(兑现 download→直接保护)。
-                match run_setup_all(&args) {
+                match run_setup_all(lang, &args) {
                     Ok(code) => code,
-                    Err(e) => {
-                        eprintln!("vigil-hub setup --all failed: {e}");
-                        std::process::ExitCode::FAILURE
-                    }
+                    Err(e) => fail_cmd(lang, "setup --all", e),
                 }
             } else if args.mcp {
                 // MCP turnkey:--apply 改写 / --uninstall 还原 / 默认只读预览。
-                match setup_mcp_dispatch(&args) {
+                match setup_mcp_dispatch(lang, &args) {
                     Ok(code) => code,
-                    Err(e) => {
-                        eprintln!("vigil-hub setup --mcp failed: {e}");
-                        std::process::ExitCode::FAILURE
-                    }
+                    Err(e) => fail_cmd(lang, "setup --mcp", e),
                 }
             } else {
                 let setup_args = SetupArgs {
@@ -579,7 +580,7 @@ fn main() -> std::process::ExitCode {
                         let mcp_wrapped = dirs::home_dir()
                             .map(|h| setup_mcp::wrapped_server_count(&h))
                             .unwrap_or(0);
-                        let code = print_setup_report(&setup_args, &report, mcp_wrapped);
+                        let code = print_setup_report(lang, &setup_args, &report, mcp_wrapped);
                         // 其余 agent 的 hook 注册面(Codex/Gemini/Cursor):检测到才注册,逐面诚实
                         // 报告。ledger 用 Claude 面已解析出的同一路径(审计链单账本)。
                         let op = if setup_args.status {
@@ -593,12 +594,9 @@ fn main() -> std::process::ExitCode {
                                 dry_run: setup_args.dry_run,
                             }
                         };
-                        run_agent_hook_legs(&report.ledger, op, code)
+                        run_agent_hook_legs(lang, &report.ledger, op, code)
                     }
-                    Err(e) => {
-                        eprintln!("vigil-hub setup failed: {e}");
-                        std::process::ExitCode::FAILURE
-                    }
+                    Err(e) => fail_cmd(lang, "setup", e),
                 }
             }
         }
@@ -615,18 +613,15 @@ fn main() -> std::process::ExitCode {
             };
             match wrap::run(&wrap_args) {
                 Ok(()) => std::process::ExitCode::SUCCESS,
-                Err(e) => {
-                    eprintln!("vigil-hub wrap failed: {e}");
-                    std::process::ExitCode::FAILURE
-                }
+                Err(e) => fail_cmd(lang, "wrap", e),
             }
         }
-        Some(Command::Checkpoint(args)) => run_checkpoint(args.ledger),
-        Some(Command::Verify(args)) => run_verify(args.ledger),
+        Some(Command::Checkpoint(args)) => run_checkpoint(lang, args.ledger),
+        Some(Command::Verify(args)) => run_verify(lang, args.ledger),
         Some(Command::Quickstart) => {
             // 只读引导:检测需要 home(找各 agent 配置)+ exe(preview 构造 wrap argv;本命令不显示)。
             let Some(home) = dirs::home_dir() else {
-                eprintln!("vigil-hub quickstart: cannot locate your home directory");
+                eprintln!("{}", i18n::t(lang, i18n::Msg::QuickstartNoHome));
                 return std::process::ExitCode::FAILURE;
             };
             let exe = std::env::current_exe().ok();
@@ -634,24 +629,57 @@ fn main() -> std::process::ExitCode {
                 .as_deref()
                 .and_then(|p| p.to_str())
                 .unwrap_or("vigil-hub");
-            match quickstart::run(&home, exe_str) {
+            match quickstart::run(&home, exe_str, lang) {
                 0 => std::process::ExitCode::SUCCESS,
                 _ => std::process::ExitCode::FAILURE,
             }
         }
-        Some(Command::Posture(args)) => run_posture(args),
-        Some(Command::Engine(args)) => run_engine(args),
-        Some(Command::Daemon(args)) => run_daemon(args),
-        Some(Command::Model(args)) => run_model(args),
+        Some(Command::Posture(args)) => run_posture(lang, args),
+        Some(Command::Engine(args)) => run_engine(lang, args),
+        Some(Command::Daemon(args)) => run_daemon(lang, args),
+        Some(Command::Model(args)) => run_model(lang, args),
+    }
+}
+
+/// 统一打印「某子命令失败」(本地化)并返回 [`ExitCode::FAILURE`](std::process::ExitCode::FAILURE)。
+/// `command` 为展示名(如 `serve` / `setup --all`),`error` 为底层错误。
+fn fail_cmd(lang: Lang, command: &str, error: impl std::fmt::Display) -> std::process::ExitCode {
+    eprintln!(
+        "{}",
+        i18n::t(
+            lang,
+            i18n::Msg::CommandFailed {
+                command,
+                error: &error.to_string(),
+            },
+        )
+    );
+    std::process::ExitCode::FAILURE
+}
+
+/// 按语言取静态文案(中 / 英并排)。供 `setup` 系列人类可读报告本地化;复杂插值 / 词序差异的句子
+/// 用 `match lang` 直接写整句。`--json` 是机器契约,**不**走本地化(键值恒英文)。
+fn tr(lang: Lang, en: &'static str, zh: &'static str) -> &'static str {
+    match lang {
+        Lang::En => en,
+        Lang::Zh => zh,
     }
 }
 
 /// `vigil-hub engine show|set`:查看 / 切换 AI 引擎模式的落盘配置(ADR 0022)。镜像 [`run_posture`]
 /// 纪律(原子写;配置目录定位失败 = fail-soft 错误退出)。消费侧(serve/wrap 回落本配置)是后续
 /// 增量;本命令只读写配置,不改任何决策路径。
-fn run_engine(args: CliEngineArgs) -> std::process::ExitCode {
+fn run_engine(lang: Lang, args: CliEngineArgs) -> std::process::ExitCode {
     let Some(path) = engine_config::default_engine_path() else {
-        eprintln!("vigil-hub engine: cannot locate the engine config directory");
+        eprintln!(
+            "{}",
+            i18n::t(
+                lang,
+                i18n::Msg::ConfigDirNotFound {
+                    component: "engine",
+                },
+            )
+        );
         return std::process::ExitCode::FAILURE;
     };
     match args.command {
@@ -660,7 +688,7 @@ fn run_engine(args: CliEngineArgs) -> std::process::ExitCode {
             if let Some(w) = &loaded.warning {
                 eprintln!("vigil-hub engine: {w}");
             }
-            // 未配置(None)= 默认 hardfp(与发行二进制实际行为一致)。
+            // 未配置(None)= 默认 hardfp(与发行二进制实际行为一致);纯值输出,刻意不本地化。
             println!("{}", loaded.mode.unwrap_or_default().as_str());
             std::process::ExitCode::SUCCESS
         }
@@ -668,11 +696,29 @@ fn run_engine(args: CliEngineArgs) -> std::process::ExitCode {
             let old = engine_config::load_engine(&path).mode.unwrap_or_default();
             match engine_config::store_engine(&path, mode) {
                 Ok(()) => {
-                    println!("engine: {} -> {}", old.as_str(), mode.as_str());
+                    println!(
+                        "{}",
+                        i18n::t(
+                            lang,
+                            i18n::Msg::EngineChanged {
+                                old: old.as_str(),
+                                new: mode.as_str(),
+                            },
+                        )
+                    );
                     std::process::ExitCode::SUCCESS
                 }
                 Err(e) => {
-                    eprintln!("vigil-hub engine: failed to store engine config ({e})");
+                    eprintln!(
+                        "{}",
+                        i18n::t(
+                            lang,
+                            i18n::Msg::ConfigStoreFailed {
+                                component: "engine",
+                                error: &e.to_string(),
+                            },
+                        )
+                    );
                     std::process::ExitCode::FAILURE
                 }
             }
@@ -682,34 +728,30 @@ fn run_engine(args: CliEngineArgs) -> std::process::ExitCode {
 
 /// `vigil-hub daemon start|status`(ADR 0024):前台启动 / 查询常驻 daemon。逻辑在
 /// [`daemon::lifecycle`];本处只做分发 + ExitCode 映射。
-fn run_daemon(args: CliDaemonArgs) -> std::process::ExitCode {
+fn run_daemon(lang: Lang, args: CliDaemonArgs) -> std::process::ExitCode {
     let result = match args.command {
-        DaemonCommand::Start => daemon::lifecycle::run_start(),
-        DaemonCommand::Status => daemon::lifecycle::run_status(),
-        DaemonCommand::Stop => daemon::lifecycle::run_stop(),
+        DaemonCommand::Start => daemon::lifecycle::run_start(lang),
+        DaemonCommand::Status => daemon::lifecycle::run_status(lang),
+        DaemonCommand::Stop => daemon::lifecycle::run_stop(lang),
     };
     match result {
         Ok(()) => std::process::ExitCode::SUCCESS,
-        Err(e) => {
-            eprintln!("vigil-hub daemon: {e}");
-            std::process::ExitCode::FAILURE
-        }
+        Err(e) => fail_cmd(lang, "daemon", e),
     }
 }
 
 /// `vigil-hub model install|status`(「安装模型支持」turnkey 入口):下载 / 查 ML 模型。逻辑在
 /// [`model`];本处只做分发 + ExitCode 映射。ort-gated(非 ML 变体 `install` 返错指向 ML 变体)。
-fn run_model(args: CliModelArgs) -> std::process::ExitCode {
+fn run_model(lang: Lang, args: CliModelArgs) -> std::process::ExitCode {
     let result = match args.command {
-        ModelCommand::Install { privacy, injection } => model::run_install(privacy, injection),
-        ModelCommand::Status => model::run_status(),
+        ModelCommand::Install { privacy, injection } => {
+            model::run_install(lang, privacy, injection)
+        }
+        ModelCommand::Status => model::run_status(lang),
     };
     match result {
         Ok(()) => std::process::ExitCode::SUCCESS,
-        Err(e) => {
-            eprintln!("vigil-hub model: {e}");
-            std::process::ExitCode::FAILURE
-        }
+        Err(e) => fail_cmd(lang, "model", e),
     }
 }
 
@@ -717,9 +759,17 @@ fn run_model(args: CliModelArgs) -> std::process::ExitCode {
 /// `set` 走 [`posture::store_posture`](原子写)+ best-effort 审计(default ledger 或 `--ledger`;
 /// 仅档位真变化时记录)。配置目录定位失败 = fail-soft 错误退出(不影响既有保护:hook 端
 /// 文件缺失自落默认 low)。
-fn run_posture(args: CliPostureArgs) -> std::process::ExitCode {
+fn run_posture(lang: Lang, args: CliPostureArgs) -> std::process::ExitCode {
     let Some(path) = posture::default_posture_path() else {
-        eprintln!("vigil-hub posture: cannot locate the posture config directory");
+        eprintln!(
+            "{}",
+            i18n::t(
+                lang,
+                i18n::Msg::ConfigDirNotFound {
+                    component: "posture",
+                },
+            )
+        );
         return std::process::ExitCode::FAILURE;
     };
     match args.command {
@@ -728,6 +778,7 @@ fn run_posture(args: CliPostureArgs) -> std::process::ExitCode {
             if let Some(w) = &loaded.warning {
                 eprintln!("vigil-hub posture: {w}");
             }
+            // 纯值输出(low / medium / high),供脚本解析 —— 刻意不本地化。
             println!("{}", loaded.profile.as_str());
             std::process::ExitCode::SUCCESS
         }
@@ -741,11 +792,29 @@ fn run_posture(args: CliPostureArgs) -> std::process::ExitCode {
                             posture::audit_posture_switch(&lp, old, profile);
                         }
                     }
-                    println!("posture: {} -> {}", old.as_str(), profile.as_str());
+                    println!(
+                        "{}",
+                        i18n::t(
+                            lang,
+                            i18n::Msg::PostureChanged {
+                                old: old.as_str(),
+                                new: profile.as_str(),
+                            },
+                        )
+                    );
                     std::process::ExitCode::SUCCESS
                 }
                 Err(e) => {
-                    eprintln!("vigil-hub posture: failed to store posture ({e})");
+                    eprintln!(
+                        "{}",
+                        i18n::t(
+                            lang,
+                            i18n::Msg::ConfigStoreFailed {
+                                component: "posture",
+                                error: &e.to_string(),
+                            },
+                        )
+                    );
                     std::process::ExitCode::FAILURE
                 }
             }
@@ -754,7 +823,10 @@ fn run_posture(args: CliPostureArgs) -> std::process::ExitCode {
 }
 
 /// `setup --mcp` 分发:`--uninstall` 还原 / `--apply` 改写 / 默认只读预览。
-fn setup_mcp_dispatch(args: &CliSetupArgs) -> Result<std::process::ExitCode, setup::SetupError> {
+fn setup_mcp_dispatch(
+    lang: Lang,
+    args: &CliSetupArgs,
+) -> Result<std::process::ExitCode, setup::SetupError> {
     let home = dirs::home_dir().ok_or(setup::SetupError::MissingHomeDir)?;
     let exe = std::env::current_exe()
         .map_err(|_| setup::SetupError::MissingCurrentExe)?
@@ -770,28 +842,36 @@ fn setup_mcp_dispatch(args: &CliSetupArgs) -> Result<std::process::ExitCode, set
         let probe_timeout = if args.probe {
             // Codex D18 R2 Low:probe 真执行每个配置 server 的启动代码 —— 动手**前**(run_doctor 内即
             // 开始 spawn)在 stderr 明确告警,而非仅 help 文案 / 事后表头。
-            eprintln!(
-                "[vigil-hub] --probe will briefly START each configured MCP server (Claude / Codex / \
-                 Cursor / Windsurf) — running its startup code — to test a real MCP handshake, then \
-                 stop it. Ctrl-C to abort."
-            );
+            match lang {
+                Lang::En => eprintln!(
+                    "[vigil-hub] --probe will briefly START each configured MCP server (Claude / Codex / \
+                     Cursor / Windsurf) — running its startup code — to test a real MCP handshake, then \
+                     stop it. Ctrl-C to abort."
+                ),
+                Lang::Zh => eprintln!(
+                    "[vigil-hub] --probe 会短暂启动每个已配置的 MCP 服务器(Claude / Codex / Cursor / \
+                     Windsurf)—— 执行其启动代码 —— 以测试真实 MCP 握手,随后停止它。Ctrl-C 可中止。"
+                ),
+            }
             Some(setup_mcp::DOCTOR_PROBE_TIMEOUT)
         } else {
             None
         };
         let rows = setup_mcp::run_doctor(&home, probe_timeout)?;
-        Ok(print_mcp_doctor(&rows))
+        Ok(print_mcp_doctor(lang, &rows))
     } else if args.uninstall {
         // 所有 agent 接入面都还原:Claude + Codex + Cursor + Windsurf(各独立文件,逐一诚实报告)。
         let rep = setup_mcp::run_uninstall(&home, args.dry_run)?;
-        let mut code = print_mcp_apply(&rep, "uninstall");
+        let mut code = print_mcp_apply(lang, &rep, "uninstall");
         code = run_codex_leg(
+            lang,
             setup_mcp::run_codex_uninstall(&home, args.dry_run),
             "uninstall",
             code,
         );
         for agent in json_mcp_agents(&home) {
             code = run_json_agent_leg(
+                lang,
                 setup_mcp::run_json_agent_uninstall(&agent, args.dry_run),
                 agent.display_name,
                 "uninstall",
@@ -804,22 +884,30 @@ fn setup_mcp_dispatch(args: &CliSetupArgs) -> Result<std::process::ExitCode, set
         // #16:apply 前先查底层程序在 PATH 是否可解析(apply 后条目变 AlreadyWrapped 不再可查)。
         let unresolvable = setup_mcp::unresolvable_wrappables(&home);
         let rep = setup_mcp::run_apply(&home, &exe, args.dry_run, args.user_scope_only, monitor)?;
-        let mut code = print_mcp_apply(&rep, "apply");
+        let mut code = print_mcp_apply(lang, &rep, "apply");
         // #16:非阻塞 WARN —— 底层程序找不到的 server 仍被 wrap(配置正确),但会在 agent 启动时静默
         // 失败,故诚实告知(避免"Protected"虚假安全感)。
         for (name, prog) in &unresolvable {
-            eprintln!(
-                "  WARNING: MCP server '{name}' command '{prog}' not found on PATH; once wrapped it \
-                 will fail when the agent starts it (install it or fix the path in your config)"
-            );
+            match lang {
+                Lang::En => eprintln!(
+                    "  WARNING: MCP server '{name}' command '{prog}' not found on PATH; once wrapped it \
+                     will fail when the agent starts it (install it or fix the path in your config)"
+                ),
+                Lang::Zh => eprintln!(
+                    "  警告:MCP 服务器 '{name}' 的命令 '{prog}' 不在 PATH 中;一旦被 wrap,agent 启动它时 \
+                     会失败(请安装它,或在配置里修好路径)"
+                ),
+            }
         }
         code = run_codex_leg(
+            lang,
             setup_mcp::run_codex_apply(&home, &exe, args.dry_run, monitor),
             "apply",
             code,
         );
         for agent in json_mcp_agents(&home) {
             code = run_json_agent_leg(
+                lang,
                 setup_mcp::run_json_agent_apply(&agent, &exe, args.dry_run, monitor),
                 agent.display_name,
                 "apply",
@@ -829,30 +917,52 @@ fn setup_mcp_dispatch(args: &CliSetupArgs) -> Result<std::process::ExitCode, set
         Ok(code)
     } else {
         let rep = setup_mcp::run_preview(&home, &exe, monitor)?;
-        let code = print_mcp_preview(&rep);
+        let code = print_mcp_preview(lang, &rep);
         // 预览只读:某 agent 配置 malformed 不硬 abort(什么都没写),优雅降级为一行提示而非突兀报错。
         match setup_mcp::run_codex_preview(&home, &exe, monitor) {
-            Ok(codex) => print_codex_preview(&codex),
+            Ok(codex) => print_codex_preview(lang, &codex),
             Err(e) => {
                 println!();
                 println!(
-                    "  Codex CLI config: {}",
+                    "  {}{}",
+                    tr(lang, "Codex CLI config: ", "Codex CLI 配置:"),
                     setup_mcp::codex_config_path(&home).display()
                 );
-                println!("  (could not read it: {e} -- fix the file to preview/protect Codex MCP servers)");
+                match lang {
+                    Lang::En => println!(
+                        "  (could not read it: {e} -- fix the file to preview/protect Codex MCP servers)"
+                    ),
+                    Lang::Zh => println!(
+                        "  (无法读取:{e} —— 修好该文件以预览 / 保护 Codex 的 MCP 服务器)"
+                    ),
+                }
             }
         }
         for agent in json_mcp_agents(&home) {
             match setup_mcp::run_json_agent_preview(&agent, &exe, monitor) {
-                Ok(r) => print_json_agent_preview(&r),
+                Ok(r) => print_json_agent_preview(lang, &r),
                 Err(e) => {
                     println!();
-                    println!(
-                        "  {} config: {}",
-                        agent.display_name,
-                        agent.config_path.display()
-                    );
-                    println!("  (could not read it: {e} -- fix the file to preview/protect its MCP servers)");
+                    match lang {
+                        Lang::En => println!(
+                            "  {} config: {}",
+                            agent.display_name,
+                            agent.config_path.display()
+                        ),
+                        Lang::Zh => println!(
+                            "  {} 配置:{}",
+                            agent.display_name,
+                            agent.config_path.display()
+                        ),
+                    }
+                    match lang {
+                        Lang::En => println!(
+                            "  (could not read it: {e} -- fix the file to preview/protect its MCP servers)"
+                        ),
+                        Lang::Zh => println!(
+                            "  (无法读取:{e} —— 修好该文件以预览 / 保护其 MCP 服务器)"
+                        ),
+                    }
                 }
             }
         }
@@ -873,27 +983,47 @@ fn json_mcp_agents(home: &std::path::Path) -> [setup_mcp::JsonMcpAgent; 2] {
 /// 文案后突兀 `?` 报错**:明确告知 Claude 侧已生效 + Codex 步失败原因 + 恢复指引,返回 FAILURE。
 /// 对齐既有 `--all` 的 `McpAfterHook` 部分失败诚实哲学(报告每步状态 + 如何恢复,而非笼统失败)。
 fn run_codex_leg(
+    lang: Lang,
     res: Result<setup_mcp::CodexApplyReport, setup::SetupError>,
     op: &str,
     claude_code: std::process::ExitCode,
 ) -> std::process::ExitCode {
     match res {
         Ok(codex) => {
-            print_codex_apply(&codex, op);
+            print_codex_apply(lang, &codex, op);
             claude_code
         }
         Err(e) => {
-            eprintln!("  [Codex] the {op} step FAILED (the Claude side already completed): {e}");
+            match lang {
+                Lang::En => eprintln!(
+                    "  [Codex] the {op} step FAILED (the Claude side already completed): {e}"
+                ),
+                Lang::Zh => {
+                    eprintln!("  [Codex] {op} 步失败(Claude 侧已完成):{e}")
+                }
+            }
             if op == "uninstall" {
-                eprintln!(
-                    "  The Claude side was restored. Fix ~/.codex/config.toml, then re-run: \
-                     vigil-hub setup --mcp --uninstall"
-                );
+                match lang {
+                    Lang::En => eprintln!(
+                        "  The Claude side was restored. Fix ~/.codex/config.toml, then re-run: \
+                         vigil-hub setup --mcp --uninstall"
+                    ),
+                    Lang::Zh => eprintln!(
+                        "  Claude 侧已还原。修好 ~/.codex/config.toml 后重跑:\
+                         vigil-hub setup --mcp --uninstall"
+                    ),
+                }
             } else {
-                eprintln!(
-                    "  The Claude side IS applied. Fix ~/.codex/config.toml and re-run; or undo \
-                     the Claude side with: vigil-hub setup --mcp --uninstall"
-                );
+                match lang {
+                    Lang::En => eprintln!(
+                        "  The Claude side IS applied. Fix ~/.codex/config.toml and re-run; or undo \
+                         the Claude side with: vigil-hub setup --mcp --uninstall"
+                    ),
+                    Lang::Zh => eprintln!(
+                        "  Claude 侧已应用。修好 ~/.codex/config.toml 后重跑;或撤销 Claude 侧:\
+                         vigil-hub setup --mcp --uninstall"
+                    ),
+                }
             }
             std::process::ExitCode::FAILURE
         }
@@ -904,6 +1034,7 @@ fn run_codex_leg(
 /// 成功 → 打印报告,返回 `prior_code`(保留前面 leg 可能的 FAILURE);失败 → 打印该 agent 步失败 +
 /// 恢复指引(其它 agent 面互不影响),返回 FAILURE。`prior_code` 链式传递 → 任一 leg 失败则总退出码 FAILURE。
 fn run_json_agent_leg(
+    lang: Lang,
     res: Result<setup_mcp::JsonAgentApplyReport, setup::SetupError>,
     agent_name: &str,
     op: &str,
@@ -911,29 +1042,48 @@ fn run_json_agent_leg(
 ) -> std::process::ExitCode {
     match res {
         Ok(r) => {
-            print_json_agent_apply(&r, op);
+            print_json_agent_apply(lang, &r, op);
             prior_code
         }
         Err(e) => {
-            eprintln!(
-                "  [{agent_name}] the {op} step FAILED (other agent surfaces unaffected): {e}"
-            );
-            eprintln!("  Fix {agent_name}'s MCP config, then re-run the same command.");
+            match lang {
+                Lang::En => {
+                    eprintln!(
+                        "  [{agent_name}] the {op} step FAILED (other agent surfaces unaffected): {e}"
+                    );
+                    eprintln!("  Fix {agent_name}'s MCP config, then re-run the same command.");
+                }
+                Lang::Zh => {
+                    eprintln!("  [{agent_name}] {op} 步失败(其它 agent 接入面不受影响):{e}");
+                    eprintln!("  修好 {agent_name} 的 MCP 配置后,重跑同一命令。");
+                }
+            }
             std::process::ExitCode::FAILURE
         }
     }
 }
 
 /// `vigil-hub checkpoint`(ADR 0020):锚定当前审计链头到 append-only sidecar(`<ledger>.checkpoints`)。
-fn run_checkpoint(ledger: Option<PathBuf>) -> std::process::ExitCode {
+fn run_checkpoint(lang: Lang, ledger: Option<PathBuf>) -> std::process::ExitCode {
     let Some(path) = ledger.or_else(setup::default_ledger_path) else {
-        eprintln!("vigil-hub checkpoint: 无法定位审计账本(给 --ledger 或设 VIGIL_LEDGER_PATH)");
+        eprintln!(
+            "vigil-hub checkpoint: {}",
+            i18n::t(lang, i18n::Msg::LedgerNotFound)
+        );
         return std::process::ExitCode::FAILURE;
     };
     let ledger = match vigil_audit::Ledger::open(&path) {
         Ok(l) => l,
         Err(e) => {
-            eprintln!("vigil-hub checkpoint: 打开账本失败: {e}");
+            eprintln!(
+                "vigil-hub checkpoint: {}",
+                i18n::t(
+                    lang,
+                    i18n::Msg::LedgerOpenFailed {
+                        error: &e.to_string(),
+                    },
+                )
+            );
             return std::process::ExitCode::FAILURE;
         }
     };
@@ -943,34 +1093,35 @@ fn run_checkpoint(ledger: Option<PathBuf>) -> std::process::ExitCode {
             // event_hash 必为 64-hex,取前 12 仅作展示。
             let head = cp.event_hash.get(..12).unwrap_or(&cp.event_hash);
             println!(
-                "✓ anchored checkpoint at event #{} (head {head}…) → {}",
-                cp.event_id,
-                log.path().display()
+                "{}",
+                i18n::t(
+                    lang,
+                    i18n::Msg::CheckpointAnchored {
+                        event_id: cp.event_id,
+                        head,
+                        path: &log.path().display().to_string(),
+                    },
+                )
             );
-            eprintln!(
-                "  tip: keep this file append-only (chattr +a) or synced offsite, so a full-chain \
-                 rewrite can't also forge the anchor."
-            );
+            eprintln!("{}", i18n::t(lang, i18n::Msg::CheckpointTip));
             std::process::ExitCode::SUCCESS
         }
         Ok(None) => {
-            println!(
-                "nothing to anchor (ledger empty, or no new events since the last checkpoint)."
-            );
+            println!("{}", i18n::t(lang, i18n::Msg::CheckpointNothing));
             std::process::ExitCode::SUCCESS
         }
-        Err(e) => {
-            eprintln!("vigil-hub checkpoint failed: {e}");
-            std::process::ExitCode::FAILURE
-        }
+        Err(e) => fail_cmd(lang, "checkpoint", e),
     }
 }
 
 /// `vigil-hub verify`(ADR 0020):链内一致性(防篡断裂)+ checkpoint 锚点(防整链重写),三态如实输出。
 /// 任何检出的篡改/损坏 → 非零退出(可脚本化);Verified / Unanchored → 0。
-fn run_verify(ledger: Option<PathBuf>) -> std::process::ExitCode {
+fn run_verify(lang: Lang, ledger: Option<PathBuf>) -> std::process::ExitCode {
     let Some(path) = ledger.or_else(setup::default_ledger_path) else {
-        eprintln!("vigil-hub verify: 无法定位审计账本(给 --ledger 或设 VIGIL_LEDGER_PATH)");
+        eprintln!(
+            "vigil-hub verify: {}",
+            i18n::t(lang, i18n::Msg::LedgerNotFound)
+        );
         return std::process::ExitCode::FAILURE;
     };
     // verify 是**只读**审计:账本不存在时诚实报告且**绝不创建**。否则 `Ledger::open` 的 create-if-missing
@@ -978,15 +1129,28 @@ fn run_verify(ledger: Option<PathBuf>) -> std::process::ExitCode {
     // 不存在的账本"伪装成"审计有效"),还污染文件系统。存在性检查先于 open。
     if !path.exists() {
         eprintln!(
-            "vigil-hub verify: 审计账本不存在:{} —— 核对 --ledger 路径(verify 只读,不会创建账本)。",
-            path.display()
+            "vigil-hub verify: {}",
+            i18n::t(
+                lang,
+                i18n::Msg::LedgerMissingForVerify {
+                    path: &path.display().to_string(),
+                },
+            )
         );
         return std::process::ExitCode::FAILURE;
     }
     let ledger = match vigil_audit::Ledger::open(&path) {
         Ok(l) => l,
         Err(e) => {
-            eprintln!("vigil-hub verify: 打开账本失败: {e}");
+            eprintln!(
+                "vigil-hub verify: {}",
+                i18n::t(
+                    lang,
+                    i18n::Msg::LedgerOpenFailed {
+                        error: &e.to_string(),
+                    },
+                )
+            );
             return std::process::ExitCode::FAILURE;
         }
     };
@@ -997,34 +1161,63 @@ fn run_verify(ledger: Option<PathBuf>) -> std::process::ExitCode {
             through_event_id,
         }) => {
             println!(
-                "✓ chain internally valid AND anchored: {checkpoints} checkpoint(s), through event #{through_event_id}."
+                "{}",
+                i18n::t(
+                    lang,
+                    i18n::Msg::VerifyValidAnchored {
+                        checkpoints,
+                        through: through_event_id,
+                    },
+                )
             );
             // 诚实框定(ADR §3):不冒充 tamper-proof。
-            println!(
-                "  (anchor detects a DB-only full-chain rewrite while the .checkpoints file is intact \
-                 — not a tamper-proof guarantee.)"
-            );
+            println!("{}", i18n::t(lang, i18n::Msg::VerifyAnchorNote));
             std::process::ExitCode::SUCCESS
         }
         Ok(vigil_audit::Anchored::Unanchored) => {
-            println!("✓ chain internally valid; ⚠ no checkpoints found.");
-            println!(
-                "  run `vigil-hub checkpoint` to anchor against a full-chain rewrite (audit threat #7)."
-            );
+            println!("{}", i18n::t(lang, i18n::Msg::VerifyValidUnanchored));
+            println!("{}", i18n::t(lang, i18n::Msg::VerifyRunCheckpointHint));
             std::process::ExitCode::SUCCESS
         }
         Err(e) => {
             match &e {
                 vigil_audit::AuditError::ChainBroken { event_id } => eprintln!(
-                    "✗ chain BROKEN at event #{event_id} — internal tampering detected."
+                    "{}",
+                    i18n::t(
+                        lang,
+                        i18n::Msg::VerifyChainBroken {
+                            event_id: *event_id,
+                        },
+                    )
                 ),
                 vigil_audit::AuditError::CheckpointMismatch { event_id } => eprintln!(
-                    "✗ checkpoint MISMATCH at event #{event_id} — chain prefix may have been rewritten."
+                    "{}",
+                    i18n::t(
+                        lang,
+                        i18n::Msg::VerifyCheckpointMismatch {
+                            event_id: *event_id,
+                        },
+                    )
                 ),
-                vigil_audit::AuditError::CheckpointStoreCorrupt { reason } => {
-                    eprintln!("✗ checkpoint store corrupt: {reason}")
-                }
-                other => eprintln!("✗ verify failed: {other}"),
+                vigil_audit::AuditError::CheckpointStoreCorrupt { reason } => eprintln!(
+                    "{}",
+                    i18n::t(
+                        lang,
+                        i18n::Msg::VerifyStoreCorrupt {
+                            reason: reason.as_str(),
+                        },
+                    )
+                ),
+                other => eprintln!(
+                    "{}",
+                    i18n::t(
+                        lang,
+                        i18n::Msg::CommandFailed {
+                            command: "verify",
+                            error: &other.to_string(),
+                        },
+                    )
+                ),
             }
             std::process::ExitCode::FAILURE
         }
@@ -1100,7 +1293,10 @@ fn build_injection_config(
 
 /// `setup --all`:一条命令同时接入 hook + MCP 网关 wrap(兑现 download→直接保护)。
 /// `--uninstall` 撤销两者;`--dry-run` 预览两者;MCP 侧默认 monitor(`--enforce` 升级硬拦)。
-fn run_setup_all(args: &CliSetupArgs) -> Result<std::process::ExitCode, setup::SetupError> {
+fn run_setup_all(
+    lang: Lang,
+    args: &CliSetupArgs,
+) -> Result<std::process::ExitCode, setup::SetupError> {
     let home = dirs::home_dir().ok_or(setup::SetupError::MissingHomeDir)?;
     let exe = std::env::current_exe().map_err(|_| setup::SetupError::MissingCurrentExe)?;
     // ledger:`--ledger` 覆盖 → 否则默认(`VIGIL_LEDGER_PATH` / `<data 目录>/Vigil/ledger.sqlite3`)。
@@ -1127,7 +1323,7 @@ fn run_setup_all(args: &CliSetupArgs) -> Result<std::process::ExitCode, setup::S
         monitor,
     ) {
         Ok((hook_rep, mcp_rep)) => {
-            let mut code = print_setup_all(&hook_rep, &mcp_rep, op);
+            let mut code = print_setup_all(lang, &hook_rep, &mcp_rep, op);
             // 其余接入面:Codex + Cursor + Windsurf。各独立文件,hook + Claude-MCP 成功后逐一做;失败经
             // `run_*_leg` **诚实半应用报告**(不回滚已应用面 —— 各面独立、各自可逆)。op 在 dry-run 时为
             // "preview";各步只认 apply/uninstall(dry 措辞由报告里 dry_run 决定)。
@@ -1138,14 +1334,14 @@ fn run_setup_all(args: &CliSetupArgs) -> Result<std::process::ExitCode, setup::S
             } else {
                 setup_mcp::run_codex_apply(&home, &exe_str, args.dry_run, monitor)
             };
-            code = run_codex_leg(codex_res, mcp_op, code);
+            code = run_codex_leg(lang, codex_res, mcp_op, code);
             for agent in json_mcp_agents(&home) {
                 let res = if args.uninstall {
                     setup_mcp::run_json_agent_uninstall(&agent, args.dry_run)
                 } else {
                     setup_mcp::run_json_agent_apply(&agent, &exe_str, args.dry_run, monitor)
                 };
-                code = run_json_agent_leg(res, agent.display_name, mcp_op, code);
+                code = run_json_agent_leg(lang, res, agent.display_name, mcp_op, code);
             }
             // 其余 agent CLI 的 hook 注册面(Codex/Gemini/Cursor 原生工具输入侧守门),
             // 与上面 MCP wrap 面正交(hook 拦原生工具,wrap 管 MCP server)。
@@ -1158,40 +1354,69 @@ fn run_setup_all(args: &CliSetupArgs) -> Result<std::process::ExitCode, setup::S
                     dry_run: args.dry_run,
                 }
             };
-            code = run_agent_hook_legs(&ledger, hook_op, code);
+            code = run_agent_hook_legs(lang, &ledger, hook_op, code);
             Ok(code)
         }
         // hook 步就失败 → 什么都没改(hook 写盘前 gate,失败即未写):诚实"nothing changed"。
         Err(setup_mcp::AllError::Hook(e)) => {
-            eprintln!("vigil-hub setup --all: hook step failed -- nothing was changed: {e}");
+            match lang {
+                Lang::En => {
+                    eprintln!("vigil-hub setup --all: hook step failed -- nothing was changed: {e}")
+                }
+                Lang::Zh => {
+                    eprintln!("vigil-hub setup --all:第一步(注册 hook)失败 —— 未改动任何配置:{e}")
+                }
+            }
             Ok(std::process::ExitCode::FAILURE)
         }
         // hook 成功、MCP 步失败 → **半应用**:诚实告知 hook 已应用 + 如何单独撤销(Codex D13 HIGH)。
         Err(setup_mcp::AllError::McpAfterHook { hook, source }) => {
             let did = if op == "uninstall" {
                 if hook.changed {
-                    "removed"
+                    tr(lang, "removed", "已移除")
                 } else {
-                    "nothing to remove"
+                    tr(lang, "nothing to remove", "无需移除")
                 }
             } else if hook.changed {
-                "applied"
+                tr(lang, "applied", "已应用")
             } else {
-                "already up to date"
+                tr(lang, "already up to date", "已是最新")
             };
-            println!(
-                "Vigil setup --all --{op}: PARTIAL (the hook step completed, the MCP step did not)"
+            let hook_label = tr(
+                lang,
+                "hook (PreToolUse input-secret guard)",
+                "hook(PreToolUse 输入侧密钥守卫)",
             );
-            println!("  [1/2] hook (PreToolUse input-secret guard): {did}");
-            eprintln!("  [2/2] MCP gateway step FAILED: {source}");
+            match lang {
+                Lang::En => println!(
+                    "Vigil setup --all --{op}: PARTIAL (the hook step completed, the MCP step did not)"
+                ),
+                Lang::Zh => println!(
+                    "Vigil setup --all --{op}:只完成了一半(原生 hook 已装好,MCP 网关未装上 —— 当前仅 hook 在生效)"
+                ),
+            }
+            println!("  [1/2] {hook_label}: {did}");
+            match lang {
+                Lang::En => eprintln!("  [2/2] MCP gateway step FAILED: {source}"),
+                Lang::Zh => eprintln!("  [2/2] MCP 网关这一步失败:{source}"),
+            }
             if op == "uninstall" {
                 // 不声称"hook 已移除"(若 changed=false 则本就没东西可移除,会过度陈述;Codex D13 R2 nit)。
-                eprintln!("  The hook step completed (see above); MCP wrap entries may remain. Retry: vigil-hub setup --mcp --uninstall");
+                match lang {
+                    Lang::En => eprintln!("  The hook step completed (see above); MCP wrap entries may remain. Retry: vigil-hub setup --mcp --uninstall"),
+                    Lang::Zh => eprintln!("  hook 这一步已完成(见上);MCP wrap 条目可能仍在。重试:vigil-hub setup --mcp --uninstall"),
+                }
             } else {
-                eprintln!(
-                    "  The hook above IS applied. Undo just the hook with: vigil-hub setup --uninstall"
-                );
-                eprintln!("  (or fix the cause and re-run: vigil-hub setup --all)");
+                match lang {
+                    Lang::En => {
+                        eprintln!("  The hook above IS applied. Undo just the hook with: vigil-hub setup --uninstall");
+                        eprintln!("  (or fix the cause and re-run: vigil-hub setup --all)");
+                    }
+                    Lang::Zh => {
+                        eprintln!("  上面的 hook 已应用。仅撤销 hook:vigil-hub setup --uninstall");
+                        eprintln!("  (或修复原因后重跑:vigil-hub setup --all)");
+                    }
+                }
             }
             Ok(std::process::ExitCode::FAILURE)
         }
@@ -1202,6 +1427,7 @@ fn run_setup_all(args: &CliSetupArgs) -> Result<std::process::ExitCode, setup::S
 /// 中断其它面(各面独立文件、各自可逆),但最终退出码降级 FAILURE(诚实半应用,同 `run_codex_leg`
 /// 模式)。未检测到的 agent 一行说明后跳过,不为不存在的 agent 创建配置。
 fn run_agent_hook_legs(
+    lang: Lang,
     ledger: &std::path::Path,
     op: setup_hooks::AgentHookOp,
     mut code: std::process::ExitCode,
@@ -1215,53 +1441,76 @@ fn run_agent_hook_legs(
         }
     };
     println!();
-    println!("Other agent CLIs (hook registration):");
+    println!(
+        "{}",
+        tr(
+            lang,
+            "Other agent CLIs (hook registration):",
+            "其它 agent CLI(hook 注册):",
+        )
+    );
     for spec in setup_hooks::all_agent_specs(&home) {
         let display = spec.display_name;
         match setup_hooks::run_agent_hook(&spec, &exe, ledger, op) {
             Ok(rep) => {
                 if !rep.detected {
-                    println!("  {display}: not detected -- skipped");
+                    println!(
+                        "  {display}: {}",
+                        tr(lang, "not detected -- skipped", "未检测到 —— 已跳过")
+                    );
                     continue;
                 }
                 use setup::ProtectionState;
                 let verdict = match op {
                     setup_hooks::AgentHookOp::Status => match rep.state {
-                        ProtectionState::Active => "ACTIVE".to_string(),
-                        ProtectionState::Stale => {
-                            "INSTALLED but STALE (re-run `vigil-hub setup` to refresh)".to_string()
+                        ProtectionState::Active => tr(lang, "ACTIVE", "已激活(ACTIVE)").to_string(),
+                        ProtectionState::Stale => tr(
+                            lang,
+                            "INSTALLED but STALE (re-run `vigil-hub setup` to refresh)",
+                            "已安装但已失效(重跑 `vigil-hub setup` 刷新)",
+                        )
+                        .to_string(),
+                        ProtectionState::NotInstalled => {
+                            tr(lang, "not installed", "未安装").to_string()
                         }
-                        ProtectionState::NotInstalled => "not installed".to_string(),
                     },
                     setup_hooks::AgentHookOp::Install { dry_run } => {
                         let did = if !rep.changed {
-                            "already up to date"
+                            tr(lang, "already up to date", "已是最新")
                         } else if dry_run {
-                            "[dry-run] would register hook"
+                            tr(
+                                lang,
+                                "[dry-run] would register hook",
+                                "[dry-run] 将注册 hook",
+                            )
                         } else {
-                            "hook registered"
+                            tr(lang, "hook registered", "已注册 hook")
                         };
                         format!("{did} ({})", rep.config_path.display())
                     }
                     setup_hooks::AgentHookOp::Uninstall { dry_run } => {
                         let did = if !rep.changed {
-                            "nothing to remove"
+                            tr(lang, "nothing to remove", "无需移除")
                         } else if dry_run {
-                            "[dry-run] would remove Vigil hook"
+                            tr(
+                                lang,
+                                "[dry-run] would remove Vigil hook",
+                                "[dry-run] 将移除 Vigil hook",
+                            )
                         } else {
-                            "Vigil hook removed"
+                            tr(lang, "Vigil hook removed", "已移除 Vigil hook")
                         };
                         format!("{did} ({})", rep.config_path.display())
                     }
                 };
                 println!("  {display}: {verdict}");
                 for w in &rep.warnings {
-                    println!("    WARNING: {w}");
+                    println!("    {}{w}", tr(lang, "WARNING: ", "警告:"));
                 }
             }
             Err(e) => {
                 // 单面失败:诚实报告 + 继续其它面(各面独立);退出码降级让脚本可感知。
-                eprintln!("  {display}: FAILED -- {e}");
+                eprintln!("  {display}: {} {e}", tr(lang, "FAILED --", "失败 ——"));
                 code = std::process::ExitCode::FAILURE;
             }
         }
@@ -1271,60 +1520,120 @@ fn run_agent_hook_legs(
 
 /// 打印 `setup --all` 合并报告(ASCII-safe)。两段(hook / mcp)各自诚实陈述 + 末尾下一步。
 fn print_setup_all(
+    lang: Lang,
     hook: &setup::SetupReport,
     mcp: &setup_mcp::McpApplyReport,
     op: &str,
 ) -> std::process::ExitCode {
     let dry = if hook.dry_run { " (dry-run)" } else { "" };
-    println!("Vigil setup --all --{op}{dry}: native-tool hook + MCP gateway in one step");
+    match lang {
+        Lang::En => {
+            println!("Vigil setup --all --{op}{dry}: native-tool hook + MCP gateway in one step")
+        }
+        Lang::Zh => {
+            println!("Vigil setup --all --{op}{dry}:原生工具 hook + MCP 网关一步到位")
+        }
+    }
 
     // [1/2] hook(原生工具输入侧 secret 拦截)
+    let hook_label = tr(
+        lang,
+        "hook (PreToolUse input-secret guard)",
+        "hook(PreToolUse 输入侧密钥守卫)",
+    );
     if !hook.claude_detected {
-        println!(
-            "  [1/2] hook: Claude Code not detected (claude not on PATH; neither ~/.claude nor ~/.claude.json found) -- hook step skipped"
-        );
+        match lang {
+            Lang::En => println!(
+                "  [1/2] hook: Claude Code not detected (claude not on PATH; neither ~/.claude nor ~/.claude.json found) -- hook step skipped"
+            ),
+            Lang::Zh => println!(
+                "  [1/2] hook:未检测到 Claude Code(claude 不在 PATH;~/.claude 与 ~/.claude.json 都不存在)—— 跳过 hook 步"
+            ),
+        }
     } else if op == "uninstall" {
         let did = if hook.changed {
-            "removed"
+            tr(lang, "removed", "已移除")
         } else {
-            "nothing to remove"
+            tr(lang, "nothing to remove", "无需移除")
         };
-        println!("  [1/2] hook (PreToolUse input-secret guard): {did}");
+        println!("  [1/2] {hook_label}: {did}");
     } else {
         let did = if hook.changed {
-            "registered"
+            tr(lang, "registered", "已注册")
         } else {
-            "already up to date"
+            tr(lang, "already up to date", "已是最新")
         };
-        println!("  [1/2] hook (PreToolUse input-secret guard): {did}");
+        println!("  [1/2] {hook_label}: {did}");
     }
 
     // [2/2] MCP 网关 wrap(脱敏 + 审计 + 审批 + descriptor pin)
     let total = mcp.total_changed();
-    let verb = if op == "uninstall" {
-        "restored"
-    } else {
-        "wrapped"
-    };
-    println!("  [2/2] MCP gateway: {verb} {total} server(s)");
+    match lang {
+        Lang::En => {
+            let verb = if op == "uninstall" {
+                "restored"
+            } else {
+                "wrapped"
+            };
+            println!("  [2/2] MCP gateway: {verb} {total} server(s)");
+        }
+        Lang::Zh => {
+            let verb = if op == "uninstall" {
+                "已还原"
+            } else {
+                "已防护"
+            };
+            println!("  [2/2] MCP 网关:{verb} {total} 个服务器");
+        }
+    }
     if mcp.local_skipped > 0 {
-        println!(
-            "        NOTE: {} local-scope server(s) left unprotected (--user-scope-only).",
-            mcp.local_skipped
-        );
+        match lang {
+            Lang::En => println!(
+                "        NOTE: {} local-scope server(s) left unprotected (--user-scope-only).",
+                mcp.local_skipped
+            ),
+            Lang::Zh => println!(
+                "        注意:有 {} 个项目级(local scope)服务器未受保护(--user-scope-only)。",
+                mcp.local_skipped
+            ),
+        }
     }
 
     // 下一步 / 撤销
     println!();
     if op == "preview" {
-        println!("  Preview only -- nothing written. Apply with: vigil-hub setup --all");
-    } else if op == "uninstall" {
-        println!("  Vigil protection removed (hook + MCP gateway). Restart your agent.");
-    } else {
         println!(
-            "  Protected. Restart your agent to activate. Confirm: vigil-hub setup --status  ·  See what Vigil catches: vigil-hub demo"
+            "  {}",
+            tr(
+                lang,
+                "Preview only -- nothing written. Apply with: vigil-hub setup --all",
+                "仅预览 —— 未写任何东西。应用:vigil-hub setup --all",
+            )
         );
-        println!("  Undo everything with: vigil-hub setup --all --uninstall");
+    } else if op == "uninstall" {
+        println!(
+            "  {}",
+            tr(
+                lang,
+                "Vigil protection removed (hook + MCP gateway). Restart your agent.",
+                "已移除 Vigil 防护(hook + MCP 网关)。请重启你的 agent。",
+            )
+        );
+    } else {
+        match lang {
+            Lang::En => {
+                println!(
+                    "  Protected. Restart your agent to activate. Confirm: vigil-hub setup --status  ·  See what Vigil catches: vigil-hub demo"
+                );
+                println!("  Undo everything with: vigil-hub setup --all --uninstall");
+            }
+            Lang::Zh => {
+                println!(
+                    "  已保护。重启 agent 使其生效。确认:vigil-hub setup --status  ·  看 Vigil 能拦什么:vigil-hub demo"
+                );
+                println!("  全部撤销:vigil-hub setup --all --uninstall");
+            }
+        }
     }
     std::process::ExitCode::SUCCESS
 }
@@ -1336,22 +1645,48 @@ fn print_setup_all(
 /// (SSOT);但若 agent 启动 `vigil-hub wrap` 的 PATH 与此不同,verdict 可能偏差 → 文案明示"在本环境"。
 /// **hygiene**(Codex D12 nit):所有展示字段(name/scope/program/resolved)过 `scrub_text` 再输出 ——
 /// argv[0]/路径通常无 secret,但纵深防御统一遵守"绝不把可能含敏感串的值原样进 UI/日志"(与 preview 一致)。
-fn print_mcp_doctor(rows: &[setup_mcp::McpDoctorRow]) -> std::process::ExitCode {
+fn print_mcp_doctor(lang: Lang, rows: &[setup_mcp::McpDoctorRow]) -> std::process::ExitCode {
     use setup_mcp::{DoctorStatus, ProbeOutcome};
     let scrub = vigil_redaction::scrub_text;
     // 是否处于深度探测档(任一行带 probe 结果)—— 决定表头/表尾措辞与失败语义。
     let probing = rows.iter().any(|r| r.probe.is_some());
-    println!("Vigil setup --mcp --doctor: can each MCP server's program be launched in THIS environment?");
-    println!("  (resolves argv[0] in the current PATH, exactly as the gateway does at spawn time)");
+    match lang {
+        Lang::En => {
+            println!("Vigil setup --mcp --doctor: can each MCP server's program be launched in THIS environment?");
+            println!("  (resolves argv[0] in the current PATH, exactly as the gateway does at spawn time)");
+        }
+        Lang::Zh => {
+            println!("Vigil setup --mcp --doctor:每个 MCP 服务器的程序在**当前环境**能否启动?");
+            println!(
+                "  (按当前 PATH 查找每个服务器的启动命令,和 Vigil 实际拉起它们时的查找方式一致)"
+            );
+        }
+    }
     if probing {
         // Codex D18 R2 Low:probe 会真执行每个 server 的启动代码 —— 在动手前明确告知(非仅 help 文案)。
-        println!("  --probe: WARNING — this briefly STARTS each configured server (runs its startup code)");
-        println!("           to complete a real MCP initialize handshake, then stops it. Direct child is killed;");
-        println!("           a misbehaving npx/uvx grandchild may survive briefly.");
+        match lang {
+            Lang::En => {
+                println!("  --probe: WARNING — this briefly STARTS each configured server (runs its startup code)");
+                println!("           to complete a real MCP initialize handshake, then stops it. Direct child is killed;");
+                println!("           a misbehaving npx/uvx grandchild may survive briefly.");
+            }
+            Lang::Zh => {
+                println!("  --probe:警告 —— 这会短暂启动每个已配置的服务器(执行其启动代码)");
+                println!(
+                    "           以完成一次真实的 MCP initialize 握手,随后停止它。直接子进程会被杀;"
+                );
+                println!("           行为异常的 npx/uvx 孙进程可能短暂存活。");
+            }
+        }
     }
     if rows.is_empty() {
         println!(
-            "  No MCP servers found across Claude / Codex / Cursor / Windsurf (nothing to check)."
+            "  {}",
+            tr(
+                lang,
+                "No MCP servers found across Claude / Codex / Cursor / Windsurf (nothing to check).",
+                "Claude / Codex / Cursor / Windsurf 均未找到 MCP 服务器(无需检查)。",
+            )
         );
         return std::process::ExitCode::SUCCESS;
     }
@@ -1376,32 +1711,55 @@ fn print_mcp_doctor(rows: &[setup_mcp::McpDoctorRow]) -> std::process::ExitCode 
                 );
                 // 深度探测结果(--probe):静态可解析但运行时起不来 = 真失败(agent 会零工具)。
                 match &r.probe {
-                    Some(ProbeOutcome::Initialized) => {
-                        // 措辞:probe 验的是**底层 server** 能起 + 说 MCP;对 vigil-wrapped 条目,真实
-                        // 网关启动还会额外强制 descriptor drift gate,故不等同"agent 一定见到工具"(Codex R2 M3)。
-                        println!("           probe: the underlying server initialized OK (started + MCP handshake succeeded)");
-                    }
+                    // 措辞:probe 验的是**底层 server** 能起 + 说 MCP;对 vigil-wrapped 条目,真实
+                    // 网关启动还会额外强制 descriptor drift gate,故不等同"agent 一定见到工具"(Codex R2 M3)。
+                    Some(ProbeOutcome::Initialized) => match lang {
+                        Lang::En => println!("           probe: the underlying server initialized OK (started + MCP handshake succeeded)"),
+                        Lang::Zh => println!("           probe:底层服务器初始化成功(已启动 + MCP 握手成功)"),
+                    },
                     Some(ProbeOutcome::Failed { reason }) => {
                         failed += 1;
                         // reason 已在 setup_mcp 侧 value-aware 脱敏 + scrub;此处直接展示。
-                        println!("           probe: FAILED to initialize: {reason}");
-                        println!("           -> the program runs but did not complete an MCP handshake; your agent will see no tools from it.");
-                        println!("           -> if it's an npx/uvx server on first run, packages may still be downloading; re-run --probe once warm.");
+                        match lang {
+                            Lang::En => {
+                                println!("           probe: FAILED to initialize: {reason}");
+                                println!("           -> the program runs but did not complete an MCP handshake; your agent will see no tools from it.");
+                                println!("           -> if it's an npx/uvx server on first run, packages may still be downloading; re-run --probe once warm.");
+                            }
+                            Lang::Zh => {
+                                println!("           probe:初始化失败:{reason}");
+                                println!("           -> 程序能跑,但没完成 MCP 握手;你的 agent 会看不到它的任何工具。");
+                                println!("           -> 若是首次运行的 npx/uvx 服务器,包可能还在下载;暖缓存后重跑 --probe。");
+                            }
+                        }
                     }
                     None => {}
                 }
             }
             DoctorStatus::ProgramNotFound { program } => {
                 failed += 1;
-                println!(
-                    "  [FAIL] {name} ({scope}){guard}: program `{}` not found in PATH",
-                    scrub(program)
-                );
+                match lang {
+                    Lang::En => println!(
+                        "  [FAIL] {name} ({scope}){guard}: program `{}` not found in PATH",
+                        scrub(program)
+                    ),
+                    Lang::Zh => println!(
+                        "  [FAIL] {name} ({scope}){guard}:程序 `{}` 不在 PATH 中",
+                        scrub(program)
+                    ),
+                }
                 // 可操作提示:最常见两类运行时。
-                let hint = match program.as_str() {
-                    "npx" | "node" => "  -> install Node.js (npx/node), then restart your agent",
-                    "uvx" | "uv" => "  -> install uv (uvx/uv), then restart your agent",
-                    _ => "  -> install this program or fix its PATH, then restart your agent",
+                let hint = match (lang, program.as_str()) {
+                    (Lang::En, "npx" | "node") => {
+                        "  -> install Node.js (npx/node), then restart your agent"
+                    }
+                    (Lang::En, "uvx" | "uv") => "  -> install uv (uvx/uv), then restart your agent",
+                    (Lang::En, _) => {
+                        "  -> install this program or fix its PATH, then restart your agent"
+                    }
+                    (Lang::Zh, "npx" | "node") => "  -> 安装 Node.js(npx/node),然后重启你的 agent",
+                    (Lang::Zh, "uvx" | "uv") => "  -> 安装 uv(uvx/uv),然后重启你的 agent",
+                    (Lang::Zh, _) => "  -> 安装该程序或修好它的 PATH,然后重启你的 agent",
                 };
                 println!("{hint}");
             }
@@ -1411,9 +1769,14 @@ fn print_mcp_doctor(rows: &[setup_mcp::McpDoctorRow]) -> std::process::ExitCode 
             }
             DoctorStatus::Malformed => {
                 failed += 1;
-                println!(
-                    "  [FAIL] {name} ({scope}){guard}: Vigil-managed entry is malformed (cannot determine the underlying program)"
-                );
+                match lang {
+                    Lang::En => println!(
+                        "  [FAIL] {name} ({scope}){guard}: Vigil-managed entry is malformed (cannot determine the underlying program)"
+                    ),
+                    Lang::Zh => println!(
+                        "  [FAIL] {name} ({scope}){guard}:Vigil 托管条目格式损坏(无法确定底层程序)"
+                    ),
+                }
             }
             // 整个 agent 配置坏了(malformed / 读不了)→ 计入失败(server 可能存在却对 doctor 不可见;
             // doctor 不能因此谎称"全部正常")。reason 含路径 → scrub(Codex D29 #5/#6/#8)。
@@ -1425,64 +1788,127 @@ fn print_mcp_doctor(rows: &[setup_mcp::McpDoctorRow]) -> std::process::ExitCode 
     }
     println!();
     if failed == 0 {
-        if probing {
-            println!(
-                "  All checked servers resolve AND their underlying program completes an MCP handshake here."
-            );
-            // Codex R2 M3:probe 验底层 server;对已 vigil-wrapped 条目,真实网关启动还会强制 descriptor
-            // drift gate(probe 刻意不走、不改状态),故 probe OK 不等同"agent 一定见到工具"。
-            println!("  (probe checks the underlying server; for vigil-wrapped entries the live gateway also enforces descriptor drift.)");
-        } else {
-            println!("  All checked servers resolve in this environment.");
+        match lang {
+            Lang::En => {
+                if probing {
+                    println!("  All checked servers resolve AND their underlying program completes an MCP handshake here.");
+                    println!("  (probe checks the underlying server; for vigil-wrapped entries the live gateway also enforces descriptor drift.)");
+                } else {
+                    println!("  All checked servers resolve in this environment.");
+                }
+                println!(
+                    "  Note: your agent must launch vigil-hub with the same PATH for this to hold."
+                );
+            }
+            Lang::Zh => {
+                if probing {
+                    println!("  所有被检查的服务器都能解析,且其底层程序在此都能完成 MCP 握手。");
+                    println!("  (probe 验的是底层服务器;对 vigil-wrapped 条目,真实网关启动还会强制 descriptor drift。)");
+                } else {
+                    println!("  所有被检查的服务器在此环境都能解析。");
+                }
+                println!("  注意:你的 agent 必须用相同的 PATH 启动 vigil-hub,本结论才成立。");
+            }
         }
-        println!("  Note: your agent must launch vigil-hub with the same PATH for this to hold.");
         std::process::ExitCode::SUCCESS
     } else {
-        let what = if probing {
-            "will not start / initialize"
-        } else {
-            "will not start"
-        };
-        println!(
-            "  {failed} server(s) {what} in this environment. Fix the above, then re-run --doctor."
-        );
+        match lang {
+            Lang::En => {
+                let what = if probing {
+                    "will not start / initialize"
+                } else {
+                    "will not start"
+                };
+                println!(
+                    "  {failed} server(s) {what} in this environment. Fix the above, then re-run --doctor."
+                );
+            }
+            Lang::Zh => {
+                let what = if probing {
+                    "无法启动 / 初始化"
+                } else {
+                    "无法启动"
+                };
+                println!("  有 {failed} 个服务器在此环境{what}。修好上面的问题后,重跑 --doctor。");
+            }
+        }
         std::process::ExitCode::from(1)
     }
 }
 
 /// 打印 `setup --mcp --apply/--uninstall` 结果(ASCII-safe)。
-fn print_mcp_apply(r: &setup_mcp::McpApplyReport, op: &str) -> std::process::ExitCode {
+fn print_mcp_apply(lang: Lang, r: &setup_mcp::McpApplyReport, op: &str) -> std::process::ExitCode {
     let dry = if r.dry_run { " (dry-run)" } else { "" };
-    let verb = if r.dry_run { "would" } else { "did" };
-    let what = if op == "uninstall" { "restore" } else { "wrap" };
+    let verb = match (lang, r.dry_run) {
+        (Lang::En, true) => "would",
+        (Lang::En, false) => "did",
+        (Lang::Zh, true) => "将",
+        (Lang::Zh, false) => "已",
+    };
+    let what = match (lang, op == "uninstall") {
+        (Lang::En, true) => "restore",
+        (Lang::En, false) => "wrap",
+        (Lang::Zh, true) => "还原",
+        (Lang::Zh, false) => "防护",
+    };
     let total = r.total_changed();
-    println!(
-        "Vigil setup --mcp --{op}{dry}: {verb} {what} {total} MCP server(s) in {}",
-        r.claude_json.display()
-    );
+    match lang {
+        Lang::En => println!(
+            "Vigil setup --mcp --{op}{dry}: {verb} {what} {total} MCP server(s) in {}",
+            r.claude_json.display()
+        ),
+        Lang::Zh => println!(
+            "Vigil setup --mcp --{op}{dry}:{verb}{what} {total} 个 MCP 服务器,改动写入配置文件 {}",
+            r.claude_json.display()
+        ),
+    }
     // 分 scope 报告:local scope(projects.*)用**项目限定 server-id**(跨项目同名不串账本)。
     if r.local_changed > 0 {
-        println!(
-            "  ({} user-scope + {} local-scope/per-project)",
-            r.changed, r.local_changed
-        );
+        match lang {
+            Lang::En => println!(
+                "  ({} user-scope + {} local-scope/per-project)",
+                r.changed, r.local_changed
+            ),
+            Lang::Zh => println!(
+                "  (其中 {} 个用户级、{} 个项目级)",
+                r.changed, r.local_changed
+            ),
+        }
     }
     if let Some(b) = &r.backup {
-        println!("  backup of the previous config: {}", b.display());
+        println!(
+            "  {}{}",
+            tr(lang, "backup of the previous config: ", "原配置备份:"),
+            b.display()
+        );
     }
     if total == 0 && !r.dry_run {
-        println!("  (nothing to {what} -- no matching servers)");
+        match lang {
+            Lang::En => println!("  (nothing to {what} -- no matching servers)"),
+            Lang::Zh => println!("  (无需{what} —— 无匹配服务器)"),
+        }
     }
     // `--user-scope-only` 跳过了可保护的 local scope server → 诚实提示它们仍未受保护。
     if r.local_skipped > 0 {
-        println!(
-            "  NOTE: {} local-scope (per-project) MCP server(s) left UNPROTECTED (--user-scope-only).",
-            r.local_skipped
-        );
+        match lang {
+            Lang::En => println!(
+                "  NOTE: {} local-scope (per-project) MCP server(s) left UNPROTECTED (--user-scope-only).",
+                r.local_skipped
+            ),
+            Lang::Zh => println!(
+                "  注意:有 {} 个项目级(local scope)MCP 服务器未受保护(--user-scope-only)。",
+                r.local_skipped
+            ),
+        }
     }
     if op == "apply" && total > 0 && !r.dry_run {
         println!(
-            "  Restart Claude Code to pick up the change. Undo with: vigil-hub setup --mcp --uninstall"
+            "  {}",
+            tr(
+                lang,
+                "Restart Claude Code to pick up the change. Undo with: vigil-hub setup --mcp --uninstall",
+                "重启 Claude Code 使改动生效。撤销:vigil-hub setup --mcp --uninstall",
+            )
         );
     }
     std::process::ExitCode::SUCCESS
@@ -1492,6 +1918,7 @@ fn print_mcp_apply(r: &setup_mcp::McpApplyReport, op: &str) -> std::process::Exi
 /// 渲染单个 server 分类的预览行(user / local / Codex scope 各调一次)。`derive_id` 由调用方注入
 /// scope 专属的 server-id 派生(user-/local-/codex-,disjoint 命名空间),让 WRAP 渲染逻辑单一真源。
 fn print_mcp_server_preview(
+    lang: Lang,
     exe: &str,
     derive_id: impl Fn(&str) -> String,
     class: &McpServerClass,
@@ -1512,62 +1939,117 @@ fn print_mcp_server_preview(
             // 再展示,守"secrets 绝不进 UI/日志"不变量(Codex setup_mcp review hygiene)。
             let from_disp = vigil_redaction::scrub_text(&format!("{} {}", command, args.join(" ")));
             let to_disp = vigil_redaction::scrub_text(&argv.join(" "));
-            println!("         from: {from_disp}");
-            println!("         to:   {to_disp}");
+            println!("         {}{from_disp}", tr(lang, "from: ", "原: "));
+            println!("         {}{to_disp}", tr(lang, "to:   ", "改: "));
             if !env_keys.is_empty() {
                 println!(
-                    "         env (key-only, values never copied): {}",
+                    "         {}{}",
+                    tr(
+                        lang,
+                        "env (key-only, values never copied): ",
+                        "env(仅键名,绝不复制值):",
+                    ),
                     env_keys.join(", ")
                 );
             }
         }
         McpServerClass::AlreadyWrapped { name } => {
-            println!("  [OK]   {name} -- already Vigil-managed (skipped)");
+            println!(
+                "  [OK]   {name} {}",
+                tr(
+                    lang,
+                    "-- already Vigil-managed (skipped)",
+                    "—— 已是 Vigil 托管(跳过)",
+                )
+            );
         }
         McpServerClass::Skipped { name, reason } => {
+            // reason 是 setup_mcp 产出的英文分类码(如 non-stdio),保持原样。
             println!("  [SKIP] {name} -- {reason}");
         }
     }
 }
 
-fn print_mcp_preview(r: &setup_mcp::McpPreviewReport) -> std::process::ExitCode {
-    println!("Vigil setup --mcp (PREVIEW ONLY -- nothing is changed)");
-    println!("  Claude Code config: {}", r.claude_json.display());
+fn print_mcp_preview(lang: Lang, r: &setup_mcp::McpPreviewReport) -> std::process::ExitCode {
+    println!(
+        "{}",
+        tr(
+            lang,
+            "Vigil setup --mcp (PREVIEW ONLY -- nothing is changed)",
+            "Vigil setup --mcp(仅预览 —— 不改动任何东西)",
+        )
+    );
+    println!(
+        "  {}{}",
+        tr(lang, "Claude Code config: ", "Claude Code 配置:"),
+        r.claude_json.display()
+    );
     if !r.exists {
         println!(
-            "  (no ~/.claude.json found -- Claude Code not configured, or no MCP servers yet)"
+            "  {}",
+            tr(
+                lang,
+                "(no ~/.claude.json found -- Claude Code not configured, or no MCP servers yet)",
+                "(未找到 ~/.claude.json —— Claude Code 未配置,或尚无 MCP 服务器)",
+            )
         );
         return std::process::ExitCode::SUCCESS;
     }
     println!("  vigil-hub: {}", r.exe);
     println!();
     if r.servers.is_empty() && r.local_servers.is_empty() {
-        println!("  No MCP servers found (user scope or per-project local scope).");
+        println!(
+            "  {}",
+            tr(
+                lang,
+                "No MCP servers found (user scope or per-project local scope).",
+                "未找到 MCP 服务器(用户级 user 或各项目本地 local 都没有)。",
+            )
+        );
         return std::process::ExitCode::SUCCESS;
     }
     // user scope(顶层 mcpServers)
     if !r.servers.is_empty() {
-        println!(
-            "  User scope (top-level mcpServers) -- {} can be protected:",
-            r.wrappable_count()
-        );
+        match lang {
+            Lang::En => println!(
+                "  User scope (top-level mcpServers) -- {} can be protected:",
+                r.wrappable_count()
+            ),
+            Lang::Zh => println!(
+                "  User scope(顶层 mcpServers)—— {} 个可保护:",
+                r.wrappable_count()
+            ),
+        }
         for s in &r.servers {
-            print_mcp_server_preview(&r.exe, setup_mcp::user_scope_server_id, s, r.monitor);
+            print_mcp_server_preview(lang, &r.exe, setup_mcp::user_scope_server_id, s, r.monitor);
         }
     }
     // local scope(projects.<path>.mcpServers)—— claude mcp add 默认写这里
     if !r.local_servers.is_empty() {
         println!();
-        println!(
-            "  Local scope (per-project mcpServers) -- {} can be protected:",
-            r.local_wrappable_count()
-        );
-        println!(
-            "  (wrapped with a project-scoped server-id so same-named servers across projects"
-        );
-        println!("   don't share audit/approval identity)");
+        match lang {
+            Lang::En => {
+                println!(
+                    "  Local scope (per-project mcpServers) -- {} can be protected:",
+                    r.local_wrappable_count()
+                );
+                println!(
+                    "  (wrapped with a project-scoped server-id so same-named servers across projects"
+                );
+                println!("   don't share audit/approval identity)");
+            }
+            Lang::Zh => {
+                println!(
+                    "  Local scope(按项目 mcpServers)—— {} 个可保护:",
+                    r.local_wrappable_count()
+                );
+                println!("  (用项目限定的 server-id 防护,使跨项目的同名服务器");
+                println!("   不共享审计 / 审批身份)");
+            }
+        }
         for (proj, s) in &r.local_servers {
             print_mcp_server_preview(
+                lang,
                 &r.exe,
                 |n| setup_mcp::local_scope_server_id(proj, n),
                 s,
@@ -1578,131 +2060,267 @@ fn print_mcp_preview(r: &setup_mcp::McpPreviewReport) -> std::process::ExitCode 
     println!();
     // 姿态提示反映将落盘的真实姿态(默认 monitor;`--enforce` 升级硬拦)。
     if r.monitor {
-        println!("  Default posture: MONITOR (servers stay usable; result redaction + raw-secret");
-        println!(
-            "  block + tamper-evident audit always on; add --enforce for default-deny gating)."
-        );
+        match lang {
+            Lang::En => {
+                println!(
+                    "  Default posture: MONITOR (servers stay usable; result redaction + raw-secret"
+                );
+                println!(
+                    "  block + tamper-evident audit always on; add --enforce for default-deny gating)."
+                );
+            }
+            Lang::Zh => {
+                println!("  默认姿态:MONITOR 观察模式(服务器保持可用;结果脱敏 + 明文密钥拦截");
+                println!("  + 防篡改审计始终开启;加 --enforce 可改用「默认拒绝放行」的严格模式)。");
+            }
+        }
     } else {
-        println!("  Posture: ENFORCE (default-deny; third-party tools without known effects are");
-        println!(
-            "  blocked -- use only for known/self-built servers). Omit --enforce for monitor."
-        );
+        match lang {
+            Lang::En => {
+                println!(
+                    "  Posture: ENFORCE (default-deny; third-party tools without known effects are"
+                );
+                println!(
+                    "  blocked -- use only for known/self-built servers). Omit --enforce for monitor."
+                );
+            }
+            Lang::Zh => {
+                println!("  姿态:ENFORCE 严格模式(默认拒绝放行;Vigil 识别不出用途的第三方工具会被");
+                println!(
+                    "  一律拦截 —— 仅建议用于你了解或自建的服务器)。省略 --enforce 即观察模式。"
+                );
+            }
+        }
+    }
+    match lang {
+        Lang::En => println!(
+            "  Apply with:  vigil-hub setup --mcp --apply{}",
+            if r.monitor { "" } else { " --enforce" }
+        ),
+        Lang::Zh => println!(
+            "  应用:  vigil-hub setup --mcp --apply{}",
+            if r.monitor { "" } else { " --enforce" }
+        ),
     }
     println!(
-        "  Apply with:  vigil-hub setup --mcp --apply{}",
-        if r.monitor { "" } else { " --enforce" }
-    );
-    println!(
-        "  (protects user + local scope; --user-scope-only skips local; --uninstall reverts)."
+        "  {}",
+        tr(
+            lang,
+            "(protects user + local scope; --user-scope-only skips local; --uninstall reverts).",
+            "(同时保护用户级与项目级;--user-scope-only 只跳过项目级;--uninstall 还原)。",
+        )
     );
     std::process::ExitCode::SUCCESS
 }
 
 /// 打印 Codex 接入面只读预览(ASCII-safe)。附在 Claude 预览之后,作为第二个受保护配置面。
 /// 复用 [`print_mcp_server_preview`](注入 `codex-` server-id 派生),WRAP 渲染单一真源。
-fn print_codex_preview(r: &setup_mcp::CodexPreviewReport) {
+fn print_codex_preview(lang: Lang, r: &setup_mcp::CodexPreviewReport) {
     println!();
-    println!("  Codex CLI config: {}", r.codex_config.display());
+    println!(
+        "  {}{}",
+        tr(lang, "Codex CLI config: ", "Codex CLI 配置:"),
+        r.codex_config.display()
+    );
     if !r.exists {
         println!(
-            "  (no ~/.codex/config.toml found -- Codex not configured, or no MCP servers yet)"
+            "  {}",
+            tr(
+                lang,
+                "(no ~/.codex/config.toml found -- Codex not configured, or no MCP servers yet)",
+                "(未找到 ~/.codex/config.toml —— Codex 未配置,或尚无 MCP 服务器)",
+            )
         );
         return;
     }
     if r.servers.is_empty() {
-        println!("  No MCP servers found in Codex [mcp_servers].");
+        println!(
+            "  {}",
+            tr(
+                lang,
+                "No MCP servers found in Codex [mcp_servers].",
+                "Codex [mcp_servers] 中未找到 MCP 服务器。",
+            )
+        );
         return;
     }
-    println!(
-        "  Codex scope ([mcp_servers]) -- {} can be protected:",
-        r.wrappable_count()
-    );
+    match lang {
+        Lang::En => println!(
+            "  Codex scope ([mcp_servers]) -- {} can be protected:",
+            r.wrappable_count()
+        ),
+        Lang::Zh => println!(
+            "  Codex scope([mcp_servers])—— {} 个可保护:",
+            r.wrappable_count()
+        ),
+    }
     for s in &r.servers {
-        print_mcp_server_preview(&r.exe, setup_mcp::codex_scope_server_id, s, r.monitor);
+        print_mcp_server_preview(lang, &r.exe, setup_mcp::codex_scope_server_id, s, r.monitor);
     }
 }
 
 /// 打印 Codex 接入面 apply/uninstall 结果(ASCII-safe)。附在 Claude 结果之后。
-fn print_codex_apply(r: &setup_mcp::CodexApplyReport, op: &str) {
+fn print_codex_apply(lang: Lang, r: &setup_mcp::CodexApplyReport, op: &str) {
     let dry = if r.dry_run { " (dry-run)" } else { "" };
-    let verb = if r.dry_run { "would" } else { "did" };
-    let what = if op == "uninstall" { "restore" } else { "wrap" };
-    println!(
-        "Vigil setup --mcp --{op}{dry} (Codex): {verb} {what} {} MCP server(s) in {}",
-        r.changed,
-        r.codex_config.display()
-    );
+    let verb = match (lang, r.dry_run) {
+        (Lang::En, true) => "would",
+        (Lang::En, false) => "did",
+        (Lang::Zh, true) => "将",
+        (Lang::Zh, false) => "已",
+    };
+    let what = match (lang, op == "uninstall") {
+        (Lang::En, true) => "restore",
+        (Lang::En, false) => "wrap",
+        (Lang::Zh, true) => "还原",
+        (Lang::Zh, false) => "防护",
+    };
+    match lang {
+        Lang::En => println!(
+            "Vigil setup --mcp --{op}{dry} (Codex): {verb} {what} {} MCP server(s) in {}",
+            r.changed,
+            r.codex_config.display()
+        ),
+        Lang::Zh => println!(
+            "Vigil setup --mcp --{op}{dry}(Codex):{verb}{what} {} 个 MCP 服务器,改动写入配置文件 {}",
+            r.changed,
+            r.codex_config.display()
+        ),
+    }
     if let Some(b) = &r.backup {
-        println!("  backup of the previous config: {}", b.display());
+        println!(
+            "  {}{}",
+            tr(lang, "backup of the previous config: ", "原配置备份:"),
+            b.display()
+        );
     }
     if r.changed == 0 && !r.dry_run {
-        println!("  (nothing to {what} in Codex -- no matching servers)");
+        match lang {
+            Lang::En => println!("  (nothing to {what} in Codex -- no matching servers)"),
+            Lang::Zh => println!("  (Codex 中无需{what} —— 无匹配服务器)"),
+        }
     }
     if op == "apply" && r.changed > 0 && !r.dry_run {
         println!(
-            "  Restart Codex to pick up the change. Undo with: vigil-hub setup --mcp --uninstall"
+            "  {}",
+            tr(
+                lang,
+                "Restart Codex to pick up the change. Undo with: vigil-hub setup --mcp --uninstall",
+                "重启 Codex 使改动生效。撤销:vigil-hub setup --mcp --uninstall",
+            )
         );
     }
 }
 
 /// 打印 JSON-agent 接入面(Cursor / Windsurf)只读预览(ASCII-safe)。附在前面各面预览之后。
 /// 复用 [`print_mcp_server_preview`](注入 `<prefix>-` server-id 派生,与 apply 真改写一致)。
-fn print_json_agent_preview(r: &setup_mcp::JsonAgentPreviewReport) {
+fn print_json_agent_preview(lang: Lang, r: &setup_mcp::JsonAgentPreviewReport) {
     println!();
-    println!("  {} config: {}", r.display_name, r.config_path.display());
+    match lang {
+        Lang::En => println!("  {} config: {}", r.display_name, r.config_path.display()),
+        Lang::Zh => println!("  {} 配置:{}", r.display_name, r.config_path.display()),
+    }
     if !r.exists {
-        println!(
-            "  (not found -- {} not configured, or no MCP servers yet)",
-            r.display_name
-        );
+        match lang {
+            Lang::En => println!(
+                "  (not found -- {} not configured, or no MCP servers yet)",
+                r.display_name
+            ),
+            Lang::Zh => println!("  (未找到 —— {} 未配置,或尚无 MCP 服务器)", r.display_name),
+        }
         return;
     }
     if r.servers.is_empty() {
-        println!("  No MCP servers found in mcpServers.");
+        println!(
+            "  {}",
+            tr(
+                lang,
+                "No MCP servers found in mcpServers.",
+                "mcpServers 中未找到 MCP 服务器。",
+            )
+        );
         return;
     }
-    println!(
-        "  {} scope (mcpServers) -- {} can be protected:",
-        r.display_name,
-        r.wrappable_count()
-    );
+    match lang {
+        Lang::En => println!(
+            "  {} scope (mcpServers) -- {} can be protected:",
+            r.display_name,
+            r.wrappable_count()
+        ),
+        Lang::Zh => println!(
+            "  {} scope(mcpServers)—— {} 个可保护:",
+            r.display_name,
+            r.wrappable_count()
+        ),
+    }
     // server-id 派生须与 apply 一致(`<prefix>-<name>`)。prefix 是 &'static str,闭包捕获。
     let prefix = r.id_prefix;
     for s in &r.servers {
-        print_mcp_server_preview(&r.exe, |n| format!("{prefix}-{n}"), s, r.monitor);
+        print_mcp_server_preview(lang, &r.exe, |n| format!("{prefix}-{n}"), s, r.monitor);
     }
 }
 
 /// 打印 JSON-agent 接入面 apply/uninstall 结果(ASCII-safe)。附在前面各面结果之后。
-fn print_json_agent_apply(r: &setup_mcp::JsonAgentApplyReport, op: &str) {
+fn print_json_agent_apply(lang: Lang, r: &setup_mcp::JsonAgentApplyReport, op: &str) {
     let dry = if r.dry_run { " (dry-run)" } else { "" };
-    let verb = if r.dry_run { "would" } else { "did" };
-    let what = if op == "uninstall" { "restore" } else { "wrap" };
-    println!(
-        "Vigil setup --mcp --{op}{dry} ({}): {verb} {what} {} MCP server(s) in {}",
-        r.display_name,
-        r.changed,
-        r.config_path.display()
-    );
+    let verb = match (lang, r.dry_run) {
+        (Lang::En, true) => "would",
+        (Lang::En, false) => "did",
+        (Lang::Zh, true) => "将",
+        (Lang::Zh, false) => "已",
+    };
+    let what = match (lang, op == "uninstall") {
+        (Lang::En, true) => "restore",
+        (Lang::En, false) => "wrap",
+        (Lang::Zh, true) => "还原",
+        (Lang::Zh, false) => "防护",
+    };
+    match lang {
+        Lang::En => println!(
+            "Vigil setup --mcp --{op}{dry} ({}): {verb} {what} {} MCP server(s) in {}",
+            r.display_name,
+            r.changed,
+            r.config_path.display()
+        ),
+        Lang::Zh => println!(
+            "Vigil setup --mcp --{op}{dry}({}):{verb}{what} {} 个 MCP 服务器,改动写入配置文件 {}",
+            r.display_name,
+            r.changed,
+            r.config_path.display()
+        ),
+    }
     if let Some(b) = &r.backup {
-        println!("  backup of the previous config: {}", b.display());
+        println!(
+            "  {}{}",
+            tr(lang, "backup of the previous config: ", "原配置备份:"),
+            b.display()
+        );
     }
     if r.changed == 0 && !r.dry_run {
-        println!(
-            "  (nothing to {what} in {} -- no matching servers)",
-            r.display_name
-        );
+        match lang {
+            Lang::En => println!(
+                "  (nothing to {what} in {} -- no matching servers)",
+                r.display_name
+            ),
+            Lang::Zh => println!("  ({} 中无需{what} —— 无匹配服务器)", r.display_name),
+        }
     }
     if op == "apply" && r.changed > 0 && !r.dry_run {
-        println!(
-            "  Restart {} to pick up the change. Undo with: vigil-hub setup --mcp --uninstall",
-            r.display_name
-        );
+        match lang {
+            Lang::En => println!(
+                "  Restart {} to pick up the change. Undo with: vigil-hub setup --mcp --uninstall",
+                r.display_name
+            ),
+            Lang::Zh => println!(
+                "  重启 {} 使改动生效。撤销:vigil-hub setup --mcp --uninstall",
+                r.display_name
+            ),
+        }
     }
 }
 
 /// 打印 setup/status 的人类可读报告(ASCII-safe,cp936/cp437 不乱码)。返回退出码。
 fn print_setup_report(
+    lang: Lang,
     args: &SetupArgs,
     r: &setup::SetupReport,
     mcp_wrapped: usize,
@@ -1710,13 +2328,17 @@ fn print_setup_report(
     use setup::ProtectionState;
     if args.status {
         let self_test = setup::doctor_self_test();
-        println!("Vigil status");
+        println!("{}", tr(lang, "Vigil status", "Vigil 状态"));
         println!(
             "  Claude Code:   {}",
             if r.claude_detected {
-                "detected"
+                tr(lang, "detected", "已检测到")
             } else {
-                "not detected (neither ~/.claude nor ~/.claude.json found)"
+                tr(
+                    lang,
+                    "not detected (neither ~/.claude nor ~/.claude.json found)",
+                    "未检测到(~/.claude 与 ~/.claude.json 都不存在)",
+                )
             }
         );
         // 总体保护 = 原生 hook 活跃 **或** 至少一个 MCP server 被 Vigil 网关 wrap(ISS-20260621-002:
@@ -1725,46 +2347,89 @@ fn print_setup_report(
         let hook_active = r.state == ProtectionState::Active;
         let overall_active = hook_active || mcp_wrapped > 0;
         if overall_active {
-            println!("  Protection:    ACTIVE");
+            println!(
+                "  {}",
+                tr(lang, "Protection:    ACTIVE", "防护状态:    已激活(ACTIVE)")
+            );
         } else if r.state == ProtectionState::Stale {
-            println!("  Protection:    INSTALLED but STALE");
+            println!(
+                "  {}",
+                tr(
+                    lang,
+                    "Protection:    INSTALLED but STALE",
+                    "防护状态:    已安装但已失效(STALE)"
+                )
+            );
         } else {
-            println!("  Protection:    not installed");
+            println!(
+                "  {}",
+                tr(lang, "Protection:    not installed", "防护状态:    未安装")
+            );
         }
         // 分层明细:两条防护面各自可见(原生工具输入侧 hook + MCP 网关逐 server wrap)。
         println!(
-            "  Native hook:   {}",
+            "  {}{}",
+            tr(lang, "Native hook:   ", "原生 hook:    "),
             match r.state {
-                ProtectionState::Active => "active",
-                ProtectionState::Stale =>
+                ProtectionState::Active => tr(lang, "active", "活跃"),
+                ProtectionState::Stale => tr(
+                    lang,
                     "STALE - points at a different binary/ledger; re-run `vigil-hub setup`",
-                ProtectionState::NotInstalled => "not installed",
+                    "已失效 —— Vigil 程序或账本路径变了(可能升级 / 移动过),请重跑 `vigil-hub setup` 修复",
+                ),
+                ProtectionState::NotInstalled => tr(lang, "not installed", "未安装"),
             }
         );
         println!(
-            "  MCP gateway:   {}",
+            "  {}{}",
+            tr(lang, "MCP gateway:   ", "MCP 网关:     "),
             if mcp_wrapped > 0 {
-                format!("{mcp_wrapped} server(s) wrapped")
+                match lang {
+                    Lang::En => format!("{mcp_wrapped} server(s) wrapped"),
+                    Lang::Zh => format!("已防护 {mcp_wrapped} 个服务器"),
+                }
             } else {
-                "no servers wrapped".to_string()
+                tr(lang, "no servers wrapped", "尚未防护任何服务器").to_string()
             }
         );
         if hook_active {
-            println!("  Hook command:  {}", r.hook_command);
+            println!(
+                "  {}{}",
+                tr(lang, "Hook command:  ", "Hook 命令:    "),
+                r.hook_command
+            );
         }
-        println!("  Audit ledger:  {}", r.ledger.display());
         println!(
-            "  Self-test:     {}",
+            "  {}{}",
+            tr(lang, "Audit ledger:  ", "审计账本:    "),
+            r.ledger.display()
+        );
+        println!(
+            "  {}{}",
+            tr(lang, "Self-test:     ", "自检:        "),
             if self_test {
-                "PASS - a synthetic fake credential was blocked by the hook logic"
+                tr(
+                    lang,
+                    "PASS - a synthetic fake credential was blocked by the hook logic",
+                    "通过 —— 用一条伪造的测试密钥验证,已被成功拦截",
+                )
             } else {
-                "FAIL - the hook did NOT block a synthetic credential (please report)"
+                tr(
+                    lang,
+                    "FAIL - the hook did NOT block a synthetic credential (please report)",
+                    "失败 —— hook 未能拦截合成凭据(请反馈)",
+                )
             }
         );
         if !overall_active && r.claude_detected {
-            println!(
-                "\n  Run `vigil-hub setup` (native-tool hook) or `vigil-hub setup --mcp --apply` (MCP gateway) to turn on protection."
-            );
+            match lang {
+                Lang::En => println!(
+                    "\n  Run `vigil-hub setup` (native-tool hook) or `vigil-hub setup --mcp --apply` (MCP gateway) to turn on protection."
+                ),
+                Lang::Zh => println!(
+                    "\n  运行 `vigil-hub setup`(原生工具 hook)或 `vigil-hub setup --mcp --apply`(MCP 网关)开启防护。"
+                ),
+            }
         }
         // self-test 失败是真问题 → 非零退出
         return if self_test {
@@ -1777,12 +2442,30 @@ fn print_setup_report(
     if args.uninstall {
         println!("Vigil setup --uninstall");
         if r.changed {
-            println!("  Removed Vigil's PreToolUse hook from Claude Code settings.");
+            println!(
+                "  {}",
+                tr(
+                    lang,
+                    "Removed Vigil's PreToolUse hook from Claude Code settings.",
+                    "已从 Claude Code 设置中移除 Vigil 的 PreToolUse hook。",
+                )
+            );
             if let Some(b) = &r.backup_path {
-                println!("  Backup:        {}", b.display());
+                println!(
+                    "  {}{}",
+                    tr(lang, "Backup:        ", "备份:        "),
+                    b.display()
+                );
             }
         } else {
-            println!("  Nothing to remove (Vigil hook was not present).");
+            println!(
+                "  {}",
+                tr(
+                    lang,
+                    "Nothing to remove (Vigil hook was not present).",
+                    "无需移除(Vigil hook 本就不存在)。",
+                )
+            );
         }
         return std::process::ExitCode::SUCCESS;
     }
@@ -1790,38 +2473,129 @@ fn print_setup_report(
     // install
     println!("Vigil setup");
     if !r.claude_detected {
-        println!("  Claude Code:   not detected (claude not on PATH; neither ~/.claude nor ~/.claude.json found)");
-        println!("  Nothing to do. Install Claude Code, then re-run `vigil-hub setup`.");
-        println!("  (For other agents, use the MCP gateway: `vigil-hub serve --stdio`.)");
+        match lang {
+            Lang::En => {
+                println!("  Claude Code:   not detected (claude not on PATH; neither ~/.claude nor ~/.claude.json found)");
+                println!("  Nothing to do. Install Claude Code, then re-run `vigil-hub setup`.");
+                println!("  (For other agents, use the MCP gateway: `vigil-hub serve --stdio`.)");
+            }
+            Lang::Zh => {
+                println!("  Claude Code:   未检测到(claude 不在 PATH;~/.claude 与 ~/.claude.json 都不存在)");
+                println!("  无事可做。请先安装 Claude Code,再重跑 `vigil-hub setup`。");
+                println!("  (其它 agent 请用 MCP 网关:`vigil-hub serve --stdio`。)");
+            }
+        }
         return std::process::ExitCode::SUCCESS;
     }
-    println!("  Claude Code:   detected");
+    println!(
+        "  {}",
+        tr(lang, "Claude Code:   detected", "Claude Code:   已检测到")
+    );
     if r.dry_run {
-        println!("  [dry-run] would register Vigil's PreToolUse hook in:");
-        println!("            {}", r.settings_path.display());
-        println!("  [dry-run] hook command: {}", r.hook_command);
-        println!("  [dry-run] audit ledger: {}", r.ledger.display());
-        println!("  (no changes written)");
+        match lang {
+            Lang::En => {
+                println!("  [dry-run] would register Vigil's PreToolUse hook in:");
+                println!("            {}", r.settings_path.display());
+                println!("  [dry-run] hook command: {}", r.hook_command);
+                println!("  [dry-run] audit ledger: {}", r.ledger.display());
+                println!("  (no changes written)");
+            }
+            Lang::Zh => {
+                println!("  [dry-run] 将把 Vigil 的 PreToolUse hook 注册到:");
+                println!("            {}", r.settings_path.display());
+                println!("  [dry-run] hook 命令:{}", r.hook_command);
+                println!("  [dry-run] 审计账本:{}", r.ledger.display());
+                println!("  (未写入任何改动)");
+            }
+        }
         return std::process::ExitCode::SUCCESS;
     }
     if r.changed {
-        println!("  Protection:    PreToolUse hook registered (all tools)");
-        println!("  Hook command:  {}", r.hook_command);
-        println!("  Audit ledger:  {}", r.ledger.display());
+        match lang {
+            Lang::En => {
+                println!("  Protection:    PreToolUse hook registered (all tools)");
+                println!("  Hook command:  {}", r.hook_command);
+                println!("  Audit ledger:  {}", r.ledger.display());
+            }
+            Lang::Zh => {
+                println!("  防护状态:    已注册 PreToolUse hook(覆盖所有工具)");
+                println!("  Hook 命令:    {}", r.hook_command);
+                println!("  审计账本:    {}", r.ledger.display());
+            }
+        }
         if let Some(b) = &r.backup_path {
-            println!("  Backup:        {}  (your previous settings)", b.display());
+            match lang {
+                Lang::En => println!("  Backup:        {}  (your previous settings)", b.display()),
+                Lang::Zh => println!("  备份:        {}  (你之前的设置)", b.display()),
+            }
         }
         println!();
-        println!("  Your Claude Code tool calls are now guarded by Vigil: raw secrets are");
-        println!("  blocked from Bash/Edit/Write/etc., and every block is recorded in a");
-        println!("  tamper-evident local audit ledger.");
-        println!();
-        println!("  Verify:  vigil-hub setup --status");
-        println!("  Undo:    vigil-hub setup --uninstall");
-        println!("  Restart Claude Code (or start a new session) for the hook to take effect.");
+        match lang {
+            Lang::En => {
+                println!("  Your Claude Code tool calls are now guarded by Vigil: raw secrets are");
+                println!("  blocked from Bash/Edit/Write/etc., and every block is recorded in a");
+                println!("  tamper-evident local audit ledger.");
+                println!();
+                println!("  Verify:  vigil-hub setup --status");
+                println!("  Undo:    vigil-hub setup --uninstall");
+                println!(
+                    "  Restart Claude Code (or start a new session) for the hook to take effect."
+                );
+            }
+            Lang::Zh => {
+                println!("  你的 Claude Code 工具调用现已受 Vigil 守护:明文密钥会被挡在");
+                println!("  Bash/Edit/Write 等工具之外,且每一次拦截都记入防篡改的本地审计账本。");
+                println!();
+                println!("  验证:  vigil-hub setup --status");
+                println!("  撤销:  vigil-hub setup --uninstall");
+                println!("  重启 Claude Code(或开新会话)使 hook 生效。");
+            }
+        }
     } else {
-        println!("  Protection:    already active (no change).");
-        println!("  Verify:  vigil-hub setup --status");
+        match lang {
+            Lang::En => {
+                println!("  Protection:    already active (no change).");
+                println!("  Verify:  vigil-hub setup --status");
+            }
+            Lang::Zh => {
+                println!("  防护状态:    已激活(无改动)。");
+                println!("  验证:  vigil-hub setup --status");
+            }
+        }
     }
     std::process::ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// localize 必须能命中**真实** Cli 树的每个 mut_subcommand / mut_arg —— `mut_arg` 对未定义
+    /// id 会 panic,故 arg id 一旦写错,线上**每次**启动(main 在 parse 前都会 localize)都会崩。
+    /// 本测试在真实 Cli 上跑两语言 localize + clap 结构自检,守住这条必经路径(mirror 测试在
+    /// i18n::help 里只是近似,本测试才是权威)。
+    #[test]
+    fn localize_applies_to_real_cli_both_langs() {
+        for lang in [Lang::En, Lang::Zh] {
+            i18n::help::localize(Cli::command(), lang).debug_assert();
+        }
+    }
+
+    /// 真实 root 帮助按语言渲染(同时验证 mut_subcommand 命中 + 文案确实生效)。term_width 调大
+    /// 关闭折行,保证目标短语逐字保留。
+    #[test]
+    fn real_root_help_is_localized() {
+        let mut zh_cmd = i18n::help::localize(Cli::command(), Lang::Zh).term_width(10_000);
+        let zh = zh_cmd.render_long_help().to_string();
+        assert!(
+            zh.contains("Vigil 位于你的 AI 编码 agent"),
+            "ZH root long help should be localized:\n{zh}"
+        );
+        let mut en_cmd = i18n::help::localize(Cli::command(), Lang::En).term_width(10_000);
+        let en = en_cmd.render_long_help().to_string();
+        assert!(
+            en.contains("Vigil sits between your AI coding agents"),
+            "EN root long help should be localized:\n{en}"
+        );
+    }
 }

--- a/apps/vigil-hub-cli/src/model.rs
+++ b/apps/vigil-hub-cli/src/model.rs
@@ -7,12 +7,24 @@
 //! **ort-gated**:模型只对 ML 变体有意义。非 ort 构建 → 报错指向 ML 变体(`vigil-cli-ml-*`),
 //! **绝不**静默假装成功。下载复用已验证的 `vigil_redaction::ensure_*_model_available`
 //! (16-chunk byte-range 并发 + sha256 校验 + ETag 304;ADR 0012,内部原子落盘)。
+//!
+//! 用户直面命令,输出按系统语言本地化(i18n)。
+
+use crate::i18n::Lang;
+
+/// 按语言取静态文案(中 / 英并排)。
+fn tr(lang: Lang, en: &'static str, zh: &'static str) -> &'static str {
+    match lang {
+        Lang::En => en,
+        Lang::Zh => zh,
+    }
+}
 
 /// `model install [--privacy] [--injection]`:下载模型。两者都未指定 = 都装(最常见诉求「装上 ML」)。
 ///
 /// fail-closed:任一下载失败(网络 / sha256 不符)→ `Err`,不留半截缓存假成功(`ensure_*` 内部
 /// 原子落盘 + 校验)。已缓存则 `ensure_*` 命中 ETag 304 秒回(幂等,重跑安全)。
-pub fn run_install(privacy: bool, injection: bool) -> Result<(), String> {
+pub fn run_install(lang: Lang, privacy: bool, injection: bool) -> Result<(), String> {
     let (do_privacy, do_injection) = if !privacy && !injection {
         (true, true) // 都未指定 → 默认两者都装
     } else {
@@ -22,46 +34,82 @@ pub fn run_install(privacy: bool, injection: bool) -> Result<(), String> {
     #[cfg(not(feature = "ort"))]
     {
         let _ = (do_privacy, do_injection);
-        Err(
-            "this build has no ML support (hard-fingerprint only). Install the ML variant \
-             (vigil-cli-ml-*) to download privacy/injection models."
-                .to_string(),
+        Err(tr(
+            lang,
+            "this build has no ML support (hard-fingerprint rules only). Install the ML build (vigil-cli-ml-*) to download the privacy / injection models.",
+            "当前版本不含 ML 支持(仅硬指纹规则)。请改用 ML 版本(vigil-cli-ml-*)再下载隐私 / 注入模型。",
         )
+        .to_string())
     }
 
     #[cfg(feature = "ort")]
     {
         if do_privacy {
-            println!("vigil-hub model: downloading privacy (PII) model… (~700MB, first run only)");
-            let paths = vigil_redaction::ensure_model_available(None)
-                .map_err(|e| format!("privacy model install failed: {e}"))?;
             println!(
-                "vigil-hub model: privacy model ready at {}",
-                paths.dir().display()
+                "{}",
+                tr(
+                    lang,
+                    "vigil-hub model: downloading the privacy (PII) model... (~700 MB, first run only)",
+                    "vigil-hub model:正在下载隐私(PII)模型…(约 700 MB,仅首次运行需要)",
+                )
             );
+            let paths = vigil_redaction::ensure_model_available(None).map_err(|e| match lang {
+                Lang::En => format!("privacy model install failed: {e}"),
+                Lang::Zh => format!("隐私模型安装失败:{e}"),
+            })?;
+            match lang {
+                Lang::En => println!(
+                    "vigil-hub model: privacy model ready at {}",
+                    paths.dir().display()
+                ),
+                Lang::Zh => println!(
+                    "vigil-hub model:隐私模型已就绪,缓存于 {}",
+                    paths.dir().display()
+                ),
+            }
         }
         if do_injection {
             println!(
-                "vigil-hub model: downloading injection classifier model… (~700MB, first run only)"
+                "{}",
+                tr(
+                    lang,
+                    "vigil-hub model: downloading the injection-classifier model... (~700 MB, first run only)",
+                    "vigil-hub model:正在下载注入分类器模型…(约 700 MB,仅首次运行需要)",
+                )
             );
-            let paths = vigil_redaction::ensure_injection_model_available(None)
-                .map_err(|e| format!("injection model install failed: {e}"))?;
-            println!(
-                "vigil-hub model: injection classifier ready at {}",
-                paths.dir().display()
-            );
+            let paths =
+                vigil_redaction::ensure_injection_model_available(None).map_err(
+                    |e| match lang {
+                        Lang::En => format!("injection model install failed: {e}"),
+                        Lang::Zh => format!("注入模型安装失败:{e}"),
+                    },
+                )?;
+            match lang {
+                Lang::En => println!(
+                    "vigil-hub model: injection classifier ready at {}",
+                    paths.dir().display()
+                ),
+                Lang::Zh => println!(
+                    "vigil-hub model:注入分类器已就绪,缓存于 {}",
+                    paths.dir().display()
+                ),
+            }
         }
         Ok(())
     }
 }
 
 /// `model status`:报告两个模型是否本地已缓存(daemon 暖载 / `--engine auto` best-effort 的前提)。
-pub fn run_status() -> Result<(), String> {
+pub fn run_status(lang: Lang) -> Result<(), String> {
     #[cfg(not(feature = "ort"))]
     {
         println!(
-            "ML models: unsupported on this build (hard-fingerprint only). \
-             Install the ML variant (vigil-cli-ml-*) to enable ML."
+            "{}",
+            tr(
+                lang,
+                "ML models: not supported by this build (hard-fingerprint rules only). Install the ML build (vigil-cli-ml-*) to enable ML.",
+                "ML 模型:当前版本不支持(仅硬指纹规则)。请改用 ML 版本(vigil-cli-ml-*)以启用 ML。",
+            )
         );
         Ok(())
     }
@@ -70,17 +118,28 @@ pub fn run_status() -> Result<(), String> {
     {
         let privacy = vigil_redaction::model_cached(None);
         let injection = vigil_redaction::injection_model_cached(None);
+        // 状态词本地化为「已安装(路径)/ 未安装」,比裸 true/false 更直白。
+        let p_status = match (lang, privacy) {
+            (Lang::En, Some(p)) => format!("installed ({})", p.dir().display()),
+            (Lang::En, None) => "not installed".to_string(),
+            (Lang::Zh, Some(p)) => format!("已安装({})", p.dir().display()),
+            (Lang::Zh, None) => "未安装".to_string(),
+        };
+        let i_status = match (lang, injection) {
+            (Lang::En, Some(p)) => format!("installed ({})", p.dir().display()),
+            (Lang::En, None) => "not installed".to_string(),
+            (Lang::Zh, Some(p)) => format!("已安装({})", p.dir().display()),
+            (Lang::Zh, None) => "未安装".to_string(),
+        };
         println!(
-            "privacy (PII) model:  {}",
-            privacy
-                .map(|p| format!("installed ({})", p.dir().display()))
-                .unwrap_or_else(|| "not installed".to_string())
+            "{}{}",
+            tr(lang, "privacy (PII) model:  ", "隐私(PII)模型:  "),
+            p_status
         );
         println!(
-            "injection classifier: {}",
-            injection
-                .map(|p| format!("installed ({})", p.dir().display()))
-                .unwrap_or_else(|| "not installed".to_string())
+            "{}{}",
+            tr(lang, "injection classifier: ", "注入分类器:      "),
+            i_status
         );
         Ok(())
     }

--- a/apps/vigil-hub-cli/src/quickstart.rs
+++ b/apps/vigil-hub-cli/src/quickstart.rs
@@ -4,9 +4,12 @@
 //! ①你机器上有哪些 AI agent、有多少 MCP server、几个已被 Vigil 保护(**真实检测**,复用
 //! `setup --mcp` 的只读 preview 分类);②怎么 30 秒看到 Vigil 拦一次密钥外泄;③一条命令保护全部 +
 //! 怎么查看/验证。**绝不改配置**(检测=只读 preview;真正接入仍须用户显式 `setup --all`)。
+//!
+//! 文案按系统语言本地化(i18n):静态行用 [`tr`] 中 / 英并排,带插值的行内联 `match lang`。
 
 use std::path::Path;
 
+use crate::i18n::Lang;
 use crate::setup_mcp::{self, JsonMcpAgent, McpServerClass};
 
 /// 单 agent 的 MCP server 分类计数。
@@ -47,37 +50,77 @@ fn count_servers<'a>(servers: impl IntoIterator<Item = &'a McpServerClass>) -> C
     c
 }
 
+/// 按语言取静态文案(中 / 英并排;无插值的行用它,无额外分配)。
+fn tr<'a>(lang: Lang, en: &'a str, zh: &'a str) -> &'a str {
+    match lang {
+        Lang::En => en,
+        Lang::Zh => zh,
+    }
+}
+
 /// 渲染一行 agent 摘要。`configured=false` → "not configured"(无配置文件 / 空 mcpServers)。
-fn agent_line(label: &str, configured: bool, c: Counts) -> String {
+fn agent_line(lang: Lang, label: &str, configured: bool, c: Counts) -> String {
     if !configured || c.total() == 0 {
-        return format!("    {label:<13} not configured");
+        return format!("    {label:<13} {}", tr(lang, "not configured", "未配置"));
     }
     let total = c.total();
-    let mut parts = vec![format!(
-        "{total} MCP server{}",
-        if total == 1 { "" } else { "s" }
-    )];
-    parts.push(format!("{} protected", c.protected));
+    let mut parts = vec![match lang {
+        Lang::En => format!("{total} MCP server{}", if total == 1 { "" } else { "s" }),
+        Lang::Zh => format!("{total} 个 MCP 服务器"),
+    }];
+    parts.push(match lang {
+        Lang::En => format!("{} protected", c.protected),
+        Lang::Zh => format!("{} 个已保护", c.protected),
+    });
     if c.unprotected > 0 {
-        parts.push(format!("{} unprotected", c.unprotected));
+        parts.push(match lang {
+            Lang::En => format!("{} unprotected", c.unprotected),
+            Lang::Zh => format!("{} 个未保护", c.unprotected),
+        });
     }
     if c.skipped > 0 {
-        parts.push(format!("{} skipped (http/sse)", c.skipped));
+        parts.push(match lang {
+            Lang::En => format!("{} unsupported (http/sse)", c.skipped),
+            Lang::Zh => format!("{} 个暂不支持(http/sse)", c.skipped),
+        });
     }
     format!("    {label:<13} {}", parts.join(" · "))
 }
 
+/// 一行"读取配置失败"提示(本地化)。
+fn could_not_read(lang: Lang, label: &str, e: impl std::fmt::Display) -> String {
+    match lang {
+        Lang::En => format!("    {label:<13} could not read config ({e})"),
+        Lang::Zh => format!("    {label:<13} 无法读取配置({e})"),
+    }
+}
+
 /// 引导首跑主入口。始终返回 0(纯信息命令,不做判定)。
-pub fn run(home: &Path, exe: &str) -> i32 {
+pub fn run(home: &Path, exe: &str, lang: Lang) -> i32 {
     println!();
-    println!("  Vigil quickstart");
-    println!("  ────────────────");
-    println!("  Vigil keeps secrets & PII out of your AI agents — locally, with a");
-    println!("  tamper-evident audit. Here's where you stand and what to do next.");
+    println!("  {}", tr(lang, "Vigil quickstart", "Vigil 快速上手"));
+    println!("  {}", tr(lang, "────────────────", "──────────────"));
+    match lang {
+        Lang::En => {
+            println!("  Vigil keeps secrets & PII out of your AI agents — locally, with a");
+            println!("  tamper-evident audit. Here's where you stand and what to do next.");
+        }
+        Lang::Zh => {
+            println!("  Vigil 把密钥与隐私数据挡在 AI agent 之外 —— 全程本地,并带防篡改审计。");
+            println!("  下面是你当前的状况,以及接下来该做什么。");
+        }
+    }
     println!();
 
     // ── 1) 真实检测(只读 preview;绝不改配置)────────────────────────────
-    println!("  1) Your agents  (read-only — nothing was changed)");
+    println!(
+        "  {}",
+        tr(
+            lang,
+            "1) Your agents  (read-only — nothing was changed)",
+            "1) 你的 agent  (只读 —— 未改动任何东西)",
+        )
+    );
     let mut total_unprotected = 0usize;
     // monitor 仅影响 preview 生成的 wrap argv(本命令不用,只数分类),传 true 任意。
     let monitor = true;
@@ -88,20 +131,20 @@ pub fn run(home: &Path, exe: &str) -> i32 {
             // user scope(`servers`)+ local scope(`projects.*` 的 `local_servers`)都算。
             let c = count_servers(&r.servers)
                 .add(count_servers(r.local_servers.iter().map(|(_, sv)| sv)));
-            println!("{}", agent_line("Claude Code", c.total() > 0, c));
+            println!("{}", agent_line(lang, "Claude Code", c.total() > 0, c));
             total_unprotected += c.unprotected;
         }
-        Err(e) => println!("    {:<13} could not read config ({e})", "Claude Code"),
+        Err(e) => println!("{}", could_not_read(lang, "Claude Code", e)),
     }
 
     // Codex(`~/.codex/config.toml`)。
     match setup_mcp::run_codex_preview(home, exe, monitor) {
         Ok(r) => {
             let c = count_servers(&r.servers);
-            println!("{}", agent_line("Codex", c.total() > 0, c));
+            println!("{}", agent_line(lang, "Codex", c.total() > 0, c));
             total_unprotected += c.unprotected;
         }
-        Err(e) => println!("    {:<13} could not read config ({e})", "Codex"),
+        Err(e) => println!("{}", could_not_read(lang, "Codex", e)),
     }
 
     // Cursor + Windsurf(JSON `mcpServers` 形态)。
@@ -109,42 +152,103 @@ pub fn run(home: &Path, exe: &str) -> i32 {
         match setup_mcp::run_json_agent_preview(&agent, exe, monitor) {
             Ok(r) => {
                 let c = count_servers(&r.servers);
-                println!("{}", agent_line(agent.display_name, c.total() > 0, c));
+                println!("{}", agent_line(lang, agent.display_name, c.total() > 0, c));
                 total_unprotected += c.unprotected;
             }
-            Err(e) => println!("    {:<13} could not read config ({e})", agent.display_name),
+            Err(e) => println!("{}", could_not_read(lang, agent.display_name, e)),
         }
     }
     println!();
     if total_unprotected > 0 {
-        println!(
-            "     → {total_unprotected} MCP server{} are NOT yet behind Vigil's firewall + redaction + audit.",
-            if total_unprotected == 1 { "" } else { "s" }
-        );
+        match lang {
+            Lang::En => println!(
+                "     → {total_unprotected} MCP server{} are NOT yet protected by Vigil (firewall + redaction + audit).",
+                if total_unprotected == 1 { "" } else { "s" }
+            ),
+            Lang::Zh => println!(
+                "     → 有 {total_unprotected} 个 MCP 服务器还没受 Vigil 保护(防火墙 + 脱敏 + 审计)。"
+            ),
+        }
     } else {
-        println!("     → No unprotected stdio MCP servers detected. (Run the demo anyway to see how it works.)");
+        match lang {
+            Lang::En => println!(
+                "     → No unprotected stdio MCP servers detected. (Run the demo anyway to see how it works.)"
+            ),
+            Lang::Zh => println!(
+                "     → 没检测到未受保护的 stdio MCP 服务器。(也可以跑下 demo 看看它怎么工作。)"
+            ),
+        }
     }
     println!();
 
     // ── 2) 看它工作 ───────────────────────────────────────────────────
-    println!("  2) See it work  (≈30s, no setup, contacts no LLM)");
+    println!(
+        "  {}",
+        tr(
+            lang,
+            "2) See it work  (≈30s, no setup, contacts no LLM)",
+            "2) 看它工作  (约 30 秒,零配置,不联系任何 LLM)",
+        )
+    );
     println!("       vigil-hub demo");
     println!();
 
     // ── 3) 保护(显式;quickstart 自身从不改配置)────────────────────────
-    println!("  3) Protect every detected agent  (one command, reversible)");
+    println!(
+        "  {}",
+        tr(
+            lang,
+            "3) Protect every detected agent  (one command, reversible)",
+            "3) 保护检测到的每个 agent  (一条命令,可逆)",
+        )
+    );
     println!("       vigil-hub setup --all");
-    println!("     Preview the exact changes first, without writing anything:");
+    println!(
+        "     {}",
+        tr(
+            lang,
+            "Preview the exact changes first, without writing anything:",
+            "想先看清具体会改什么、且不写任何文件:",
+        )
+    );
     println!("       vigil-hub setup --mcp");
     println!();
 
     // ── 4) 查看 / 验证 ────────────────────────────────────────────────
-    println!("  4) Watch & verify");
-    println!("       vigil-hub setup --mcp --doctor    # health-check every agent surface");
-    println!("       vigil-hub verify                  # audit chain + tamper-rewrite anchor");
-    println!("     …or open the Vigils desktop app for the live Protection Overview.");
+    println!("  {}", tr(lang, "4) Watch & verify", "4) 查看与验证"));
+    println!(
+        "       vigil-hub setup --mcp --doctor    # {}",
+        tr(
+            lang,
+            "health-check every agent",
+            "检查每个 agent 的接入是否正常",
+        )
+    );
+    println!(
+        "       vigil-hub verify                  # {}",
+        tr(
+            lang,
+            "verify the audit log is intact and untampered",
+            "验证审计记录完整、未被篡改",
+        )
+    );
+    println!(
+        "     {}",
+        tr(
+            lang,
+            "…or open the Vigils desktop app for the live Protection Overview.",
+            "…或打开 Vigils 桌面应用查看实时「防护总览」。",
+        )
+    );
     println!();
-    println!("  Everything runs on your machine. Nothing leaves it.");
+    println!(
+        "  {}",
+        tr(
+            lang,
+            "Everything runs on your machine. Nothing leaves it.",
+            "全程在你的机器上运行。数据不外泄。",
+        )
+    );
     println!();
     0
 }
@@ -183,11 +287,15 @@ mod tests {
 
     #[test]
     fn agent_line_renders_not_configured_for_empty() {
-        let line = agent_line("Codex", false, Counts::default());
+        // En:既有英文断言不变(传 Lang::En)。
+        let line = agent_line(Lang::En, "Codex", false, Counts::default());
         assert!(line.contains("not configured"), "got: {line}");
         // 即便 configured=true 但全 0 也算 not configured(无 server)。
-        let line2 = agent_line("Codex", true, Counts::default());
+        let line2 = agent_line(Lang::En, "Codex", true, Counts::default());
         assert!(line2.contains("not configured"), "got: {line2}");
+        // Zh:对应中文文案。
+        let zh = agent_line(Lang::Zh, "Codex", false, Counts::default());
+        assert!(zh.contains("未配置"), "got: {zh}");
     }
 
     #[test]
@@ -197,9 +305,14 @@ mod tests {
             unprotected: 3,
             skipped: 0,
         };
-        let line = agent_line("Claude Code", true, c);
+        let line = agent_line(Lang::En, "Claude Code", true, c);
         assert!(line.contains("4 MCP servers"), "got: {line}");
         assert!(line.contains("1 protected"), "got: {line}");
         assert!(line.contains("3 unprotected"), "got: {line}");
+        // Zh:同一计数的中文渲染。
+        let zh = agent_line(Lang::Zh, "Claude Code", true, c);
+        assert!(zh.contains("4 个 MCP 服务器"), "got: {zh}");
+        assert!(zh.contains("1 个已保护"), "got: {zh}");
+        assert!(zh.contains("3 个未保护"), "got: {zh}");
     }
 }


### PR DESCRIPTION
## 概要 / Summary

让 `vigil-hub` CLI 按系统语言输出中文或英文(system-language aware EN/ZH),做正式 i18n。

机制:clap derive 的 doc 注释编译期烘死、无法运行时切语言 → 在 `Cli::parse` **之前**用 builder `mut_subcommand` / `mut_arg` / `about` / `long_about` **运行时改写**(只改展示,**绝不动**子命令名 / flag / arg id 等解析契约)。语言选择:`VIGIL_LANG`(`en` / `zh` / `auto`,测试 / 覆盖用)→ 系统 locale(`sys-locale`,跨平台)→ `En` 回落。

新增 `src/i18n/{mod,help}.rs`;源码 `///` 仍是开发者注释,用户看到的帮助来自运行时改写层。

## 覆盖面 / Coverage

- **root + 全部子命令帮助**(serve / hook / setup / wrap / checkpoint / verify / quickstart / posture / engine / daemon / model / inspect)
- **`demo`、`quickstart`** 整屏中英双语
- **`setup` 全家**(install / `--status` / `--uninstall` / `--all` / `--mcp` preview·apply·doctor / 各 agent 面 / 半应用失败路径)
- **`posture` / `engine` / `daemon` / `model`** 的用户可见输出

**有意不本地化**:`--json` 路径(GUI / 脚本机器契约,键值恒英文)、`posture` / `engine` 纯值输出(`low`/`high`、`hardfp`/`ml`,供脚本解析)、secret scrub(`[REDACTED]`)。

## 文案贴切化 / Wording

顺手把若干抽象 / 翻译腔术语改贴切:`包裹`→`防护`、monitor→`观察模式`、default-deny→`严格模式(默认拒绝放行)`、`demo` 三段对照统一为「含真密钥? 否/是/否」一列、`daemon` 陈旧态去内部黑话并给可执行指引。

## inspect

`inspect`(本仓独有命令)顶层 about / long_about 已本地化(EN 不再泄漏中文)。其子命令(activity / search / approvals / verify-chain / protection 等)与参数的**深度本地化留作后续增量** —— inspect 是 advanced 审计面、非首跑 onboarding 路径,深度树较大,单独成 PR 更易评审。

## 验证 / Verification

- `cargo build` / `cargo test`(336 lib + 集成 + doc) / `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check`(内容)**全绿**
- 关键守门:`localize_applies_to_real_cli_both_langs` 在**真实 Cli** 上两语言跑 `localize().debug_assert()` —— `mut_arg` 对未定义 id 会 panic,故线上每次启动必经此路径(arg id 写错即崩,不会静默)
- **真二进制双语跑**(`VIGIL_LANG=zh/en`):`--help`、`quickstart`、`posture`、`model status`、`inspect --help` 确认本地化生效
