### PR TITLE
ci(release): preflight 门禁 — 绝不从未过 CI(fmt/clippy/test)的提交发版

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,43 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # ── 0. Pre-flight gate:绝不从未过 CI 的提交切发布 ────────────────────
+  # v0.4.5 复盘:tag 从 fmt-红的提交切(产物本身 OK,但 Release workflow 不跑
+  # fmt/clippy/test,红提交照样发布)。此 job 镜像 ci.yml 的 Rust 门;
+  # create-release 依赖它 → 任一检查失败则不创建 Release、不发布任何产物。
+  preflight:
+    name: Pre-flight (fmt / clippy / test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      # System deps for Tauri / GTK on Linux (matches ci.yml)
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev librsvg2-dev
+
+      - name: Format check
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Test
+        run: cargo test --workspace
+
   # ── 1. 创建（或复用）Release ───────────────────────────────────────────
   create-release:
+    needs: preflight
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}


### PR DESCRIPTION
## 背景

v0.4.5 发版复盘发现:`v0.4.5` 的 tag 是从 **CI(`Format check`)红的提交**切的。产物本身没问题——`Release` workflow 不跑 fmt/clippy/test,13 个 job 照常全平台编译发布,且已通过三平台(Linux/macOS/Windows)真机 release-acceptance(打包审计 26/0 + 运行时 e2e 全绿)。但理想上发布应从**绿 CI** 切,而非红提交。

根因:`CI` 与 `Release` 是两个独立 workflow。`Release` 由 tag push 触发,不包含 `CI` 的 fmt/clippy/test 门 → 一个 fmt-红(或将来 clippy/test-红)的提交打上 tag 后照样发布。

## 改动

新增 `preflight` job,镜像 `ci.yml` 的 Rust 门:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

并让 `create-release` `needs: preflight`。因所有构建/发布 job 都(传递性)依赖 `create-release`,`preflight` 成为整个 workflow 的唯一根 job → **任一检查失败则不创建 Release、不发布任何产物**。

## 影响 / 安全性

- 当前 `main` CI 全绿,`preflight` 对当前树会 PASS,**不会误阻断**正常发版。
- 反验:v0.4.5 提交当时 fmt-红,`preflight` 的 `cargo fmt --all -- --check` 会在同一棵树失败 → `create-release` 阻断 → 不会发出 v0.4.5,直到 fmt 修好。正是想要的行为。
- 仅新增一个 ubuntu job(~2min,与 `ci.yml` 同),不改动任何既有构建/发布逻辑。
- 范围只镜像 `ci.yml` 的 `rust` job(实际缺口);`ui` job 未镜像,因 `desktop` 构建 job 已覆盖 UI。

## 验证

- `yaml.safe_load` 解析通过;job 依赖图核验:`preflight` 为唯一根 job,其余全部(传递性)受其门控。
