### PR TITLE
release: v0.4.6-beta.2 —— 值守式用户验收 CI(功能 + agent 接入 + GUI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Vigils are documented here. The format follows
 
 ---
 
-## [v0.4.6-beta.1] — 2026-07-02 — user-level polish: server-name slugify, honest status surfaces
+## [v0.4.6-beta.2] — 2026-07-02 — unattended user-acceptance CI (functional + agent-integration + GUI) atop beta.1 polish
 
 A beta focused on findings from a feature-by-feature user-level verification pass (real binaries on
 all three platforms). No security-invariant changes; hard floors are untouched.
@@ -56,6 +56,11 @@ all three platforms). No security-invariant changes; hard floors are untouched.
 - README (en/zh): the ML-variant availability note was stale (ML builds ship since v0.4.0);
   softened "restored byte-for-byte" to the verified claim (only Vigils' own entries are removed,
   settings restored faithfully).
+
+### Added (test infrastructure)
+
+- **Unattended user-acceptance CI** (`.github/workflows/acceptance.yml`): after every release, three GitHub-hosted platforms download the published assets like a user, verify sha256 + SLSA provenance, and run `user-sim.sh`, `functional-sweep.sh`, `core-e2e.mjs` (privacy-filter + secret-lease four-leg on the real MCP gateway), `agent-compat.sh` (Claude/Codex/Gemini/Cursor native-hook protocol), plus desktop GUI smoke (Windows WebView2 CDP; Linux/macOS install→launch→screenshot). ML model-download e2e stays on internal machines.
+- **`serve --monitor`** (symmetric with `wrap --monitor`): observe-and-audit posture for headless/e2e when there is no GUI approval resolver; hard floors unchanged.
 
 ---
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -8,7 +8,7 @@ Vigils 的所有重要变更记录于此。格式遵循
 
 ---
 
-## [v0.4.6-beta.1] — 2026-07-02 — 用户级打磨:server 名 slugify、状态陈述如实化
+## [v0.4.6-beta.2] — 2026-07-02 — 值守式用户验收 CI(功能 + agent 接入 + GUI),含 beta.1 打磨
 
 本测试版聚焦「逐功能用户级验证」(三平台真二进制走查)发现的问题。不涉及任何安全不变量变更,硬底线不动。
 
@@ -44,6 +44,11 @@ Vigils 的所有重要变更记录于此。格式遵循
   真实的上游转发行为,并把安装指引指向 GitHub Releases。
 - README(中英):ML 变体可用性说明已过时(v0.4.0 起随每个 release 发布);「逐字节还原」措辞
   收敛为经验证的承诺(只删 Vigils 自己的条目,你的配置如实还原)。
+
+### 新增(测试基建)
+
+- **值守式用户验收 CI**(`.github/workflows/acceptance.yml`):每次发布后三平台像用户一样下载已发布产物、校验 sha256 + SLSA 溯源,跑 `user-sim.sh`、`functional-sweep.sh`、`core-e2e.mjs`(真 MCP 网关的隐私过滤 + 密钥租约四段)、`agent-compat.sh`(Claude/Codex/Gemini/Cursor 原生 hook 协议),外加桌面 GUI 冒烟(Windows WebView2 CDP;Linux/macOS 装→启→截图)。ML 模型下载 e2e 留内部真机。
+- **`serve --monitor`**(与 `wrap --monitor` 对称):headless/e2e 无 GUI 审批 resolver 时观察放行 + 审计;硬地板不变。
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5790,7 +5790,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vigil-audit"
-version = "0.4.6-beta.1"
+version = "0.4.6-beta.2"
 dependencies = [
  "criterion",
  "hex",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-browser"
-version = "0.4.6-beta.1"
+version = "0.4.6-beta.2"
 dependencies = [
  "once_cell",
  "regex",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-desktop"
-version = "0.4.6-beta.1"
+version = "0.4.6-beta.2"
 dependencies = [
  "base64 0.22.1",
  "blake2",
@@ -5858,7 +5858,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-firewall"
-version = "0.4.6-beta.1"
+version = "0.4.6-beta.2"
 dependencies = [
  "dunce",
  "hex",
@@ -5882,7 +5882,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-http-auth"
-version = "0.4.6-beta.1"
+version = "0.4.6-beta.2"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -5899,7 +5899,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-http-transport"
-version = "0.4.6-beta.1"
+version = "0.4.6-beta.2"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-hub-cli"
-version = "0.4.6-beta.1"
+version = "0.4.6-beta.2"
 dependencies = [
  "clap",
  "dirs 6.0.0",
@@ -5969,7 +5969,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-lease"
-version = "0.4.6-beta.1"
+version = "0.4.6-beta.2"
 dependencies = [
  "hex",
  "keyring",
@@ -5987,7 +5987,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-mcp"
-version = "0.4.6-beta.1"
+version = "0.4.6-beta.2"
 dependencies = [
  "hex",
  "once_cell",
@@ -6012,7 +6012,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-native-host"
-version = "0.4.6-beta.1"
+version = "0.4.6-beta.2"
 dependencies = [
  "clap",
  "dirs 6.0.0",
@@ -6026,7 +6026,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-policy"
-version = "0.4.6-beta.1"
+version = "0.4.6-beta.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -6036,7 +6036,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-redaction"
-version = "0.4.6-beta.1"
+version = "0.4.6-beta.2"
 dependencies = [
  "criterion",
  "dirs 5.0.1",
@@ -6058,7 +6058,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-runner"
-version = "0.4.6-beta.1"
+version = "0.4.6-beta.2"
 dependencies = [
  "cap-std",
  "dunce",
@@ -6079,7 +6079,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-runner-types"
-version = "0.4.6-beta.1"
+version = "0.4.6-beta.2"
 dependencies = [
  "dunce",
  "serde",
@@ -6088,7 +6088,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-sandbox-linux"
-version = "0.4.6-beta.1"
+version = "0.4.6-beta.2"
 dependencies = [
  "landlock",
  "libc",
@@ -6098,7 +6098,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-sdk"
-version = "0.4.6-beta.1"
+version = "0.4.6-beta.2"
 dependencies = [
  "serde_json",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-types"
-version = "0.4.6-beta.1"
+version = "0.4.6-beta.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -6120,7 +6120,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-ui-protocol"
-version = "0.4.6-beta.1"
+version = "0.4.6-beta.2"
 dependencies = [
  "serde",
  "serde_jcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.6-beta.1"
+version = "0.4.6-beta.2"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Vigils",
-  "version": "0.4.6-beta.1",
+  "version": "0.4.6-beta.2",
   "identifier": "ai.vigils.desktop",
   "mainBinaryName": "vigils",
   "build": {

--- a/crates/vigil-audit/Cargo.toml
+++ b/crates/vigil-audit/Cargo.toml
@@ -19,10 +19,10 @@ workspace = true
 test-util = []
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.4.6-beta.1" }
+vigil-types = { path = "../vigil-types", version = "0.4.6-beta.2" }
 # I01 扩展依赖:fail-closed 入口自检(ADR 0002 §D1)。
 # I00 的 "只能依赖 vigil-types" 约束是 I00 阶段性规则,I01 按 ADR 0002 明确放开。
-vigil-redaction = { path = "../vigil-redaction", version = "0.4.6-beta.1" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.4.6-beta.2" }
 
 # I01 核心依赖
 rusqlite = { workspace = true }

--- a/crates/vigil-firewall/Cargo.toml
+++ b/crates/vigil-firewall/Cargo.toml
@@ -14,12 +14,12 @@ categories = ["api-bindings", "authentication"]
 workspace = true
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.4.6-beta.1" }
-vigil-policy = { path = "../vigil-policy", version = "0.4.6-beta.1" }
-vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.1" }
+vigil-types = { path = "../vigil-types", version = "0.4.6-beta.2" }
+vigil-policy = { path = "../vigil-policy", version = "0.4.6-beta.2" }
+vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.2" }
 # ISS-010: T0 preflight 扫描(vigil-firewall 在 evaluate 前调 scan_text 产 PII findings)。
 # 依赖方向 T1 → T0 合法(vigil-redaction 纯函数、无反向依赖)。
-vigil-redaction = { path = "../vigil-redaction", version = "0.4.6-beta.1" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.4.6-beta.2" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/vigil-lease/Cargo.toml
+++ b/crates/vigil-lease/Cargo.toml
@@ -20,8 +20,8 @@ default = []
 os-keychain = ["dep:keyring"]
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.4.6-beta.1" }
-vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.1" }
+vigil-types = { path = "../vigil-types", version = "0.4.6-beta.2" }
+vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.2" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/vigil-mcp/Cargo.toml
+++ b/crates/vigil-mcp/Cargo.toml
@@ -20,24 +20,24 @@ workspace = true
 ort = ["vigil-redaction/ort"]
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.4.6-beta.1" }
-vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.1" }
-vigil-firewall = { path = "../vigil-firewall", version = "0.4.6-beta.1" }
-vigil-redaction = { path = "../vigil-redaction", version = "0.4.6-beta.1" }
+vigil-types = { path = "../vigil-types", version = "0.4.6-beta.2" }
+vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.2" }
+vigil-firewall = { path = "../vigil-firewall", version = "0.4.6-beta.2" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.4.6-beta.2" }
 # I07.5+ (ADR 0007 §I-7.1):共享 Native spawn env 政策 helper(apply_native_env_policy)。
 # ADR 0018 v0.13 split:改依赖 vigil-runner-types(pure types + env policy,0 vigil
 # deps,unblock SDK publish chain),不再拉 vigil-runner concrete impl(wasmtime 等)。
-vigil-runner-types = { path = "../vigil-runner-types", version = "0.4.6-beta.1" }
+vigil-runner-types = { path = "../vigil-runner-types", version = "0.4.6-beta.2" }
 # v0.5 P1 ADR 0014 α2:`pub fn Hub::resolve_approval` 用到的 typed 协议结构
 # (ResolveApprovalReq / ApprovalAction / ApprovalResolutionDto)。
 # vigil-ui-protocol 自身只依赖 vigil-types / vigil-audit / vigil-runner,
 # 与 vigil-mcp 现有 deps 无循环。
-vigil-ui-protocol = { path = "../vigil-ui-protocol", version = "0.4.6-beta.1" }
+vigil-ui-protocol = { path = "../vigil-ui-protocol", version = "0.4.6-beta.2" }
 # 可逆脱敏 Slice 2:复用 `SecretValue`(Zeroizing/non-Debug/单一 expose)的值卫生装
 # Hub-owned `SecretAliasMap`。**只取值包装**,不引 LeaseBroker 审批门控语义(设计 D2:
 # broker mint-time 3-tuple 绑定与"运行时选 tool"现实冲突)。不启 os-keychain feature
 # —— keyring 读取在 vigil-hub-cli(已带该 feature)。
-vigil-lease = { path = "../vigil-lease", version = "0.4.6-beta.1" }
+vigil-lease = { path = "../vigil-lease", version = "0.4.6-beta.2" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -52,7 +52,7 @@ once_cell = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 rusqlite = { workspace = true }
-vigil-policy = { path = "../vigil-policy", version = "0.4.6-beta.1" }
+vigil-policy = { path = "../vigil-policy", version = "0.4.6-beta.2" }
 # α2 集成测试 `tests/resolve_approval.rs` 用 Ledger 真实建 approval + 调
 # `Hub::resolve_approval` 全链路验证 approve / deny / cancel(已是 main dep,
 # 此处显式声明仅为 IDE / `cargo metadata` 可读性)。

--- a/crates/vigil-policy/Cargo.toml
+++ b/crates/vigil-policy/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["api-bindings", "authentication"]
 workspace = true
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.4.6-beta.1" }
+vigil-types = { path = "../vigil-types", version = "0.4.6-beta.2" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/vigil-sdk/Cargo.toml
+++ b/crates/vigil-sdk/Cargo.toml
@@ -23,14 +23,14 @@ ort = ["vigil-firewall/ort", "vigil-redaction/ort"]
 
 [dependencies]
 # Stable SDK re-exports;path-dep,locked to workspace version
-vigil-types = { path = "../vigil-types", version = "0.4.6-beta.1" }
-vigil-firewall = { path = "../vigil-firewall", version = "0.4.6-beta.1" }
-vigil-redaction = { path = "../vigil-redaction", version = "0.4.6-beta.1" }
-vigil-mcp = { path = "../vigil-mcp", version = "0.4.6-beta.1" }
+vigil-types = { path = "../vigil-types", version = "0.4.6-beta.2" }
+vigil-firewall = { path = "../vigil-firewall", version = "0.4.6-beta.2" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.4.6-beta.2" }
+vigil-mcp = { path = "../vigil-mcp", version = "0.4.6-beta.2" }
 # v0.16 FirewallBuilder facade:内部装配用(Ledger / PolicyEngine + default_ruleset)。
 # **不** re-export —— 仅 firewall_builder 内化使用,守 SDK 边界。
-vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.1" }
-vigil-policy = { path = "../vigil-policy", version = "0.4.6-beta.1" }
+vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.2" }
+vigil-policy = { path = "../vigil-policy", version = "0.4.6-beta.2" }
 # decide_call 便捷方法生成 invocation_id(UUIDv4);内部用,不进 SDK public API。
 uuid = { workspace = true }
 # decide_call 的 args 形参类型(serde_json::Value 已是 ToolInvocation.args 的公开类型,不扩面)。

--- a/crates/vigil-ui-protocol/Cargo.toml
+++ b/crates/vigil-ui-protocol/Cargo.toml
@@ -14,11 +14,11 @@ categories = ["data-structures", "api-bindings"]
 workspace = true
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.4.6-beta.1" }
-vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.1" }
+vigil-types = { path = "../vigil-types", version = "0.4.6-beta.2" }
+vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.2" }
 # ADR 0018 v0.13 split:改依赖 vigil-runner-types(pure types,0 vigil deps),
 # 不再拉 vigil-runner concrete(wasmtime/sandbox-linux),unblock SDK publish。
-vigil-runner-types = { path = "../vigil-runner-types", version = "0.4.6-beta.1" }
+vigil-runner-types = { path = "../vigil-runner-types", version = "0.4.6-beta.2" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
beta.2 = beta.1 用户级打磨 + 本轮核心功能 e2e 值守化(#47)。版本三处一致 + Cargo.lock + CHANGELOG 双语。合并后打 tag `v0.4.6-beta.2` 触发 release,随后 acceptance workflow 自动对它全套值守(core-e2e 因带 `--monitor` 首次真实执行)。