### PR TITLE
docs+release: v0.4.6-beta.1 —— 文档漂移修正 + 版本 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,57 @@ All notable changes to Vigils are documented here. The format follows
 
 ---
 
+## [v0.4.6-beta.1] — 2026-07-02 — user-level polish: server-name slugify, honest status surfaces
+
+A beta focused on findings from a feature-by-feature user-level verification pass (real binaries on
+all three platforms). No security-invariant changes; hard floors are untouched.
+
+### Added
+
+- **Server names with uppercase / spaces / dots are now protectable** (`setup --mcp` / `--all`):
+  gateway server-ids are derived through a slugifier (`Playwright` → `user-playwright-<hash8>`)
+  instead of skipping the server and asking you to rename it in your MCP config. Already-valid
+  names keep their exact ids (backward compatible); case-variants can't collapse into one identity
+  (hash suffix).
+- Bare `vigil-hub posture` / `engine` / `daemon` now default to `show` / `status` instead of
+  printing help.
+
+### Fixed
+
+- `daemon status` uptime was frozen at `0s`; it now reports real elapsed time. `daemon stop` no
+  longer leaks the OS kill helper's localized output (mojibake on non-UTF-8 codepages).
+- `setup --all` output honesty: the `[2/2]` MCP gateway line is scoped ("Claude Code") so per-agent
+  sections aren't misread against a global total; "changes written to <config>" only appears when
+  the file was actually written; agent-CLI status now says "hook not registered" instead of the
+  misleading "not installed".
+- `demo` now points at `vigil-hub setup --all` (the turnkey path) instead of the manual
+  `serve --stdio` flow.
+- `checkpoint` tip is platform-aware — no more Linux-only `chattr +a` advice on Windows; macOS
+  suggests `chflags uappnd`.
+- `setup --mcp` preview skip-reasons are localized in Chinese output; `quickstart` no longer
+  mislabels every skipped server as "http/sse".
+- `--help` for `model` on the standard (non-ML) build says up front that the ML build variant is
+  required, instead of letting you discover it at `model install`.
+- Internal review shorthand removed from `setup --help` text.
+- Desktop: the daemon card no longer promises "start it to enable ML protection" when no model is
+  installed (it now says the daemon would run model-less on the hard-fingerprint floor); Naive UI
+  built-in texts (empty tables, pagination) follow the app language.
+- Extension: internal spec references removed from user-facing text; disabled buttons now look
+  disabled; guarded-site copy matches the actual manifest list.
+
+### Docs
+
+- `docs/user-guide/`: removed commands that don't exist (`ledger verify` / `ledger query` →
+  `vigil-hub verify` + Activity Feed / direct SQLite), corrected the default ledger path
+  (`%LOCALAPPDATA%\Vigil\ledger.sqlite3` and per-OS equivalents, aligned via
+  `VIGIL_LEDGER_PATH`), replaced the stale "Stage 1: `tools/list` returns empty" note with the
+  real upstream-forwarding behavior, and pointed installation at GitHub Releases.
+- README (en/zh): the ML-variant availability note was stale (ML builds ship since v0.4.0);
+  softened "restored byte-for-byte" to the verified claim (only Vigils' own entries are removed,
+  settings restored faithfully).
+
+---
+
 ## [v0.4.5] — 2026-06-30 — close `VIGIL-SEC-ML-SKIP` (`secret://` face): same-leaf soft-PII redaction restored
 
 ### Security

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -8,6 +8,45 @@ Vigils 的所有重要变更记录于此。格式遵循
 
 ---
 
+## [v0.4.6-beta.1] — 2026-07-02 — 用户级打磨:server 名 slugify、状态陈述如实化
+
+本测试版聚焦「逐功能用户级验证」(三平台真二进制走查)发现的问题。不涉及任何安全不变量变更,硬底线不动。
+
+### 新增
+
+- **含大写 / 空格 / 点的 server 名现在可被保护**(`setup --mcp` / `--all`):网关 server-id 经
+  slugifier 派生(`Playwright` → `user-playwright-<hash8>`),不再跳过并要求你去改 MCP 配置里的名字。
+  本就合法的名字 id 逐字不变(向后兼容);大小写变体不会塌缩成同一身份(哈希后缀)。
+- 裸 `vigil-hub posture` / `engine` / `daemon` 现在默认执行 `show` / `status`,不再甩出 help。
+
+### 修复
+
+- `daemon status` 的运行时长恒为 `0s`;现在如实报告已运行时间。`daemon stop` 不再把系统结束进程
+  助手的本地化输出漏进用户界面(非 UTF-8 代码页下曾乱码)。
+- `setup --all` 输出如实化:`[2/2]` MCP 网关行标注 scope(Claude Code),不再被误读成全局总数;
+  「改动写入配置文件」只在真实写盘时出现;agent CLI 状态由易误读的「未安装」改为「hook 未注册」。
+- `demo` 结尾改推 `vigil-hub setup --all`(一键路径),不再指向手动 `serve --stdio` 流程。
+- `checkpoint` 提示按平台给建议 —— Windows 不再出现 Linux 专属的 `chattr +a`;macOS 建议
+  `chflags uappnd`。
+- `setup --mcp` 预览的跳过原因在中文输出下本地化;`quickstart` 不再把所有被跳过的 server 统称
+  「http/sse」。
+- 标准(非 ML)构建的 `model` help 直接标注需 ML 版二进制,不再等到 `model install` 才发现。
+- `setup --help` 文本清理内部评审速记。
+- 桌面:模型未安装时,守护进程卡不再承诺「启动即开启 ML 防护」(现在说明此时 daemon 以无模型方式
+  运行,hook 保持硬指纹底座);Naive UI 内建文案(空表、分页)随应用语言。
+- 扩展:用户可见文本清除内部规范编号;禁用按钮有了禁用外观;守护站点文案与 manifest 实际清单一致。
+
+### 文档
+
+- `docs/user-guide/`:移除不存在的命令(`ledger verify` / `ledger query` → `vigil-hub verify` +
+  Activity Feed / 直查 SQLite),修正默认账本路径(`%LOCALAPPDATA%\Vigil\ledger.sqlite3` 及各
+  平台等价路径,用 `VIGIL_LEDGER_PATH` 对齐),把过时的「Stage 1:`tools/list` 返空」说明替换为
+  真实的上游转发行为,并把安装指引指向 GitHub Releases。
+- README(中英):ML 变体可用性说明已过时(v0.4.0 起随每个 release 发布);「逐字节还原」措辞
+  收敛为经验证的承诺(只删 Vigils 自己的条目,你的配置如实还原)。
+
+---
+
 ## [v0.4.5] — 2026-06-30 — 闭合 `VIGIL-SEC-ML-SKIP`(`secret://` 面):恢复同段 soft-PII 脱敏
 
 ### 安全

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4851,6 +4851,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5781,7 +5790,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vigil-audit"
-version = "0.4.5"
+version = "0.4.6-beta.1"
 dependencies = [
  "criterion",
  "hex",
@@ -5801,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-browser"
-version = "0.4.5"
+version = "0.4.6-beta.1"
 dependencies = [
  "once_cell",
  "regex",
@@ -5814,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-desktop"
-version = "0.4.5"
+version = "0.4.6-beta.1"
 dependencies = [
  "base64 0.22.1",
  "blake2",
@@ -5849,7 +5858,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-firewall"
-version = "0.4.5"
+version = "0.4.6-beta.1"
 dependencies = [
  "dunce",
  "hex",
@@ -5873,7 +5882,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-http-auth"
-version = "0.4.5"
+version = "0.4.6-beta.1"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -5890,7 +5899,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-http-transport"
-version = "0.4.5"
+version = "0.4.6-beta.1"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -5924,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-hub-cli"
-version = "0.4.5"
+version = "0.4.6-beta.1"
 dependencies = [
  "clap",
  "dirs 6.0.0",
@@ -5938,6 +5947,7 @@ dependencies = [
  "serde_jcs",
  "serde_json",
  "sha2",
+ "sys-locale",
  "tempfile",
  "thiserror 1.0.69",
  "toml_edit 0.25.12+spec-1.1.0",
@@ -5959,7 +5969,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-lease"
-version = "0.4.5"
+version = "0.4.6-beta.1"
 dependencies = [
  "hex",
  "keyring",
@@ -5977,7 +5987,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-mcp"
-version = "0.4.5"
+version = "0.4.6-beta.1"
 dependencies = [
  "hex",
  "once_cell",
@@ -6002,7 +6012,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-native-host"
-version = "0.4.5"
+version = "0.4.6-beta.1"
 dependencies = [
  "clap",
  "dirs 6.0.0",
@@ -6016,7 +6026,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-policy"
-version = "0.4.5"
+version = "0.4.6-beta.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -6026,7 +6036,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-redaction"
-version = "0.4.5"
+version = "0.4.6-beta.1"
 dependencies = [
  "criterion",
  "dirs 5.0.1",
@@ -6048,7 +6058,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-runner"
-version = "0.4.5"
+version = "0.4.6-beta.1"
 dependencies = [
  "cap-std",
  "dunce",
@@ -6069,7 +6079,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-runner-types"
-version = "0.4.5"
+version = "0.4.6-beta.1"
 dependencies = [
  "dunce",
  "serde",
@@ -6078,7 +6088,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-sandbox-linux"
-version = "0.4.5"
+version = "0.4.6-beta.1"
 dependencies = [
  "landlock",
  "libc",
@@ -6088,7 +6098,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-sdk"
-version = "0.4.5"
+version = "0.4.6-beta.1"
 dependencies = [
  "serde_json",
  "uuid",
@@ -6102,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-types"
-version = "0.4.5"
+version = "0.4.6-beta.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -6110,7 +6120,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-ui-protocol"
-version = "0.4.5"
+version = "0.4.6-beta.1"
 dependencies = [
  "serde",
  "serde_jcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.5"
+version = "0.4.6-beta.1"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ vigil-hub serve --engine ml       # strict ML: fetches models on first run, fail
 vigil-hub serve --engine auto     # ML only if models are already cached and the dylib is present; otherwise degrades to hardfp and never downloads
 ```
 
-Models are fetched from Hugging Face (primary) with a [vigils.ai](https://vigils.ai) mirror fallback, each verified by SHA-256 (fail-closed). The ML build bundles [ONNX Runtime](https://onnxruntime.ai) 1.24 next to `vigil-hub`. Platform floors for the **ML** build: **Linux glibc ≥ 2.28**, **macOS ≥ 14** — the default hard-fingerprint build has neither. _(ML builds ship from the next release onward; an earlier release may not include them yet.)_
+Models are fetched from Hugging Face (primary) with a [vigils.ai](https://vigils.ai) mirror fallback, each verified by SHA-256 (fail-closed). The ML build bundles [ONNX Runtime](https://onnxruntime.ai) 1.24 next to `vigil-hub`. Platform floors for the **ML** build: **Linux glibc ≥ 2.28**, **macOS ≥ 14** — the default hard-fingerprint build has neither. _(ML builds ship with every release since v0.4.0 — look for the `vigils-cli-ml-*` assets.)_
 
 > Early releases aren't OS-code-signed yet; your OS may show a Gatekeeper / SmartScreen prompt
 > on first run — they're still independently verifiable (see below, or the full
@@ -234,7 +234,7 @@ vigil-hub setup --all       # protect everything, in one step
 ```bash
 vigil-hub setup --mcp --doctor    # pre-flight: will each wrapped MCP server actually start? (PATH check, read-only)
 vigil-hub inspect protection      # after using your agent: see what Vigils caught (secrets blocked, leaks redacted, chain intact)
-vigil-hub setup --all --uninstall # cleanly remove everything (your config restored byte-for-byte)
+vigil-hub setup --all --uninstall # cleanly remove everything (only Vigils' own entries; your settings restored faithfully)
 ```
 
 Restart Claude Code (or start a new session) and you're protected. This is the fastest path from a

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -131,7 +131,7 @@ vigil-hub serve --engine ml       # 严格 ML:首跑下载模型,不可用则 fa
 vigil-hub serve --engine auto     # 仅当模型已缓存且 dylib 就位才启用 ML;否则降级硬指纹,绝不下载
 ```
 
-模型从 Hugging Face(主源)拉取,带 [vigils.ai](https://vigils.ai) 镜像 fallback,逐文件 SHA-256 校验(fail-closed)。ML 构建把 [ONNX Runtime](https://onnxruntime.ai) 1.24 捆在 `vigil-hub` 同目录。**ML** 构建的平台地板:**Linux glibc ≥ 2.28**、**macOS ≥ 14** —— 默认硬指纹构建则没有。_(ML 构建从下一个 release 起提供;更早的 release 可能尚未包含。)_
+模型从 Hugging Face(主源)拉取,带 [vigils.ai](https://vigils.ai) 镜像 fallback,逐文件 SHA-256 校验(fail-closed)。ML 构建把 [ONNX Runtime](https://onnxruntime.ai) 1.24 捆在 `vigil-hub` 同目录。**ML** 构建的平台地板:**Linux glibc ≥ 2.28**、**macOS ≥ 14** —— 默认硬指纹构建则没有。_(ML 构建自 v0.4.0 起随每个 release 发布 —— 认准 `vigils-cli-ml-*` 资产。)_
 
 > 早期版本未签名;首次运行时系统可能弹出 Gatekeeper / SmartScreen 提示。
 
@@ -176,7 +176,7 @@ vigil-hub setup --all       # 一步全保护
 ```bash
 vigil-hub setup --mcp --doctor    # 接入前预检:每个被包裹的 MCP server 真能启动吗?(PATH 检查,只读)
 vigil-hub inspect protection      # 用过 agent 后:一眼看清 Vigils 拦了什么(裸 secret 拦截、泄漏脱敏、链完整)
-vigil-hub setup --all --uninstall # 干净移除全部(你的配置逐字节还原)
+vigil-hub setup --all --uninstall # 干净移除全部(只删 Vigils 自己的条目;你的配置如实还原)
 ```
 
 重启 Claude Code(或开新会话)即受保护。这是从 GitHub 下载到真实防护的最快路径。

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Vigils",
-  "version": "0.4.5",
+  "version": "0.4.6-beta.1",
   "identifier": "ai.vigils.desktop",
   "mainBinaryName": "vigils",
   "build": {

--- a/crates/vigil-audit/Cargo.toml
+++ b/crates/vigil-audit/Cargo.toml
@@ -19,10 +19,10 @@ workspace = true
 test-util = []
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.4.5" }
+vigil-types = { path = "../vigil-types", version = "0.4.6-beta.1" }
 # I01 扩展依赖:fail-closed 入口自检(ADR 0002 §D1)。
 # I00 的 "只能依赖 vigil-types" 约束是 I00 阶段性规则,I01 按 ADR 0002 明确放开。
-vigil-redaction = { path = "../vigil-redaction", version = "0.4.5" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.4.6-beta.1" }
 
 # I01 核心依赖
 rusqlite = { workspace = true }

--- a/crates/vigil-firewall/Cargo.toml
+++ b/crates/vigil-firewall/Cargo.toml
@@ -14,12 +14,12 @@ categories = ["api-bindings", "authentication"]
 workspace = true
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.4.5" }
-vigil-policy = { path = "../vigil-policy", version = "0.4.5" }
-vigil-audit = { path = "../vigil-audit", version = "0.4.5" }
+vigil-types = { path = "../vigil-types", version = "0.4.6-beta.1" }
+vigil-policy = { path = "../vigil-policy", version = "0.4.6-beta.1" }
+vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.1" }
 # ISS-010: T0 preflight 扫描(vigil-firewall 在 evaluate 前调 scan_text 产 PII findings)。
 # 依赖方向 T1 → T0 合法(vigil-redaction 纯函数、无反向依赖)。
-vigil-redaction = { path = "../vigil-redaction", version = "0.4.5" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.4.6-beta.1" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/vigil-lease/Cargo.toml
+++ b/crates/vigil-lease/Cargo.toml
@@ -20,8 +20,8 @@ default = []
 os-keychain = ["dep:keyring"]
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.4.5" }
-vigil-audit = { path = "../vigil-audit", version = "0.4.5" }
+vigil-types = { path = "../vigil-types", version = "0.4.6-beta.1" }
+vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/vigil-mcp/Cargo.toml
+++ b/crates/vigil-mcp/Cargo.toml
@@ -20,24 +20,24 @@ workspace = true
 ort = ["vigil-redaction/ort"]
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.4.5" }
-vigil-audit = { path = "../vigil-audit", version = "0.4.5" }
-vigil-firewall = { path = "../vigil-firewall", version = "0.4.5" }
-vigil-redaction = { path = "../vigil-redaction", version = "0.4.5" }
+vigil-types = { path = "../vigil-types", version = "0.4.6-beta.1" }
+vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.1" }
+vigil-firewall = { path = "../vigil-firewall", version = "0.4.6-beta.1" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.4.6-beta.1" }
 # I07.5+ (ADR 0007 §I-7.1):共享 Native spawn env 政策 helper(apply_native_env_policy)。
 # ADR 0018 v0.13 split:改依赖 vigil-runner-types(pure types + env policy,0 vigil
 # deps,unblock SDK publish chain),不再拉 vigil-runner concrete impl(wasmtime 等)。
-vigil-runner-types = { path = "../vigil-runner-types", version = "0.4.5" }
+vigil-runner-types = { path = "../vigil-runner-types", version = "0.4.6-beta.1" }
 # v0.5 P1 ADR 0014 α2:`pub fn Hub::resolve_approval` 用到的 typed 协议结构
 # (ResolveApprovalReq / ApprovalAction / ApprovalResolutionDto)。
 # vigil-ui-protocol 自身只依赖 vigil-types / vigil-audit / vigil-runner,
 # 与 vigil-mcp 现有 deps 无循环。
-vigil-ui-protocol = { path = "../vigil-ui-protocol", version = "0.4.5" }
+vigil-ui-protocol = { path = "../vigil-ui-protocol", version = "0.4.6-beta.1" }
 # 可逆脱敏 Slice 2:复用 `SecretValue`(Zeroizing/non-Debug/单一 expose)的值卫生装
 # Hub-owned `SecretAliasMap`。**只取值包装**,不引 LeaseBroker 审批门控语义(设计 D2:
 # broker mint-time 3-tuple 绑定与"运行时选 tool"现实冲突)。不启 os-keychain feature
 # —— keyring 读取在 vigil-hub-cli(已带该 feature)。
-vigil-lease = { path = "../vigil-lease", version = "0.4.5" }
+vigil-lease = { path = "../vigil-lease", version = "0.4.6-beta.1" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -52,7 +52,7 @@ once_cell = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 rusqlite = { workspace = true }
-vigil-policy = { path = "../vigil-policy", version = "0.4.5" }
+vigil-policy = { path = "../vigil-policy", version = "0.4.6-beta.1" }
 # α2 集成测试 `tests/resolve_approval.rs` 用 Ledger 真实建 approval + 调
 # `Hub::resolve_approval` 全链路验证 approve / deny / cancel(已是 main dep,
 # 此处显式声明仅为 IDE / `cargo metadata` 可读性)。

--- a/crates/vigil-policy/Cargo.toml
+++ b/crates/vigil-policy/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["api-bindings", "authentication"]
 workspace = true
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.4.5" }
+vigil-types = { path = "../vigil-types", version = "0.4.6-beta.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/vigil-sdk/Cargo.toml
+++ b/crates/vigil-sdk/Cargo.toml
@@ -23,14 +23,14 @@ ort = ["vigil-firewall/ort", "vigil-redaction/ort"]
 
 [dependencies]
 # Stable SDK re-exports;path-dep,locked to workspace version
-vigil-types = { path = "../vigil-types", version = "0.4.5" }
-vigil-firewall = { path = "../vigil-firewall", version = "0.4.5" }
-vigil-redaction = { path = "../vigil-redaction", version = "0.4.5" }
-vigil-mcp = { path = "../vigil-mcp", version = "0.4.5" }
+vigil-types = { path = "../vigil-types", version = "0.4.6-beta.1" }
+vigil-firewall = { path = "../vigil-firewall", version = "0.4.6-beta.1" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.4.6-beta.1" }
+vigil-mcp = { path = "../vigil-mcp", version = "0.4.6-beta.1" }
 # v0.16 FirewallBuilder facade:内部装配用(Ledger / PolicyEngine + default_ruleset)。
 # **不** re-export —— 仅 firewall_builder 内化使用,守 SDK 边界。
-vigil-audit = { path = "../vigil-audit", version = "0.4.5" }
-vigil-policy = { path = "../vigil-policy", version = "0.4.5" }
+vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.1" }
+vigil-policy = { path = "../vigil-policy", version = "0.4.6-beta.1" }
 # decide_call 便捷方法生成 invocation_id(UUIDv4);内部用,不进 SDK public API。
 uuid = { workspace = true }
 # decide_call 的 args 形参类型(serde_json::Value 已是 ToolInvocation.args 的公开类型,不扩面)。

--- a/crates/vigil-ui-protocol/Cargo.toml
+++ b/crates/vigil-ui-protocol/Cargo.toml
@@ -14,11 +14,11 @@ categories = ["data-structures", "api-bindings"]
 workspace = true
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.4.5" }
-vigil-audit = { path = "../vigil-audit", version = "0.4.5" }
+vigil-types = { path = "../vigil-types", version = "0.4.6-beta.1" }
+vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.1" }
 # ADR 0018 v0.13 split:改依赖 vigil-runner-types(pure types,0 vigil deps),
 # 不再拉 vigil-runner concrete(wasmtime/sandbox-linux),unblock SDK publish。
-vigil-runner-types = { path = "../vigil-runner-types", version = "0.4.5" }
+vigil-runner-types = { path = "../vigil-runner-types", version = "0.4.6-beta.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -2,6 +2,8 @@
 
 假设你已按 [installation.md](installation.md) 装好:**Vigils** 桌面应用(可执行文件 `vigils.exe`)可双击启动,Chrome 扩展已加载并注册 Native Host。
 
+> **先认清边界**:Vigil 防的是**意外**泄密(原文凭据)+ 审计 + 可逆脱敏,**不是**对抗蓄意外泄 agent 的密封屏障(混淆编码可绕过输入侧检测)。开始前请读 [README §防护边界](README.md#防护边界请先读--不制造虚假安全感)。
+
 ## 场景 1:粘贴 token 被拦截(最直观)
 
 ### 步骤
@@ -27,14 +29,15 @@
 
 1. 启动 **Vigils** 桌面应用(Windows 上可执行文件为 `vigils.exe`)
 2. 左侧 4 Tab:
-   - **Activity Feed**:刚才场景 1 的粘贴事件应在列表里(event_type = `browser.paste.redacted`,findings = `[github_token]`)
+   - **Activity Feed**:刚才场景 1 的粘贴事件应在列表里(event_type = `browser.paste.redacted`,findings = `[github_token]`)。
+     > 注:浏览器事件要出现在这里,需 native-host 与桌面指向**同一持久 ledger**;不设 `VIGIL_LEDGER_PATH` 时,二者默认都落 canonical 路径(`%LOCALAPPDATA%\Vigil\ledger.sqlite3`)。
    - **Approval Queue**:v0.2 仅 Desktop 内 UI;若 agent 调未批工具会进这里(需要场景 3)
    - **Server Registry**:还没配 MCP server 时是空
    - **Session Replay**:展开 session 看完整时间线
 3. 点 Activity Feed 里任一事件 → 打开 Event Detail Modal
 4. **验证**:Modal 的 payload JSON 不应含 `ghp_1234567890abcdef1234567890abcdef12345678` 原文(应只显示 `[REDACTED github_token]`)
 
-## 场景 3:CLI Agent 通过 vigil-hub 连接(v0.3 Stage 1)
+## 场景 3:CLI Agent 通过 vigil-hub 连接
 
 Vigil 的核心能力之一是**作为 MCP 代理**插在 Agent(Claude Code / Codex / OpenCode / Cursor / Zed)和上游 MCP server 之间。
 
@@ -49,7 +52,7 @@ Vigil 的核心能力之一是**作为 MCP 代理**插在 Agent(Claude Code / Co
   "mcpServers": {
     "vigil": {
       "command": "C:\\Vigil\\vigil-hub.exe",
-      "args": ["serve", "--stdio", "--ledger", "C:\\Vigil\\ledger.sqlite"]
+      "args": ["serve", "--stdio", "--ledger", "C:\\Vigil\\ledger.sqlite3"]
     }
   }
 }
@@ -68,16 +71,11 @@ vigil-hub serve: started stdio MCP server (PID 12345)
 启动 **Vigils** 桌面应用(`vigils.exe`):
 - Activity Feed 应有 `session.started` 事件(source = `vigil-hub-serve`)
 
-### 3.4 Stage 1 边界说明
+### 3.4 上游 MCP server 转发
 
-**当前版本(v0.3 Stage 1)**:agent 能连上 vigil-hub,`tools/list` 返空(零 upstream attach)。**真实 upstream MCP server 的转发留 Stage 2**。
+`vigil-hub serve --stdio` 配 `--upstream-config`(或经 `vigil-hub wrap` 注入单个 upstream)即可 attach 真实 MCP server:`tools/list` 会**聚合并命名空间化** upstream 工具,每次 tool call 经 firewall / redaction / audit / sandbox 全套策略。
 
-所以:agent 连上后暂时看不到任何工具。这一步的价值是**验证通路**:
-- Vigil 作为 MCP stdio server 协议实现正确
-- Agent 能识别 `vigil` 连接
-- 所有 agent 活动(即使 handshake 阶段)进入 Vigil 的 session / audit 链
-
-Stage 2 会补全上游 attach。如需立即接入真实 MCP server 做评测,请绕过 vigil 直连(但失去审计/审批)。
+更省事的路径:`vigil-hub setup --all` 一条命令把你已配置的 MCP server 全部纳入网关防护(可逆,`--uninstall` 撤销);逐个接入见 [agent-integration.md](agent-integration.md)。
 
 ## 场景 4:查看审计链
 

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -1,4 +1,6 @@
-# Installation — Vigil v0.2
+# Installation — Vigil
+
+> **从 [GitHub Releases](https://github.com/duncatzat/vigils/releases) 获取当前版本产物**(CLI 三平台 zip/tar、桌面安装包、ML 变体、Chrome 扩展,全部带 `.sha256` 与 minisign 签名)。下文示例中的 `dist/v0.2/` 目录布局是**旧版打包形态**,仅作路径示意;复制到 PATH、注册扩展 / native-host 等步骤在各版本通用。较新命令(`setup` / `posture` / `demo` 等)见 [getting-started](getting-started.md) 与 [`CHANGELOG.md`](../../CHANGELOG.md)。
 
 ## 1. 系统要求
 
@@ -82,7 +84,7 @@ cd C:\Vigil
 # 双击不会出窗口。GUI 唯一入口 = vigil-desktop-gui.exe
 ```
 
-首次启动会在 `%APPDATA%\Vigil\` 下创建 SQLite ledger。
+首次启动会在 `%LOCALAPPDATA%\Vigil\ledger.sqlite3` 创建 SQLite ledger(**是 `%LOCALAPPDATA%`,不是 `%APPDATA%`/Roaming,文件名带 `3`**;Linux = `~/.local/share/Vigil/ledger.sqlite3`,macOS = `~/Library/Application Support/Vigil/ledger.sqlite3`)。
 
 ## 4. Linux 安装(v0.2 起支持 GUI)
 
@@ -134,7 +136,7 @@ vigil-native-host install --extension-id <EXTENSION_ID>
 
 ```powershell
 # Windows
-.\vigil-hub.exe --version      # 应打印 vigil-hub 版本号(如 vigil-hub 0.2.0)
+.\vigil-hub.exe --version      # 应打印 vigil-hub 版本号(如 vigil-hub 0.4.6)
 .\vigil-native-host.exe status # 应打印 installed: true + manifest 路径
 ```
 
@@ -149,7 +151,7 @@ Chrome 打开 `chrome://extensions` → "Vigil" 项 → 展开 service worker �
 .\vigil-native-host.exe uninstall
 Remove-Item -Recurse C:\Vigil
 # Chrome 扩展页手动移除
-# %APPDATA%\Vigil\ 的 ledger 数据(审计链)按需保留/删除
+# %LOCALAPPDATA%\Vigil\ledger.sqlite3 的 ledger 数据(审计链)按需保留/删除
 ```
 
 Linux/macOS 对应:`rm` binary + `vigil-native-host uninstall` + 清 `~/.config/Vigil/` 或 `~/Library/Application Support/Vigil/`。

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -2,7 +2,7 @@
 
 ## 安装阶段
 
-### Q1: `.\vigil-native-host.exe install --extension-id XXX` 报 `extension id must be 32 a-p chars`
+### Q1: `.\vigil-native-host.exe install --extension-id XXX` 报 `invalid extension id: <id> (must be 32 chars in a-p)`
 
 Chrome 扩展 ID 只含 `a-p` 小写字母,**32 字符**。如果你输入的 ID 含数字或其他字母,说明复制错了。
 
@@ -46,17 +46,17 @@ Linux 用户级 manifest 路径是 `~/.config/google-chrome/NativeMessagingHosts
 ### Q5: Desktop UI 启动但 Activity Feed 始终空
 
 **原因**:
-- Ledger 文件位置错:默认 `%APPDATA%\Vigil\vigil.sqlite`(Windows),`~/.config/Vigil/` (Linux / macOS)
+- Ledger 文件位置错:默认 `%LOCALAPPDATA%\Vigil\ledger.sqlite3`(Windows,**不是** `%APPDATA%`/Roaming,文件名带 `3`),`~/.local/share/Vigil/ledger.sqlite3` (Linux),`~/Library/Application Support/Vigil/ledger.sqlite3` (macOS)
 - Chrome 扩展的事件没写进同一个 ledger(可能 Native Host 和 Desktop 看向不同文件)
 
 **修**:
 ```powershell
 # 打开 Desktop 时指定 ledger 路径
-.\vigil-desktop.exe --ledger C:\Vigil\data\vigil.sqlite
-# Native Host 也要同路径(environment 或配置文件;v0.2 以默认路径为准)
+.\vigil-desktop.exe --ledger %LOCALAPPDATA%\Vigil\ledger.sqlite3
+# CLI / hook / serve / Native Host 也用同路径(环境变量 VIGIL_LEDGER_PATH,或不设时都落上面的默认 canonical 路径)
 ```
 
-v0.3 会做 UI-level ledger 选择器。v0.2 约定两者都用**默认路径**。
+设 `VIGIL_LEDGER_PATH` 让所有组件(CLI、hook、serve、Desktop、Native Host)指向同一账本;不设时它们都用上面的默认 canonical 路径。
 
 ### Q6: Desktop 启动报 `failed to enable WAL journal mode`
 
@@ -93,23 +93,25 @@ v0.3 会做 UI-level ledger 选择器。v0.2 约定两者都用**默认路径**�
 ### Q10: 如何证明"ledger 没被篡改"?
 
 ```powershell
-.\vigil-hub.exe ledger verify
-# 输出:
-# chain length: 12345
-# verified: OK(每条 event 的 content_hash + prev_hash 闭合)
+.\vigil-hub.exe verify
+# 输出(示例):
+# ✓ the audit chain is internally consistent AND anchored: N checkpoint(s), through event #M
+# (每条 event 的 content_hash + prev_hash 闭合;链完整则退出码 0)
 ```
 
-如果报 `chain break at event_id=NNNN`:
+如果报 `✗ the audit chain is BROKEN at event #NNNN — tampering detected`(退出码非 0):
 - 该 event 之后的链都失真
 - **不要自己改数据库修**,上报 incident
 
 ### Q11: 想审计某段时间的 findings
 
-```powershell
-.\vigil-hub.exe ledger query --since 2026-04-01 --event-type "browser.paste.*"
-```
+Vigil CLI **没有** `ledger query` 子命令。查历史 findings 用以下任一方式:
 
-Activity Feed UI 有 FTS5 搜索框,更直观。
+- **桌面 Activity Feed**:内置 FTS5 搜索框,按 event_type / 时间 / 关键词过滤,最直观。
+- **直接查 SQLite**(高级):
+  ```powershell
+  sqlite3 %LOCALAPPDATA%\Vigil\ledger.sqlite3 "SELECT * FROM events WHERE event_type LIKE 'browser.paste.%' ORDER BY id DESC LIMIT 10;"
+  ```
 
 ## 仍然不行?
 


### PR DESCRIPTION
为 **v0.4.6-beta.1** 测试版做准备:

## docs 漂移修正(逐条对照代码事实源核验)
- **user-guide/troubleshooting**: 移除不存在的 `ledger verify` / `ledger query`(→ `vigil-hub verify` 真实输出 + Activity Feed / 直查 SQLite);默认账本路径 `%APPDATA%` → `%LOCALAPPDATA%\Vigil\ledger.sqlite3`(三平台);`VIGIL_LEDGER_PATH` 对齐说明
- **user-guide/getting-started**: 删除过时的「Stage 1: tools/list 返空」(上游转发早已实装);补防护边界提醒与 ledger 对齐注
- **user-guide/installation**: 指向 GitHub Releases;dist/v0.2 布局标注为旧版示意;路径/版本示例修正
- **README(en/zh)**: ML 变体「下个版本才有」已过时(v0.4.0 起随发);「byte-for-byte」收敛为经真机验证的措辞

## release 准备
- CHANGELOG(en/zh)新增 v0.4.6-beta.1 段(汇总 #40 用户级修复批)
- 版本三处一致(release.yml 门禁):workspace + tauri.conf + 内部 crate 依赖引用 26 处 + Cargo.lock
- bump 后远端独立构建全 workspace 测试 **1212 passed / 0 failed**

合并后打 tag `v0.4.6-beta.1` 触发 release workflow(带 `-` 自动标 pre-release)。