### PR TITLE
fix: 用户级验证批——server 名 slugify、daemon uptime、信任面与用户文案如实化

### DIFF
--- a/apps/desktop/ui/src/App.vue
+++ b/apps/desktop/ui/src/App.vue
@@ -12,6 +12,8 @@ import {
   NMessageProvider,
   darkTheme,
   lightTheme,
+  zhCN,
+  dateZhCN,
   NSelect,
 } from "naive-ui";
 import { RouterLink, RouterView, useRoute, useRouter } from "vue-router";
@@ -35,6 +37,10 @@ import IconSettings from "@/components/icons/IconSettings.vue";
 const route = useRoute();
 const { t } = useI18n();
 const settings = useSettingsStore();
+
+// Naive UI 内建文案随 app locale(空表 "No Data"、分页等;null = 默认英文)。
+const naiveLocale = computed(() => (settings.locale === "zh-CN" ? zhCN : null));
+const naiveDateLocale = computed(() => (settings.locale === "zh-CN" ? dateZhCN : null));
 const helpOpen = ref(false);
 useGlobalShortcuts({ router, helpOpen });
 
@@ -138,7 +144,12 @@ function navClass(name: string): string {
 </script>
 
 <template>
-  <NConfigProvider :theme="activeTheme" :theme-overrides="themeOverrides">
+  <NConfigProvider
+    :theme="activeTheme"
+    :theme-overrides="themeOverrides"
+    :locale="naiveLocale"
+    :date-locale="naiveDateLocale"
+  >
     <NMessageProvider>
       <NDialogProvider>
         <div class="flex h-screen bg-vigils-bg-page text-vigils-text-primary overflow-hidden">

--- a/apps/desktop/ui/src/i18n/locales/en-US.json
+++ b/apps/desktop/ui/src/i18n/locales/en-US.json
@@ -281,6 +281,7 @@
     "daemon": {
       "title": "Daemon (resident engine)",
       "subtitle": "A resident daemon holds the warm AI model so the hook main path runs ML with zero cold-start. Start it to enable ML protection for your agent.",
+      "subtitle_no_model": "No AI model installed yet: starting now runs model-less (the hook stays on the hard-fingerprint floor). Install the AI model above first so the daemon can warm ML protection.",
       "status_stopped": "STOPPED",
       "status_running": "RUNNING",
       "status_ml": "RUNNING · ML WARM",

--- a/apps/desktop/ui/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/ui/src/i18n/locales/zh-CN.json
@@ -281,6 +281,7 @@
     "daemon": {
       "title": "守护进程（常驻引擎）",
       "subtitle": "常驻 daemon 守住已暖载的 AI 模型，让 hook 主路径零冷启动跑 ML。启动它即为你的 agent 开启 ML 防护。",
+      "subtitle_no_model": "当前未安装 AI 模型：现在启动只会以无模型方式运行（hook 保持硬指纹底座）。先在上方安装 AI 模型，daemon 才能暖载 ML 防护。",
       "status_stopped": "未运行",
       "status_running": "运行中",
       "status_ml": "运行中 · ML 已暖",

--- a/apps/desktop/ui/src/pages/Settings.vue
+++ b/apps/desktop/ui/src/pages/Settings.vue
@@ -370,8 +370,13 @@ function updatePollingInterval(v: number | null): void {
             <div class="text-sm font-medium text-vigils-text-primary">
               {{ t("settings.daemon.title") }}
             </div>
+            <!-- 模型未装时如实降级承诺:此时启动的 daemon 两个模型都不加载,hook 走硬指纹底座。 -->
             <div class="text-xs text-vigils-text-muted mt-0.5">
-              {{ t("settings.daemon.subtitle") }}
+              {{
+                model && !(model.privacy_installed || model.injection_installed)
+                  ? t("settings.daemon.subtitle_no_model")
+                  : t("settings.daemon.subtitle")
+              }}
             </div>
           </div>
           <div class="flex items-center gap-3 shrink-0">

--- a/apps/vigil-hub-cli/src/daemon/lifecycle.rs
+++ b/apps/vigil-hub-cli/src/daemon/lifecycle.rs
@@ -135,7 +135,7 @@ pub fn run_start(lang: Lang) -> Result<(), String> {
         injection,
         pii_loaded,
         inj_loaded,
-        uptime_secs: 0,
+        started: std::time::Instant::now(),
     };
     serve(listener, caps); // 阻塞;正常不返回(accept 循环)。
 
@@ -253,7 +253,9 @@ fn kill_pid(lang: Lang, pid: u32) -> Result<(), String> {
         c.arg(pid.to_string());
         c
     };
-    let status = cmd.status().map_err(|e| match lang {
+    // `output()` 捕获(吞掉)helper 自身的 stdout/stderr:taskkill 的本地化系统消息
+    // (非 UTF-8 代码页下还会乱码)不该混进 Vigil 的用户输出;结果仍由退出码判定。
+    let status = cmd.output().map(|o| o.status).map_err(|e| match lang {
         Lang::En => format!("failed to spawn the kill helper: {e}"),
         Lang::Zh => format!("启动结束进程助手失败:{e}"),
     })?;

--- a/apps/vigil-hub-cli/src/daemon/server.rs
+++ b/apps/vigil-hub-cli/src/daemon/server.rs
@@ -48,8 +48,8 @@ pub struct DaemonCaps {
     pub pii_loaded: bool,
     /// 注入分类器是否暖载。
     pub inj_loaded: bool,
-    /// daemon 启动至今秒数(Status 上报)。
-    pub uptime_secs: u64,
+    /// daemon 启动时刻;`Status` 的 `uptime_secs` 由此**实时计算**(存静态秒数会恒报启动值)。
+    pub started: std::time::Instant,
 }
 
 // 手写 Debug:`dyn PiiScanner` / `InjectionClassifier` 无 Debug bound;且**绝不**经 Debug 泄漏 token。
@@ -60,7 +60,7 @@ impl std::fmt::Debug for DaemonCaps {
             .field("ledger", &self.ledger.as_ref().map(|_| "<bound>"))
             .field("pii_loaded", &self.pii_loaded)
             .field("inj_loaded", &self.inj_loaded)
-            .field("uptime_secs", &self.uptime_secs)
+            .field("uptime_secs", &self.started.elapsed().as_secs())
             .finish_non_exhaustive() // token + injection 刻意省略(不入 Debug)
     }
 }
@@ -149,7 +149,7 @@ fn dispatch(req: &Request, caps: &DaemonCaps) -> Response {
         Request::Status => Response::Status {
             pii_loaded: caps.pii_loaded,
             inj_loaded: caps.inj_loaded,
-            uptime_secs: caps.uptime_secs,
+            uptime_secs: caps.started.elapsed().as_secs(),
             inflight: 0,
         },
         Request::RedactScan { text, .. } => match &caps.scanner {
@@ -265,7 +265,7 @@ mod tests {
             injection: None,
             pii_loaded: true,
             inj_loaded: false,
-            uptime_secs: 7,
+            started: std::time::Instant::now() - std::time::Duration::from_secs(7),
         }
     }
 
@@ -305,7 +305,7 @@ mod tests {
             injection: None,
             pii_loaded: false,
             inj_loaded: false,
-            uptime_secs: 7,
+            started: std::time::Instant::now() - std::time::Duration::from_secs(7),
         }
     }
 

--- a/apps/vigil-hub-cli/src/daemon/transport.rs
+++ b/apps/vigil-hub-cli/src/daemon/transport.rs
@@ -275,7 +275,7 @@ mod tests {
             injection: None,
             pii_loaded: false,
             inj_loaded: false,
-            uptime_secs: up,
+            started: std::time::Instant::now() - std::time::Duration::from_secs(up),
         };
         let listener = bind(sock).unwrap();
         std::thread::spawn(move || serve(listener, caps));

--- a/apps/vigil-hub-cli/src/demo.rs
+++ b/apps/vigil-hub-cli/src/demo.rs
@@ -638,9 +638,7 @@ fn ending_screen(lang: Lang) {
             println!("    provider was simulated.");
             println!();
             println!("    Protect your real agent:");
-            println!(
-                "      vigil-hub serve --stdio      # point Claude Code / Codex / Cursor at it"
-            );
+            println!("      vigil-hub setup --all        # one command, reversible");
             println!();
         }
         Lang::Zh => {
@@ -662,7 +660,7 @@ fn ending_screen(lang: Lang) {
             println!("    都是 Vigil 真实的运行时代码 —— 只有模型 / 工具一侧是模拟的。");
             println!();
             println!("    保护你真实的 agent:");
-            println!("      vigil-hub serve --stdio      # 把 Claude Code / Codex / Cursor 指向它");
+            println!("      vigil-hub setup --all        # 一条命令接入,全程可逆");
             println!();
         }
     }

--- a/apps/vigil-hub-cli/src/i18n/help.rs
+++ b/apps/vigil-hub-cli/src/i18n/help.rs
@@ -595,13 +595,15 @@ fn localize_checkpoint(c: Command, lang: Lang) -> Command {
                 "(<ledger>.checkpoints). Run it periodically (or from cron): the hash chain alone\n",
                 "can't detect a rewrite of the whole history, but these anchors can.\n",
                 "\n",
-                "Tip: keep the .checkpoints file append-only (chattr +a) or synced offsite.",
+                "Tip: keep the .checkpoints file append-only (Linux: chattr +a; macOS: chflags \
+                 uappnd) or sync it offsite (works on every OS, incl. Windows).",
             ),
             concat!(
                 "把当前审计链链头的快照写入一个独立的 append-only 文件(<ledger>.checkpoints)。\n",
                 "周期运行(或用 cron):仅靠哈希链检不出「整条历史被重写」,但这些锚点可以。\n",
                 "\n",
-                "提示:把 .checkpoints 文件设为 append-only(chattr +a)或异地同步。",
+                "提示:把 .checkpoints 文件设为 append-only(Linux:chattr +a;macOS:chflags uappnd)\n",
+                "或异地同步(任何系统含 Windows 都适用)。",
             ),
         ));
     arg_help(
@@ -815,31 +817,39 @@ fn localize_daemon(c: Command, lang: Lang) -> Command {
 }
 
 fn localize_model(c: Command, lang: Lang) -> Command {
-    let c = c
-        .about(s(
-            lang,
+    // 非 ML 构建在**顶层命令列表**就标注版本要求(F-14:用户照 help 跑到 `model install`
+    // 才被告知要换 ML 变体 = 撞墙式发现)。ML 构建不加噪音。
+    let (about_en, about_zh) = if cfg!(feature = "ort") {
+        (
             "Download or check the ML models (private-data + injection detectors, ~700MB each)",
             "下载或查看 ML 模型(隐私数据 + 注入检测器,各约 700MB)",
-        ))
-        .long_about(s(
-            lang,
-            concat!(
-                "Manages the optional ML models. The turnkey path is:\n",
-                "  vigil-hub model install  ->  vigil-hub daemon start  ->  vigil-hub engine set ml\n",
-                "\n",
-                "  install  download the models (--privacy / --injection to pick one; default both)\n",
-                "  status   show whether each model is cached locally\n",
-                "Needs an ML build (--features ort); a non-ML binary points you to the ML variant.",
-            ),
-            concat!(
-                "管理可选的 ML 模型。开箱即用的完整流程为:\n",
-                "  vigil-hub model install  →  vigil-hub daemon start  →  vigil-hub engine set ml\n",
-                "\n",
-                "  install  下载模型(--privacy / --injection 只装其一;默认两个都装)\n",
-                "  status   查看每个模型是否已在本地缓存\n",
-                "需 ML 构建变体(--features ort);非 ML 二进制会提示你改用 ML 变体。",
-            ),
-        ));
+        )
+    } else {
+        (
+            "Download or check the ML models (~700MB each; needs the ML build variant -- \
+             this standard binary will point you to it)",
+            "下载或查看 ML 模型(各约 700MB;需 ML 版二进制 —— 本标准版会提示你获取)",
+        )
+    };
+    let c = c.about(s(lang, about_en, about_zh)).long_about(s(
+        lang,
+        concat!(
+            "Manages the optional ML models. The turnkey path is:\n",
+            "  vigil-hub model install  ->  vigil-hub daemon start  ->  vigil-hub engine set ml\n",
+            "\n",
+            "  install  download the models (--privacy / --injection to pick one; default both)\n",
+            "  status   show whether each model is cached locally\n",
+            "Needs an ML build (--features ort); a non-ML binary points you to the ML variant.",
+        ),
+        concat!(
+            "管理可选的 ML 模型。开箱即用的完整流程为:\n",
+            "  vigil-hub model install  →  vigil-hub daemon start  →  vigil-hub engine set ml\n",
+            "\n",
+            "  install  下载模型(--privacy / --injection 只装其一;默认两个都装)\n",
+            "  status   查看每个模型是否已在本地缓存\n",
+            "需 ML 构建变体(--features ort);非 ML 二进制会提示你改用 ML 变体。",
+        ),
+    ));
     let c = c.mut_subcommand("install", |sc| {
         let sc = sc.about(s(
             lang,

--- a/apps/vigil-hub-cli/src/i18n/mod.rs
+++ b/apps/vigil-hub-cli/src/i18n/mod.rs
@@ -279,14 +279,30 @@ pub fn t(lang: Lang, msg: Msg<'_>) -> String {
             }
             Lang::Zh => format!("✓ 已在事件 #{event_id} 处锚定链头(head {head}…)→ {path}"),
         },
-        Msg::CheckpointTip => match lang {
-            Lang::En => "  tip: keep that file append-only (chattr +a) or synced offsite, so a \
-                 full-history rewrite can't also forge the anchor."
-                .into(),
-            Lang::Zh => "  提示:把锚点文件设为 append-only(chattr +a)或异地同步,\
-                 这样即便有人整体重写历史,也伪造不了锚点。"
-                .into(),
-        },
+        Msg::CheckpointTip => {
+            // 平台相关命令示例:Windows 无 append-only 文件属性 → 只建议异地同步。
+            let (en_how, zh_how) = if cfg!(windows) {
+                ("sync it offsite", "把锚点文件异地同步(如网络盘 / 备份)")
+            } else if cfg!(target_os = "macos") {
+                (
+                    "make it append-only (chflags uappnd) or sync it offsite",
+                    "把锚点文件设为 append-only(chflags uappnd)或异地同步",
+                )
+            } else {
+                (
+                    "make it append-only (chattr +a) or sync it offsite",
+                    "把锚点文件设为 append-only(chattr +a)或异地同步",
+                )
+            };
+            match lang {
+                Lang::En => format!(
+                    "  tip: {en_how}, so a full-history rewrite can't also forge the anchor."
+                ),
+                Lang::Zh => {
+                    format!("  提示:{zh_how},这样即便有人整体重写历史,也伪造不了锚点。")
+                }
+            }
+        }
         Msg::CheckpointNothing => match lang {
             Lang::En => {
                 "Nothing to anchor (the ledger is empty, or there are no new events since the last \

--- a/apps/vigil-hub-cli/src/main.rs
+++ b/apps/vigil-hub-cli/src/main.rs
@@ -75,8 +75,8 @@ enum Command {
     /// 锚定审计链头(ADR 0020):把当前链头快照写入与账本分离的 append-only sidecar
     /// (`<ledger>.checkpoints`)。周期运行(或 cron)即可检出**整链重写**——哈希链单独检不出的篡改。
     ///
-    /// 安全建议:把 `.checkpoints` 设为 OS append-only(`chattr +a`)或异地同步,锚点才能完全闭合
-    /// "持完整本地写权限者整链重写"。
+    /// 安全建议:把 `.checkpoints` 设为 OS append-only(Linux:`chattr +a`;macOS:`chflags uappnd`)
+    /// 或异地同步(含 Windows 均适用),锚点才能完全闭合"持完整本地写权限者整链重写"。
     Checkpoint(CliCheckpointArgs),
     /// 校验审计链:先链内一致性(防篡断裂),再比对 checkpoint 锚点(防整链重写)。三态如实输出。
     Verify(CliVerifyArgs),
@@ -110,8 +110,9 @@ enum Command {
 
 #[derive(clap::Args, Debug)]
 struct CliPostureArgs {
+    /// 省略子命令 = `show`(裸 `vigil-hub posture` 直接给当前值,不甩 help;F-11)。
     #[command(subcommand)]
-    command: PostureCommand,
+    command: Option<PostureCommand>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -131,8 +132,9 @@ enum PostureCommand {
 
 #[derive(clap::Args, Debug)]
 struct CliEngineArgs {
+    /// 省略子命令 = `show`(同 posture;F-11)。
     #[command(subcommand)]
-    command: EngineCommand,
+    command: Option<EngineCommand>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -149,8 +151,9 @@ enum EngineCommand {
 
 #[derive(clap::Args, Debug)]
 struct CliDaemonArgs {
+    /// 省略子命令 = `status`(裸 `vigil-hub daemon` 报运行态;`start`/`stop` 仍需显式;F-11)。
     #[command(subcommand)]
-    command: DaemonCommand,
+    command: Option<DaemonCommand>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -305,8 +308,8 @@ struct CliSetupArgs {
     /// Vigil 的 effect 提取词表内 → 提取不出 effect → enforce 下一律 default-deny = 真实 server **全部
     /// 不可用**(turnkey 一键接入直接打挂用户现有工作流 = 采用毒药)。monitor 姿态保留全部硬地板
     /// (裸 secret 拦截 + 结果脱敏可逆往返 + 显式 Deny + descriptor drift),只把 default-deny **地板**
-    /// 降级为观察放行 —— 实际交付的价值(脱敏 + 审计 + 输入拦截)全在,且 server 可用。Codex 评估
-    /// 与三方研究一致(93% 审批被未读即批 → 审批门是剧场;确定性脱敏 >> 阻塞审批)。
+    /// 降级为观察放行 —— 实际交付的价值(脱敏 + 审计 + 输入拦截)全在,且 server 可用。业界研究也一致:
+    /// 绝大多数审批弹窗被未读即批,拦截式审批容易沦为形式,而确定性脱敏保护始终生效。
     /// 想要硬拦语义(已知工具集 / 自建 server / 高保障场景)再显式 `--enforce`。
     #[arg(long)]
     enforce: bool,
@@ -328,10 +331,10 @@ struct CliSetupArgs {
     /// --apply` 两步合一(两者写不同文件、互不冲突)。`--all --uninstall` 撤销两者;`--all --dry-run`
     /// 预览两者;MCP 侧默认 monitor 姿态(加 `--enforce` 升级硬拦)。
     ///
-    /// 与只读操作 `--status` / `--doctor` **互斥**(Codex D13 HIGH:否则 `--all --status` 会因
-    /// `--all` 优先而**变成写操作**,破坏只读契约)—— clap 在 parse 期即拒绝该组合,fail-fast 防惊吓写入。
-    /// 也与 `--mcp` 互斥(Codex D13 R2 nit:`--all` 已含 MCP wrap,`--mcp` 此处会被静默忽略 = 歧义;
-    /// 拒绝逼用户明确用 `--all` **或** `--mcp` 之一)。
+    /// 与只读操作 `--status` / `--doctor` **互斥**(否则 `--all --status` 会因 `--all` 优先而
+    /// **变成写操作**,破坏只读预期)—— 该组合在解析期即被拒绝,避免意外写入。
+    /// 也与 `--mcp` 互斥(`--all` 已包含 MCP wrap,叠加 `--mcp` 会被静默忽略造成歧义;
+    /// 请二选一:`--all` 或 `--mcp`)。
     #[arg(long, conflicts_with_all = ["status", "doctor", "mcp"])]
     all: bool,
 }
@@ -682,7 +685,7 @@ fn run_engine(lang: Lang, args: CliEngineArgs) -> std::process::ExitCode {
         );
         return std::process::ExitCode::FAILURE;
     };
-    match args.command {
+    match args.command.unwrap_or(EngineCommand::Show) {
         EngineCommand::Show => {
             let loaded = engine_config::load_engine(&path);
             if let Some(w) = &loaded.warning {
@@ -729,7 +732,7 @@ fn run_engine(lang: Lang, args: CliEngineArgs) -> std::process::ExitCode {
 /// `vigil-hub daemon start|status`(ADR 0024):前台启动 / 查询常驻 daemon。逻辑在
 /// [`daemon::lifecycle`];本处只做分发 + ExitCode 映射。
 fn run_daemon(lang: Lang, args: CliDaemonArgs) -> std::process::ExitCode {
-    let result = match args.command {
+    let result = match args.command.unwrap_or(DaemonCommand::Status) {
         DaemonCommand::Start => daemon::lifecycle::run_start(lang),
         DaemonCommand::Status => daemon::lifecycle::run_status(lang),
         DaemonCommand::Stop => daemon::lifecycle::run_stop(lang),
@@ -772,7 +775,7 @@ fn run_posture(lang: Lang, args: CliPostureArgs) -> std::process::ExitCode {
         );
         return std::process::ExitCode::FAILURE;
     };
-    match args.command {
+    match args.command.unwrap_or(PostureCommand::Show) {
         PostureCommand::Show => {
             let loaded = posture::load_posture(&path);
             if let Some(w) = &loaded.warning {
@@ -1470,8 +1473,10 @@ fn run_agent_hook_legs(
                             "已安装但已失效(重跑 `vigil-hub setup` 刷新)",
                         )
                         .to_string(),
+                        // 「hook 未注册」而非「未安装」—— 本段说的是 Vigil hook 的注册态;
+                        // 「未安装」会被读成"该 agent CLI 没装"(F-5:机器上明明装着 Codex)。
                         ProtectionState::NotInstalled => {
-                            tr(lang, "not installed", "未安装").to_string()
+                            tr(lang, "hook not registered", "hook 未注册").to_string()
                         }
                     },
                     setup_hooks::AgentHookOp::Install { dry_run } => {
@@ -1566,7 +1571,9 @@ fn print_setup_all(
         println!("  [1/2] {hook_label}: {did}");
     }
 
-    // [2/2] MCP 网关 wrap(脱敏 + 审计 + 审批 + descriptor pin)
+    // [2/2] MCP 网关 wrap(脱敏 + 审计 + 审批 + descriptor pin)。
+    // 标注 scope(Claude Code):本计数只含 Claude 的 user+local server;Codex/Cursor/Windsurf
+    // 各有独立段落 —— 不标注会让用户误以为这就是全局总数(F-6:真机 22 个被读成 1 个)。
     let total = mcp.total_changed();
     match lang {
         Lang::En => {
@@ -1575,7 +1582,7 @@ fn print_setup_all(
             } else {
                 "wrapped"
             };
-            println!("  [2/2] MCP gateway: {verb} {total} server(s)");
+            println!("  [2/2] MCP gateway (Claude Code): {verb} {total} server(s); other agents follow below");
         }
         Lang::Zh => {
             let verb = if op == "uninstall" {
@@ -1583,7 +1590,7 @@ fn print_setup_all(
             } else {
                 "已防护"
             };
-            println!("  [2/2] MCP 网关:{verb} {total} 个服务器");
+            println!("  [2/2] MCP 网关(Claude Code):{verb} {total} 个服务器;其它 agent 见下方各段");
         }
     }
     if mcp.local_skipped > 0 {
@@ -1852,14 +1859,24 @@ fn print_mcp_apply(lang: Lang, r: &setup_mcp::McpApplyReport, op: &str) -> std::
         (Lang::Zh, false) => "防护",
     };
     let total = r.total_changed();
+    // 「改动写入配置文件」只在真写盘时声称(0 改动 / dry-run 未写文件,措辞失实 = F-6c)。
+    let wrote = total > 0 && !r.dry_run;
     match lang {
         Lang::En => println!(
-            "Vigil setup --mcp --{op}{dry}: {verb} {what} {total} MCP server(s) in {}",
-            r.claude_json.display()
+            "Vigil setup --mcp --{op}{dry}: {verb} {what} {total} MCP server(s){}",
+            if wrote {
+                format!(" in {}", r.claude_json.display())
+            } else {
+                format!(" ({} untouched)", r.claude_json.display())
+            }
         ),
         Lang::Zh => println!(
-            "Vigil setup --mcp --{op}{dry}:{verb}{what} {total} 个 MCP 服务器,改动写入配置文件 {}",
-            r.claude_json.display()
+            "Vigil setup --mcp --{op}{dry}:{verb}{what} {total} 个 MCP 服务器{}",
+            if wrote {
+                format!(",改动写入配置文件 {}", r.claude_json.display())
+            } else {
+                format!("(配置文件 {} 未改动)", r.claude_json.display())
+            }
         ),
     }
     // 分 scope 报告:local scope(projects.*)用**项目限定 server-id**(跨项目同名不串账本)。
@@ -1964,10 +1981,63 @@ fn print_mcp_server_preview(
             );
         }
         McpServerClass::Skipped { name, reason } => {
-            // reason 是 setup_mcp 产出的英文分类码(如 non-stdio),保持原样。
-            println!("  [SKIP] {name} -- {reason}");
+            // reason 是 setup_mcp 产出的英文分类码;zh 输出按已知前缀映射中文,未知则原样
+            // (F-4:英文整句混进中文预览)。
+            match lang {
+                Lang::En => println!("  [SKIP] {name} -- {reason}"),
+                Lang::Zh => println!("  [SKIP] {name} —— {}", skip_reason_zh(reason)),
+            }
         }
     }
+}
+
+/// 把 `setup_mcp` 的英文 Skip 分类码按**稳定前缀**映射为中文(未知原样返回,fail-open 到英文)。
+/// 分类码是 `&'static str` 且仅在 setup_mcp 内定义 —— 前缀匹配足够稳,免为文案引入枚举 ripple。
+fn skip_reason_zh(reason: &str) -> String {
+    const MAP: &[(&str, &str)] = &[
+        (
+            "appears already wrapped under a wrapper prefix",
+            "疑似已被 wrapper 前缀(stdbuf/sh/env…)包裹 —— 跳过,避免嵌套",
+        ),
+        (
+            "Vigil's own server/gateway entry",
+            "Vigil 自身的 server/网关条目 —— 绝不包裹(会自我嵌套)",
+        ),
+        (
+            "remote (http/sse) server",
+            "远程(http/sse)server —— HTTP MCP 的包裹在后续版本支持",
+        ),
+        (
+            "non-stdio or malformed `type`",
+            "非 stdio 或 `type` 字段异常 —— 当前版本不包裹",
+        ),
+        (
+            "`args` is present but not an array",
+            "`args` 存在但不是数组(形状异常)—— 原样未动",
+        ),
+        (
+            "entry has no `command`",
+            "条目缺 `command`(形状异常)—— 原样未动",
+        ),
+        (
+            "`args` has a non-string element",
+            "`args` 含非字符串元素(形状异常)—— 原样未动",
+        ),
+        (
+            "`command` is a single shell string with quotes",
+            "`command` 是含引号的单条 shell 字符串;请在 MCP 配置里拆成 `command` + `args` 数组后再保护",
+        ),
+        (
+            "single-string `command` is itself a vigil-hub invocation",
+            "单串 `command` 本身就是一次 vigil-hub 调用 —— 跳过,避免二次包裹",
+        ),
+    ];
+    for (prefix, zh) in MAP {
+        if reason.starts_with(prefix) {
+            return (*zh).to_string();
+        }
+    }
+    reason.to_string()
 }
 
 fn print_mcp_preview(lang: Lang, r: &setup_mcp::McpPreviewReport) -> std::process::ExitCode {
@@ -2174,16 +2244,25 @@ fn print_codex_apply(lang: Lang, r: &setup_mcp::CodexApplyReport, op: &str) {
         (Lang::Zh, true) => "还原",
         (Lang::Zh, false) => "防护",
     };
+    let wrote = r.changed > 0 && !r.dry_run;
     match lang {
         Lang::En => println!(
-            "Vigil setup --mcp --{op}{dry} (Codex): {verb} {what} {} MCP server(s) in {}",
+            "Vigil setup --mcp --{op}{dry} (Codex): {verb} {what} {} MCP server(s){}",
             r.changed,
-            r.codex_config.display()
+            if wrote {
+                format!(" in {}", r.codex_config.display())
+            } else {
+                format!(" ({} untouched)", r.codex_config.display())
+            }
         ),
         Lang::Zh => println!(
-            "Vigil setup --mcp --{op}{dry}(Codex):{verb}{what} {} 个 MCP 服务器,改动写入配置文件 {}",
+            "Vigil setup --mcp --{op}{dry}(Codex):{verb}{what} {} 个 MCP 服务器{}",
             r.changed,
-            r.codex_config.display()
+            if wrote {
+                format!(",改动写入配置文件 {}", r.codex_config.display())
+            } else {
+                format!("(配置文件 {} 未改动)", r.codex_config.display())
+            }
         ),
     }
     if let Some(b) = &r.backup {
@@ -2274,18 +2353,27 @@ fn print_json_agent_apply(lang: Lang, r: &setup_mcp::JsonAgentApplyReport, op: &
         (Lang::Zh, true) => "还原",
         (Lang::Zh, false) => "防护",
     };
+    let wrote = r.changed > 0 && !r.dry_run;
     match lang {
         Lang::En => println!(
-            "Vigil setup --mcp --{op}{dry} ({}): {verb} {what} {} MCP server(s) in {}",
+            "Vigil setup --mcp --{op}{dry} ({}): {verb} {what} {} MCP server(s){}",
             r.display_name,
             r.changed,
-            r.config_path.display()
+            if wrote {
+                format!(" in {}", r.config_path.display())
+            } else {
+                format!(" ({} untouched)", r.config_path.display())
+            }
         ),
         Lang::Zh => println!(
-            "Vigil setup --mcp --{op}{dry}({}):{verb}{what} {} 个 MCP 服务器,改动写入配置文件 {}",
+            "Vigil setup --mcp --{op}{dry}({}):{verb}{what} {} 个 MCP 服务器{}",
             r.display_name,
             r.changed,
-            r.config_path.display()
+            if wrote {
+                format!(",改动写入配置文件 {}", r.config_path.display())
+            } else {
+                format!("(配置文件 {} 未改动)", r.config_path.display())
+            }
         ),
     }
     if let Some(b) = &r.backup {

--- a/apps/vigil-hub-cli/src/quickstart.rs
+++ b/apps/vigil-hub-cli/src/quickstart.rs
@@ -79,9 +79,17 @@ fn agent_line(lang: Lang, label: &str, configured: bool, c: Counts) -> String {
         });
     }
     if c.skipped > 0 {
+        // `Skipped` 含多种原因(http/sse 远程、配置形状异常等)—— 不再统称 http/sse
+        // (F-4b:曾把「名字不合法」的 stdio server 错标成 http/sse,与 setup --mcp 预览矛盾)。
         parts.push(match lang {
-            Lang::En => format!("{} unsupported (http/sse)", c.skipped),
-            Lang::Zh => format!("{} 个暂不支持(http/sse)", c.skipped),
+            Lang::En => format!(
+                "{} not wrappable (http/sse or unusual shape; see `vigil-hub setup --mcp`)",
+                c.skipped
+            ),
+            Lang::Zh => format!(
+                "{} 个暂不可保护(http/sse 或形状异常;详见 vigil-hub setup --mcp)",
+                c.skipped
+            ),
         });
     }
     format!("    {label:<13} {}", parts.join(" · "))

--- a/apps/vigil-hub-cli/src/setup_mcp.rs
+++ b/apps/vigil-hub-cli/src/setup_mcp.rs
@@ -260,18 +260,9 @@ fn classify_one(name: &str, entry: &Value) -> McpServerClass {
                 .collect()
         }
     };
-    // F3(Codex holistic MEDIUM):server-id 由 name 派生(`user-<name>` / `local-<hash>-<name>`),
-    // 但网关 attach 时只接受 `^[a-z0-9_-]+$`(namespace::validate_server_id)。若 name 含大写/空格/点/
-    // 斜杠等(Claude server 名可任意),改写会"apply 成功但 wrap 启动失败"(配置坏了却看不出)。
-    // 用**真验证器**校验 name —— 名合法则 `user-`/`local-<hash>-` 前缀拼接后必合法;不合法则 Skip
-    // (不改写),让用户改名后再保护,而非产出一个起不来的网关条目。
-    if vigil_mcp::namespace::validate_server_id(name).is_err() {
-        return McpServerClass::Skipped {
-            name: name.into(),
-            reason: "server name has characters not allowed in a gateway id (use a-z 0-9 _ -); \
-                     rename it in your MCP config to protect it",
-        };
-    }
+    // server 名可含大写/空格/点等任意字符(如 `Playwright`)—— 网关 id 由各派生函数经
+    // [`server_id_component`] 规约(小写 slug + 哈希去歧义),**不再因命名 Skip**(修 F-4:
+    // 专有名词大写命名极常见,让用户手动改名=成规模漏保护)。
 
     // env **键名**(只键不值;绝不读 secret 值)。
     let env_keys: Vec<String> = entry
@@ -369,15 +360,45 @@ pub fn wrapped_argv(
 /// 碰撞概率 ~ n²/2¹²⁸,对任何现实项目数天文级不可能(Codex D8 review:8 hex/32-bit 太短,要求 ≥128-bit)。
 const LOCAL_ID_HASH_HEX: usize = 32;
 
-/// 为 **user scope**(顶层 `mcpServers`)的 server 派生 server-id:`user-<name>`。
+/// 把 agent 配置里的 server 名规约成网关 id 合法组件(`^[a-z0-9_-]+$`)。
+///
+/// 名本就合法 → **原样返回**(既有用户的 server-id 逐字不变 = 向后兼容)。含大写/空格/点等
+/// 非法字符(如 `Playwright`)→ 小写化 + 非法字符折叠为 `-`,再追加 `-<sha256(原名)[:8]>`
+/// 去歧义:两个仅大小写不同的名 slug 相同,哈希后缀保证身份不塌缩;同名恒同 id(稳定)。
+/// 全部字符都不可用(如纯中文名)→ 退化为 `srv-<hash>`。修 F-4:此前直接 Skip 让用户手动
+/// 改名 —— 专有名词大写命名极常见,会成规模漏保护。
+fn server_id_component(name: &str) -> String {
+    let is_valid = |c: char| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-';
+    if !name.is_empty() && name.chars().all(is_valid) {
+        return name.to_string();
+    }
+    let mut slug = String::with_capacity(name.len());
+    for c in name.to_lowercase().chars() {
+        if is_valid(c) {
+            slug.push(c);
+        } else if !slug.ends_with('-') {
+            slug.push('-');
+        }
+    }
+    let slug = slug.trim_matches('-');
+    let digest = Sha256::digest(name.as_bytes());
+    let hash = &hex::encode(digest)[..8];
+    if slug.is_empty() {
+        format!("srv-{hash}")
+    } else {
+        format!("{slug}-{hash}")
+    }
+}
+
+/// 为 **user scope**(顶层 `mcpServers`)的 server 派生 server-id:`user-<组件>`。
 ///
 /// 加 `user-` 前缀(而非裸 `<name>`)是为与 [`local_scope_server_id`] 的 `local-` 命名空间**可证不相交**
 /// —— Codex D8 R1 指出:裸名会与 local id 撞(用户若把 user-scope server 命名成形似 local id 的串,
 /// 两者在共享账本里塌缩)。两侧都由 Vigil 加 disjoint 前缀后,任意用户取名都不可能跨 scope 撞 id。
 /// 分隔符用 `-`(**非** `:`)—— `:` 不在网关 `SERVER_ID_RE = ^[a-z0-9_-]+$` 字符集内会 attach 失败
-/// (Codex D8 R2 抓的回归);`-` 合法。
+/// (Codex D8 R2 抓的回归);`-` 合法。名含非法字符时经 [`server_id_component`] 规约。
 pub fn user_scope_server_id(name: &str) -> String {
-    format!("user-{name}")
+    format!("user-{}", server_id_component(name))
 }
 
 /// 为 **local scope**(`projects.<path>.mcpServers`)的 server 派生**项目限定** server-id。
@@ -394,7 +415,7 @@ pub fn user_scope_server_id(name: &str) -> String {
 pub fn local_scope_server_id(project_path: &str, name: &str) -> String {
     let digest = Sha256::digest(project_path.as_bytes());
     let hash = &hex::encode(digest)[..LOCAL_ID_HASH_HEX];
-    format!("local-{hash}-{name}")
+    format!("local-{hash}-{}", server_id_component(name))
 }
 
 /// 枚举 **local scope**(`projects.<path>.mcpServers`)所有 server → `(project_path, 分类)`。纯函数。
@@ -846,13 +867,13 @@ pub fn codex_config_path(home: &Path) -> PathBuf {
     home.join(".codex").join("config.toml")
 }
 
-/// 为 Codex `[mcp_servers.<name>]` 条目派生 server-id:`codex-<name>`。
+/// 为 Codex `[mcp_servers.<name>]` 条目派生 server-id:`codex-<组件>`。
 ///
 /// 加 `codex-` 前缀与 [`user_scope_server_id`](`user-`)/ [`local_scope_server_id`](`local-`)
-/// 命名空间不相交。`name` 已由 [`classify_one`] 用真验证器 `validate_server_id` 过滤(`^[a-z0-9_-]+$`),
-/// 故 `codex-<name>` 拼接后必合法(`codex-` 全在字符集内)。
+/// 命名空间不相交。名经 [`server_id_component`] 规约(合法名原样;非法字符 slug + 哈希),
+/// 拼接后必合法(`codex-` 全在字符集内)。
 pub fn codex_scope_server_id(name: &str) -> String {
-    format!("codex-{name}")
+    format!("codex-{}", server_id_component(name))
 }
 
 /// 读 + 解析 `~/.codex/config.toml`(格式保留)。不存在 → `Ok(None)`;损坏 / 超大 → abort
@@ -1228,9 +1249,10 @@ impl JsonMcpAgent {
         }
     }
     /// 派生 server-id:`<prefix>-<name>`(与 `user-`/`local-`/`codex-` 命名空间不相交)。
-    /// `name` 已由 [`classify_one`] 用真验证器过滤,前缀全在 `^[a-z0-9_-]+$` 字符集内,拼接后必合法。
+    /// 名经 [`server_id_component`] 规约(合法名原样;非法字符 slug + 哈希),前缀全在
+    /// `^[a-z0-9_-]+$` 字符集内,拼接后必合法。
     fn server_id(&self, name: &str) -> String {
-        format!("{}-{}", self.id_prefix, name)
+        format!("{}-{}", self.id_prefix, server_id_component(name))
     }
 }
 
@@ -2176,9 +2198,10 @@ mod tests {
     }
 
     #[test]
-    fn invalid_server_name_skipped_not_wrapped() {
-        // F3(Codex holistic MEDIUM):名含网关 server-id 不允许的字符(大写/空格/点/斜杠)→ Skip,
-        // 否则 apply 成功但 wrap attach 在 validate_server_id 失败 = 坏配置。逐名核对真验证器口径。
+    fn invalid_server_name_wrappable_with_valid_derived_id() {
+        // F-4 修订:名含网关 server-id 不允许的字符(大写/空格/点/斜杠)不再 Skip ——
+        // 派生 id 经 [`server_id_component`] slug 化后必过真验证器,配置键名原样保留。
+        // (旧契约「非法名必 Skip」让 Playwright 这类大写命名成规模漏保护。)
         let cfg = json!({"mcpServers": {
             "Filesystem": {"command": "npx", "args": ["a"]},          // 大写
             "my server": {"command": "npx", "args": ["a"]},          // 空格
@@ -2187,21 +2210,23 @@ mod tests {
             "good-name_1": {"command": "npx", "args": ["a"]}         // 合法
         }});
         let c = classify_user_scope_servers(&cfg);
-        let skipped = |n: &str| {
-            c.iter()
-                .any(|x| matches!(x, McpServerClass::Skipped { name, .. } if name == n))
-        };
-        for bad in ["Filesystem", "my server", "weather.api", "a/b"] {
+        for n in [
+            "Filesystem",
+            "my server",
+            "weather.api",
+            "a/b",
+            "good-name_1",
+        ] {
             assert!(
-                skipped(bad),
-                "非法名 `{bad}` 须 Skipped(否则 wrap 启动失败)"
+                c.iter()
+                    .any(|x| matches!(x, McpServerClass::Wrappable { name, .. } if name == n)),
+                "名 `{n}` 应 Wrappable(id 由派生函数 slug 化)"
             );
+            // 派生 id 必过网关真验证器(原始名不合法时靠 slug + 哈希兜住)
+            vigil_mcp::namespace::validate_server_id(&user_scope_server_id(n))
+                .unwrap_or_else(|e| panic!("`{n}` 的派生 id 必合法:{e:?}"));
         }
-        // 合法名仍 Wrappable
-        assert!(c
-            .iter()
-            .any(|x| matches!(x, McpServerClass::Wrappable { name, .. } if name == "good-name_1")));
-        // 真验证器一致性:被 Skip 的名确实过不了 validate_server_id
+        // 真验证器口径不变:原始非法名裸用仍过不了(slug 收口的必要性)
         assert!(vigil_mcp::namespace::validate_server_id("Filesystem").is_err());
         assert!(vigil_mcp::namespace::validate_server_id("good-name_1").is_ok());
     }
@@ -2511,6 +2536,50 @@ mod tests {
             vigil_mcp::namespace::validate_server_id(id)
                 .unwrap_or_else(|e| panic!("生成的 server-id `{id}` 必须过网关校验:{e:?}"));
         }
+    }
+
+    #[test]
+    fn server_id_component_slugs_invalid_names_stably() {
+        // 合法名**原样**(既有用户的 server-id 逐字不变 = 向后兼容)。
+        assert_eq!(server_id_component("filesystem"), "filesystem");
+        assert_eq!(server_id_component("my_srv-2"), "my_srv-2");
+        // 大写名(F-4 实测场景 `Playwright`)→ 小写 slug + 8hex 哈希;同名恒同、大小写变体不塌缩。
+        let p = server_id_component("Playwright");
+        assert!(
+            p.starts_with("playwright-") && p.len() == "playwright-".len() + 8,
+            "slug+8hex:{p}"
+        );
+        assert_eq!(p, server_id_component("Playwright"), "同名恒同 id(稳定)");
+        assert_ne!(
+            p,
+            server_id_component("playwright"),
+            "大小写变体不得塌缩为同一身份"
+        );
+        // 全非法字符退化 `srv-<hash>`;空格/点折叠为单个 `-`。
+        assert!(server_id_component("数据库").starts_with("srv-"));
+        assert!(server_id_component("My Server.v2").starts_with("my-server-v2-"));
+        // 一切产物(含前缀拼接后)必过网关真验证器。
+        for n in ["Playwright", "My Server.v2", "数据库", "a--B", " x "] {
+            let c = server_id_component(n);
+            vigil_mcp::namespace::validate_server_id(&c)
+                .unwrap_or_else(|e| panic!("slug `{c}` 必合法:{e:?}"));
+        }
+        vigil_mcp::namespace::validate_server_id(&user_scope_server_id("My Server")).unwrap();
+        vigil_mcp::namespace::validate_server_id(&codex_scope_server_id("Chrome DevTools"))
+            .unwrap();
+    }
+
+    #[test]
+    fn classify_accepts_uppercase_server_names_as_wrappable() {
+        // F-4:大写名不再 Skip —— 进入可保护集合(id 由派生函数 slug 化,原配置键名不动)。
+        let cfg = json!({"mcpServers": {"Playwright":
+            {"command": "npx", "args": ["-y", "x"], "type": "stdio"}}});
+        let cls = classify_user_scope_servers(&cfg);
+        assert_eq!(cls.len(), 1);
+        assert!(
+            matches!(&cls[0], McpServerClass::Wrappable { name, .. } if name == "Playwright"),
+            "大写名应 Wrappable,got {cls:?}"
+        );
     }
 
     #[test]
@@ -3070,15 +3139,19 @@ args = ["wrap", "--server-id", "codex-already", "--vigil-managed-mcp", "--", "np
         assert!(!run_codex_preview(home, "vigil-hub", true).unwrap().exists);
     }
 
-    /// 非法 server 名(含大写 / 点)→ Skipped(不产出一个起不来的网关条目)。
+    /// 非法 server 名(含大写 / 点)→ Wrappable(F-4 修订:id 经 slug 化派生,不再要求用户改名)。
     #[test]
-    fn codex_invalid_server_name_skipped() {
+    fn codex_invalid_server_name_wrappable_with_valid_id() {
         let doc = "[mcp_servers.\"Bad.Name\"]\ncommand = \"npx\"\nargs = [\"x\"]\n"
             .parse::<DocumentMut>()
             .unwrap();
         let classes = classify_codex_servers(&doc);
         assert_eq!(classes.len(), 1);
-        assert!(matches!(&classes[0], McpServerClass::Skipped { name, .. } if name == "Bad.Name"));
+        assert!(
+            matches!(&classes[0], McpServerClass::Wrappable { name, .. } if name == "Bad.Name"),
+            "非法名应 Wrappable,got {classes:?}"
+        );
+        vigil_mcp::namespace::validate_server_id(&codex_scope_server_id("Bad.Name")).unwrap();
     }
 
     /// 内联表条目形态(`[mcp_servers]` 表内 `foo = { command=.., args=.. }`)也能 wrap/unwrap 往返,

--- a/extensions/chrome-mv3/options.html
+++ b/extensions/chrome-mv3/options.html
@@ -47,7 +47,7 @@
   </section>
 
   <section class="section">
-    <h2>守门档位(ISS-007)</h2>
+    <h2>守门档位</h2>
     <p class="desc">
       决定命中硬指纹后 Vigils 的行为。默认 <strong>balanced</strong>;
       in-memory 会话级设置(浏览器重启恢复默认)。
@@ -83,7 +83,7 @@
       <li>host_permissions:ChatGPT / Claude / Gemini / Perplexity 及已列入 manifest 的国内 AI 站点</li>
       <li>实时提示在网页输入框内显示;Options 仅用于安装、档位和权限说明</li>
       <li>CSP <code>script-src 'self'</code>,禁 <code>unsafe-eval</code> / 内联 script</li>
-      <li>原文永不入 chrome.storage / console.log(ADR 0009 §I-9.1)</li>
+      <li>原文永不写入 chrome.storage,也不打印到 console.log</li>
     </ul>
   </section>
 

--- a/extensions/chrome-mv3/popup.css
+++ b/extensions/chrome-mv3/popup.css
@@ -164,6 +164,14 @@ button {
 button:hover {
   background: var(--panel-soft);
 }
+/* 禁用态可视化:JS 已在非 http(s) / 已豁免时 disabled 按钮,但无样式时看起来仍可点。 */
+button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+button:disabled:hover {
+  background: transparent;
+}
 .actions a {
   color: var(--accent);
   text-decoration: none;

--- a/extensions/chrome-mv3/popup.html
+++ b/extensions/chrome-mv3/popup.html
@@ -67,7 +67,7 @@
 
   <footer>
     <small>
-      原文仅在本机 Native Host 内存停留,分类完立即 drop(ADR 0009 §I-9.1)。
+      原文仅在本机 Native Host 内存停留,分类完立即丢弃,绝不落盘。
     </small>
   </footer>
 


### PR DESCRIPTION
逐功能用户级验证(真二进制三端走查:CLI 全命令 + GUI CDP 交互 + headless 浏览器扩展加载)发现的一批修复,从内部仓移植。

## 变更
- **feat(setup): server 名 slugify** —— 大写/含非法字符命名(如 `Playwright`)不再 SKIP 漏保护。`server_id_component` 单点收口全部 id 派生:合法名逐字不变(既有 server-id 向后兼容);非法名小写 slug + sha256(原名)[:8] 去歧义(大小写变体不塌缩)。quickstart 的 Skipped 标签不再统称 http/sse(此前与 setup --mcp 预览矛盾)。+3 单测。
- **fix(daemon)**: status uptime 实时计算(此前恒报 0s,确定性复现);stop 吞掉 taskkill 系统输出(非 UTF-8 代码页乱码直漏用户面)。
- **fix(cli)**: demo 结尾改推 `setup --all`;setup --help 清理内部评审留痕;checkpoint 提示平台化(Windows 不再建议 Linux 专属 `chattr +a`);setup --all 输出如实化([2/2] 标注 scope、「改动写入配置文件」按真实写盘条件);「未安装」→「hook 未注册」;[SKIP] 理由 zh 映射;posture/engine/daemon 裸调用默认 show/status;非 ML 构建 model help 标注需 ML 版。
- **fix(desktop)**: daemon 卡在模型未装时如实降级承诺;NConfigProvider 接 naive-ui zhCN(空表 No Data 等内建文案随语言)。
- **fix(extension)**: 用户界面清理内部编号引用;补 button:disabled 视觉样式。

## 验证
- 独立构建门禁:fmt + clippy `-D warnings` + **1212 tests / 0 failed**
- 前端 vue-tsc + vite build 通过
- 内部仓同批修复已经真机复验(CLI 六项 + GUI CDP 全页复走 + mac 截图)