### PR TITLE
fix(acceptance): 下载加超时/重试 — 慢链路 fail-fast 而非挂死

### DIFF
--- a/tests/acceptance/daemon-regression.sh
+++ b/tests/acceptance/daemon-regression.sh
@@ -23,8 +23,9 @@ cleanup(){ pkill -f "$SBX/ml/vigil-hub" 2>/dev/null || true
            rm -rf "$SBX"; }
 trap cleanup EXIT
 
-curl -fsSL -o "$SBX/ml.tgz" "https://github.com/$REPO/releases/download/$VERSION/vigils-cli-ml-${PLAT}.tar.gz" \
-  || { echo "download failed"; exit 1; }
+curl -fsSL --connect-timeout 20 --speed-limit 10000 --speed-time 30 --retry 3 --retry-delay 5 --max-time 600 \
+  -o "$SBX/ml.tgz" "https://github.com/$REPO/releases/download/$VERSION/vigils-cli-ml-${PLAT}.tar.gz" \
+  || { echo "download failed (or too slow: <10KB/s for 30s)"; exit 1; }
 mkdir -p "$SBX/ml"; tar -xzf "$SBX/ml.tgz" -C "$SBX/ml"; chmod +x "$HUB"
 
 wait_running(){ for i in $(seq 1 25); do sleep 1; "$HUB" daemon status 2>&1 | grep -q 'running (pid' && return 0; done; return 1; }

--- a/tests/acceptance/ml-e2e.sh
+++ b/tests/acceptance/ml-e2e.sh
@@ -35,7 +35,8 @@ cleanup(){ "$HUB" daemon stop >/dev/null 2>&1 || true
 trap cleanup EXIT
 
 echo "### ML hook-ML e2e: $ARCHIVE (RUN_ML_MODEL=$RUN_ML_MODEL) ###"
-curl -fsSL -o "$SBX/ml.$EXT" "$URL" || { echo "download $URL failed"; exit 1; }
+curl -fsSL --connect-timeout 20 --speed-limit 10000 --speed-time 30 --retry 3 --retry-delay 5 --max-time 600 \
+  -o "$SBX/ml.$EXT" "$URL" || { echo "download $URL failed (or too slow: <10KB/s for 30s)"; exit 1; }
 mkdir -p "$SBX/ml"; tar -xzf "$SBX/ml.$EXT" -C "$SBX/ml"; chmod +x "$HUB"
 
 # --- bundled dylib present, exe-adjacent, right arch ---


### PR DESCRIPTION
## 问题

release-acceptance 的两个下载点用裸 `curl -fsSL` 下 cli-ml 归档,**无任何超时/重试**:
- `tests/acceptance/ml-e2e.sh`
- `tests/acceptance/daemon-regression.sh`

在到 GitHub release CDN 慢/卡的链路上会**无限挂起**——acceptance 既不失败也不结束(实测某 China-egress 测试机到 GitHub CDN 间歇仅 ~5KB/s,曾挂 6 分钟才被手动中断)。

## 改动

两处 curl 各加:
```
--connect-timeout 20 --speed-limit 10000 --speed-time 30 --retry 3 --retry-delay 5 --max-time 600
```
- 持续 **<10KB/s 达 30s → 中止(fail-fast)**,不再吊死
- 瞬时失败 **重试 3 次**(5s 间隔)
- 硬上限 600s

## 验证

- `bash -n`:两脚本语法 OK
- **快机 happy-path**:整包 14.26MB @ ~6 MB/s,`exit 0`(超时参数不伤正常下载)
- **确定性 fail-fast**:`--limit-rate 3k` 强制 3KB/s(<阈值)→ `curl: (28) Operation too slow. Less than 10000 bytes/sec transferred the last 30 seconds`,~30s 中止

> 注:测试机映射(`config.env`)是 gitignored 的本地配置,不在本 PR 内;本 PR 只是让 harness 在任何慢链路 fail-fast,而非依赖具体机器。
