### PR TITLE
feat(acceptance): 发布桌面包 GUI 冒烟——Windows CDP 深测 + Linux/mac 装启存活

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -157,3 +157,161 @@ jobs:
             grep -E "SUMMARY|FAIL " audit.out 2>/dev/null || true
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+  desktop-smoke-windows:
+    # 已发布 NSIS 安装包:静默安装 → WebView2 CDP 深冒烟(路由遍历/双语翻转/零 console error/逐页截图)
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
+    runs-on: windows-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Resolve tag
+        id: tag
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${{ github.event.workflow_run.head_branch }}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "ver=${TAG#v}" >> "$GITHUB_OUTPUT"
+      - name: Download published NSIS installer
+        shell: bash
+        run: |
+          gh release download "${{ steps.tag.outputs.tag }}" -R "${{ github.repository }}"             -p "Vigils_${{ steps.tag.outputs.ver }}_x64-setup.exe" -D dl --clobber
+          ls -la dl/
+      - name: Silent install
+        shell: pwsh
+        run: |
+          $setup = Get-ChildItem dl/*-setup.exe | Select-Object -First 1
+          Start-Process -Wait -FilePath $setup.FullName -ArgumentList '/S'
+          $exe = Join-Path $env:LOCALAPPDATA 'Vigils/vigils.exe'
+          if (-not (Test-Path $exe)) { $exe = Join-Path $env:LOCALAPPDATA 'Programs/Vigils/vigils.exe' }
+          if (-not (Test-Path $exe)) { Get-ChildItem -Recurse $env:LOCALAPPDATA -Filter vigils.exe -ErrorAction SilentlyContinue | Select-Object -First 3; throw 'installed vigils.exe not found' }
+          "VIGILS_EXE=$exe" | Out-File -Append $env:GITHUB_ENV
+          Write-Host "installed at $exe"
+      - name: GUI smoke over CDP
+        shell: bash
+        run: |
+          WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS="--remote-debugging-port=9222 --remote-allow-origins=*" "$VIGILS_EXE" >gui.log 2>&1 &
+          node tests/acceptance/gui-smoke.mjs 9222 gui-shots | tee gsmoke.out
+          RC=${PIPESTATUS[0]}
+          taskkill //F //IM vigils.exe >/dev/null 2>&1 || true
+          exit "$RC"
+      - name: Job summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## desktop-smoke windows — ${{ steps.tag.outputs.tag }}"
+            echo '```'
+            grep -E "SUMMARY|FAIL " gsmoke.out 2>/dev/null || echo "(no output — launch failed?)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: gui-shots-windows-${{ steps.tag.outputs.tag }}
+          path: gui-shots/
+          if-no-files-found: ignore
+
+  desktop-smoke-linux:
+    # 已发布 .deb:安装(自动拉 WebKitGTK 依赖)→ Xvfb 启动 → 存活/窗口/截图非空
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
+    runs-on: ubuntu-22.04
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Resolve tag
+        id: tag
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${{ github.event.workflow_run.head_branch }}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "ver=${TAG#v}" >> "$GITHUB_OUTPUT"
+      - name: Download published .deb
+        shell: bash
+        run: |
+          gh release download "${{ steps.tag.outputs.tag }}" -R "${{ github.repository }}"             -p "Vigils_${{ steps.tag.outputs.ver }}_amd64.deb" -D dl --clobber
+      - name: Install smoke deps
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq xvfb xdotool imagemagick
+      - name: Headless GUI smoke
+        shell: bash
+        run: |
+          DEB="$(ls dl/*.deb)" OUT=gui-shots bash tests/acceptance/gui-smoke-headless.sh | tee gsmoke.out
+      - name: Job summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## desktop-smoke linux — ${{ steps.tag.outputs.tag }}"
+            echo '```'
+            grep -E "SUMMARY|FAIL " gsmoke.out 2>/dev/null || echo "(no output)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: gui-shots-linux-${{ steps.tag.outputs.tag }}
+          path: gui-shots/
+          if-no-files-found: ignore
+
+  desktop-smoke-macos:
+    # 已发布 .dmg:挂载 → 去 quarantine → 启动 → 存活/截图非空(WKWebView 无 CDP)
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
+    runs-on: macos-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Resolve tag
+        id: tag
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${{ github.event.workflow_run.head_branch }}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "ver=${TAG#v}" >> "$GITHUB_OUTPUT"
+      - name: Download published .dmg
+        shell: bash
+        run: |
+          gh release download "${{ steps.tag.outputs.tag }}" -R "${{ github.repository }}"             -p "Vigils_${{ steps.tag.outputs.ver }}_aarch64.dmg" -D dl --clobber
+      - name: Headless GUI smoke
+        shell: bash
+        run: |
+          DMG="$(ls dl/*.dmg)" OUT=gui-shots bash tests/acceptance/gui-smoke-headless.sh | tee gsmoke.out
+      - name: Job summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## desktop-smoke macos — ${{ steps.tag.outputs.tag }}"
+            echo '```'
+            grep -E "SUMMARY|FAIL " gsmoke.out 2>/dev/null || echo "(no output)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: gui-shots-macos-${{ steps.tag.outputs.tag }}
+          path: gui-shots/
+          if-no-files-found: ignore

--- a/tests/acceptance/README.md
+++ b/tests/acceptance/README.md
@@ -21,7 +21,12 @@ cp config.env.example config.env      # fill in REPO + your test-machine SSH tar
 finishes (and via *Run workflow* with a tag for back-testing): on all three GitHub-hosted
 platforms it downloads the **published** assets exactly like a user, verifies sha256 +
 build-provenance attestation, then runs `user-sim.sh` + `functional-sweep.sh`; a fourth
-job runs `local-audit.sh` over the full asset set. What CI cannot cover stays on the
+job runs `local-audit.sh` over the full asset set, and three `desktop-smoke-*` jobs test the
+**published desktop packages**: Windows silent-installs the NSIS setup and drives the real
+WebView2 over CDP (`gui-smoke.mjs`: dynamic route walk, locale flip, zero-console-error,
+per-page screenshots as artifacts); Linux installs the `.deb` and macOS mounts the `.dmg`,
+then both assert install → launch → stays-alive → non-blank screenshot
+(`gui-smoke-headless.sh` — WebKitGTK/WKWebView have no CDP). What CI cannot cover stays on the
 internal real machines via `run.sh`: the ~1.5 GB ML model-download e2e (`ml-e2e.sh`,
 `RUN_ML_MODEL=1`) and desktop-GUI pixel verification.
 

--- a/tests/acceptance/gui-smoke-headless.sh
+++ b/tests/acceptance/gui-smoke-headless.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# gui-smoke-headless.sh — Linux / macOS 桌面产物「装 → 启 → 活 → 截图非空」冒烟。
+#
+# 这两个平台的 tauri WebView(WebKitGTK / WKWebView)没有 CDP,深交互走不了
+# gui-smoke.mjs(那是 Windows WebView2 专属);本脚本守住发布桌面包的底线:
+# 能安装、能启动、进程活过 N 秒不崩、屏幕/窗口截图不是空白。
+#
+# 用法:
+#   Linux : DEB=path/to/Vigils_*_amd64.deb  bash gui-smoke-headless.sh
+#           (需要:sudo、xvfb、xdotool、imagemagick —— CI 步骤里安装)
+#   macOS : DMG=path/to/Vigils_*_aarch64.dmg bash gui-smoke-headless.sh
+# 产物:$OUT(默认 gui-shots/)下截图,供 artifact 上传人工复核。
+set -u
+OUT="${OUT:-gui-shots}"; mkdir -p "$OUT"
+P=0; F=0
+ok(){ printf '  PASS %s\n' "$*"; P=$((P+1)); }
+no(){ printf '  FAIL %s\n' "$*"; F=$((F+1)); }
+fin(){ printf '\n========== GUI-SMOKE(headless) SUMMARY: %d passed, %d failed ==========\n' "$P" "$F"; [ "$F" = 0 ]; exit $?; }
+
+size_of(){ wc -c < "$1" 2>/dev/null | tr -d ' '; }
+
+case "$(uname -s)" in
+Linux)
+  : "${DEB:?set DEB=path to Vigils .deb}"
+  echo "== install (.deb pulls WebKitGTK deps) =="
+  if sudo apt-get install -y "./$DEB" >/dev/null 2>&1 || sudo apt-get install -y "$DEB" >/dev/null 2>&1; then
+    ok "deb installed"
+  else no "deb install failed"; fin; fi
+  BIN="$(command -v vigils || echo /usr/bin/vigils)"
+  [ -x "$BIN" ] && ok "binary on PATH ($BIN)" || { no "vigils binary missing after install"; fin; }
+
+  echo "== launch under Xvfb =="
+  Xvfb :99 -screen 0 1280x800x24 >/dev/null 2>&1 &
+  XVFB=$!
+  export DISPLAY=:99
+  "$BIN" >/dev/null 2>&1 &
+  APP=$!
+  sleep 10
+  kill -0 "$APP" 2>/dev/null && ok "process alive after 10s" || { no "app exited early"; kill "$XVFB" 2>/dev/null; fin; }
+
+  echo "== window + screenshot =="
+  WIN=""
+  for _ in $(seq 1 20); do
+    WIN="$(xdotool search --name -- Vigils 2>/dev/null | head -1)"
+    [ -n "$WIN" ] && break; sleep 1
+  done
+  [ -n "$WIN" ] && ok "window found (id=$WIN)" || no "no window matching 'Vigils'"
+  import -display :99 -window root "$OUT/linux-root.png" 2>/dev/null
+  SZ="$(size_of "$OUT/linux-root.png")"
+  [ -n "$SZ" ] && [ "$SZ" -gt 15000 ] && ok "screenshot non-blank (${SZ}B)" || no "screenshot blank/tiny (${SZ:-0}B)"
+  kill "$APP" 2>/dev/null; wait "$APP" 2>/dev/null
+  kill "$XVFB" 2>/dev/null
+  fin
+  ;;
+Darwin)
+  : "${DMG:?set DMG=path to Vigils .dmg}"
+  echo "== mount dmg + copy app =="
+  MNT="$(mktemp -d)/dmg"
+  if hdiutil attach -nobrowse -readonly -mountpoint "$MNT" "$DMG" >/dev/null 2>&1; then ok "dmg mounted"; else no "dmg mount failed"; fin; fi
+  APPSRC="$(ls -d "$MNT"/*.app 2>/dev/null | head -1)"
+  [ -n "$APPSRC" ] || { no "no .app inside dmg"; hdiutil detach "$MNT" >/dev/null 2>&1; fin; }
+  APPDST="${TMPDIR:-/tmp}/VigilsSmoke.app"; rm -rf "$APPDST"
+  cp -R "$APPSRC" "$APPDST" && ok "app copied ($(basename "$APPSRC"))" || no "app copy failed"
+  hdiutil detach "$MNT" >/dev/null 2>&1
+  xattr -cr "$APPDST" 2>/dev/null   # 未签名 beta:去 quarantine,免 Gatekeeper 拦启动
+
+  echo "== launch =="
+  BIN="$(find "$APPDST/Contents/MacOS" -type f -perm +111 2>/dev/null | head -1)"
+  [ -n "$BIN" ] && ok "binary found ($(basename "$BIN"))" || { no "no executable in Contents/MacOS"; fin; }
+  "$BIN" >/dev/null 2>&1 &
+  APP=$!
+  sleep 10
+  kill -0 "$APP" 2>/dev/null && ok "process alive after 10s" || { no "app exited early"; fin; }
+
+  echo "== screenshot =="
+  screencapture -x "$OUT/mac-screen.png" 2>/dev/null
+  SZ="$(size_of "$OUT/mac-screen.png")"
+  [ -n "$SZ" ] && [ "$SZ" -gt 30000 ] && ok "screenshot captured (${SZ}B)" || no "screenshot blank/tiny (${SZ:-0}B)"
+  kill "$APP" 2>/dev/null; wait "$APP" 2>/dev/null
+  rm -rf "$APPDST"
+  fin
+  ;;
+*)
+  echo "unsupported platform for headless smoke (Windows uses gui-smoke.mjs over CDP)"; exit 2 ;;
+esac

--- a/tests/acceptance/gui-smoke.mjs
+++ b/tests/acceptance/gui-smoke.mjs
@@ -1,0 +1,130 @@
+// gui-smoke.mjs — 桌面 GUI 深冒烟(Windows WebView2 CDP;对**已安装的发布版**)。
+//
+// 结构无关设计(不硬编码页面/testid,新旧 UI 代都能吃):
+//   G1 CDP 可达 + 首屏真渲染(htmlLen/可见元素阈值 —— 白屏检验)
+//   G2 动态收集侧栏 hash 路由并逐页遍历:每页可见元素 > 阈值 + 逐页截图
+//   G3 双语翻转:localStorage['vigil-locale'] 反转 + reload → 正文 CJK 占比显著变化(再还原)
+//   G4 全程零未捕获异常 / console error
+//
+// 前置:vigils.exe 以
+//   WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS="--remote-debugging-port=<port> --remote-allow-origins=*"
+// 启动。用法: node gui-smoke.mjs <port> <out-dir>
+import { writeFileSync, mkdirSync } from "node:fs";
+
+const PORT = process.argv[2] || "9222";
+const OUT = process.argv[3] || "gui-shots";
+const BASE = `http://127.0.0.1:${PORT}`;
+mkdirSync(OUT, { recursive: true });
+
+let P = 0, F = 0;
+const ok = (m) => { console.log(`  PASS ${m}`); P++; };
+const no = (m) => { console.log(`  FAIL ${m}`); F++; };
+
+async function connect() {
+  let targets;
+  for (let i = 0; i < 60; i++) {
+    try {
+      targets = await (await fetch(`${BASE}/json`)).json();
+      if (targets?.some((t) => t.type === "page")) break;
+    } catch {}
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  const page = (targets || []).find((t) => t.type === "page");
+  if (!page) throw new Error("no CDP page target (WebView2 debug port not open?)");
+  const ws = new WebSocket(page.webSocketDebuggerUrl);
+  await new Promise((res, rej) => { ws.onopen = res; ws.onerror = () => rej(new Error("ws fail")); });
+  let nextId = 1;
+  const pending = new Map();
+  const errors = [];
+  ws.onmessage = (e) => {
+    const m = JSON.parse(e.data);
+    if (m.id && pending.has(m.id)) { pending.get(m.id)(m); pending.delete(m.id); return; }
+    if (m.method === "Runtime.exceptionThrown") {
+      const d = m.params?.exceptionDetails;
+      errors.push("EXC: " + (d?.exception?.description || d?.text || "?").slice(0, 160));
+    }
+    if (m.method === "Runtime.consoleAPICalled" && m.params?.type === "error") {
+      errors.push("CONSOLE: " + (m.params.args || []).map((a) => a.value || a.description || "").join(" ").slice(0, 160));
+    }
+  };
+  const send = (method, params = {}) =>
+    new Promise((res) => { const id = nextId++; pending.set(id, res); ws.send(JSON.stringify({ id, method, params })); });
+  return { ws, send, errors };
+}
+
+async function evalJson(send, expr) {
+  const r = await send("Runtime.evaluate", { expression: expr, returnByValue: true });
+  try { return JSON.parse(r?.result?.result?.value ?? "null"); } catch { return null; }
+}
+
+const FACTS = `JSON.stringify((() => {
+  const text = ((document.body && document.body.innerText) || "").replace(/\\s+/g, " ").trim();
+  const cjk = (text.match(/[\\u4e00-\\u9fff]/g) || []).length;
+  return {
+    hash: location.hash,
+    htmlLen: document.documentElement.outerHTML.length,
+    visibleEls: [...document.querySelectorAll("button,a,h1,h2,div,span,img")].filter(el => el.getClientRects().length).length,
+    links: [...new Set([...document.querySelectorAll("a[href^='#/']")].map(a => a.getAttribute("href")))].slice(0, 12),
+    cjkRatio: text.length ? cjk / text.length : 0,
+    sample: text.slice(0, 120),
+  };
+})())`;
+
+async function shot(send, name) {
+  const s = await send("Page.captureScreenshot", { format: "png" });
+  if (s?.result?.data) writeFileSync(`${OUT}/${name}.png`, Buffer.from(s.result.data, "base64"));
+}
+
+async function main() {
+  const { ws, send, errors } = await connect();
+  await send("Page.enable");
+  await send("Runtime.enable");
+  await new Promise((r) => setTimeout(r, 4000)); // 首屏挂载
+
+  // G1 首屏真渲染(白屏检验)
+  const f0 = await evalJson(send, FACTS);
+  console.log("== G1 first paint ==");
+  console.log(`  facts: ${JSON.stringify({ ...f0, links: (f0?.links || []).length })}`);
+  f0 && f0.htmlLen > 800 ? ok(`htmlLen=${f0.htmlLen} (>800, not a blank shell)`) : no(`htmlLen=${f0?.htmlLen} (blank screen?)`);
+  f0 && f0.visibleEls > 10 ? ok(`visibleEls=${f0.visibleEls} (>10)`) : no(`visibleEls=${f0?.visibleEls}`);
+  await shot(send, "initial");
+
+  // G2 动态路由遍历(从真实 DOM 收集,不硬编码页面集)
+  console.log("== G2 route walk ==");
+  const links = f0?.links || [];
+  links.length >= 3 ? ok(`discovered ${links.length} hash routes from the sidebar`) : no(`only ${links.length} hash routes discovered`);
+  for (const href of links) {
+    const route = href.replace(/^#/, "");
+    await send("Runtime.evaluate", { expression: `location.hash=${JSON.stringify(href.slice(1) ? "#" + href.slice(1) : href)}` });
+    await send("Runtime.evaluate", { expression: `location.hash=${JSON.stringify(href)}` });
+    await new Promise((r) => setTimeout(r, 1800));
+    const f = await evalJson(send, FACTS);
+    const slug = route.replace(/[^a-z0-9]+/gi, "-").replace(/^-|-$/g, "") || "root";
+    f && f.visibleEls > 5 ? ok(`${route} renders (visibleEls=${f.visibleEls})`) : no(`${route} looks blank (visibleEls=${f?.visibleEls})`);
+    await shot(send, `page-${slug}`);
+  }
+
+  // G3 双语翻转(vigil-locale)
+  console.log("== G3 locale flip ==");
+  const orig = await evalJson(send, `JSON.stringify(localStorage.getItem('vigil-locale'))`);
+  const before = (await evalJson(send, FACTS))?.cjkRatio ?? 0;
+  const target = before > 0.05 ? "en-US" : "zh-CN";
+  await send("Runtime.evaluate", { expression: `localStorage.setItem('vigil-locale','${target}'); location.reload()` });
+  await new Promise((r) => setTimeout(r, 3500));
+  const after = (await evalJson(send, FACTS))?.cjkRatio ?? 0;
+  const flipped = target === "zh-CN" ? after > before + 0.05 : after < before - 0.05;
+  flipped ? ok(`locale flip works (cjkRatio ${before.toFixed(2)} -> ${after.toFixed(2)})`) : no(`locale flip had no effect (${before.toFixed(2)} -> ${after.toFixed(2)})`);
+  await shot(send, `locale-${target}`);
+  const restore = orig ? `localStorage.setItem('vigil-locale',${JSON.stringify(orig)})` : `localStorage.removeItem('vigil-locale')`;
+  await send("Runtime.evaluate", { expression: `${restore}; location.reload()` });
+  await new Promise((r) => setTimeout(r, 1500));
+
+  // G4 零 console error / 未捕获异常
+  console.log("== G4 console hygiene ==");
+  errors.length === 0 ? ok("zero console errors / uncaught exceptions across the walk") : no(`${errors.length} console errors, first: ${errors[0]}`);
+
+  ws.close();
+  console.log(`\n========== GUI-SMOKE SUMMARY: ${P} passed, ${F} failed ==========`);
+  process.exit(F === 0 ? 0 : 1);
+}
+main().catch((e) => { console.error("gui-smoke error:", e.message); process.exit(2); });


### PR DESCRIPTION
补齐值守验收的 GUI 面(接 #42):

- **gui-smoke.mjs**(Windows):对**已发布 NSIS 静默安装**的真实 vigils.exe 经 WebView2 CDP 深冒烟。结构无关(不硬编码页面/testid):首屏白屏检验 → 动态收集侧栏路由逐页遍历+截图 → `vigil-locale` 双语翻转(CJK 占比位移断言)→ 全程零 console error。本机对另一代 UI 实测 **12/12 全绿**(泛化性证明)。
- **gui-smoke-headless.sh**(Linux .deb / macOS .dmg):WebKitGTK/WKWebView 无 CDP → 守「安装→启动→存活 10s→窗口存在→截图非空」底线,截图上传 artifact 供人工复核。
- **acceptance.yml + 3 个 desktop-smoke job**:与 user-sim 同触发(Release 完成自动 + dispatch 补跑)。

合并后将 dispatch 对 v0.4.6-beta.1 全量跑(7 job),验证云端 Windows CDP 可行性。