### PR TITLE
test(acceptance): 验收脚本钉 VIGIL_LANG=en——修 zh locale 机文案断言误报

### DIFF
--- a/tests/acceptance/agent-compat.sh
+++ b/tests/acceptance/agent-compat.sh
@@ -17,6 +17,7 @@ set -u
 : "${HUB:?set HUB=path to vigil-hub}"
 SBX="${TMPDIR:-/tmp}/vigil-compat-$$"; rm -rf "$SBX"; mkdir -p "$SBX"
 export VIGIL_LEDGER_PATH="$SBX/ledger.sqlite3"
+export VIGIL_LANG=en          # 断言锚定英文输出(与 locale 无关地稳定)
 case "$(uname -s)" in Linux|Darwin) export HOME="$SBX" XDG_DATA_HOME="$SBX/.local/share" XDG_CONFIG_HOME="$SBX/.config";; esac
 trap 'rm -rf "$SBX"' EXIT
 

--- a/tests/acceptance/core-e2e.mjs
+++ b/tests/acceptance/core-e2e.mjs
@@ -63,7 +63,7 @@ const hub = spawn(HUB, [
   "--redact-tool-results",   // 结果携密 → in-band 脱敏后再回客户端(C3/C2-leg4)
   "--monitor",               // 无 GUI resolver 时观察放行(硬地板不变),否则 mock 工具审批阻塞 ~300s
   "--auto-approve-first-seen",
-], { env: { ...process.env, VIGIL_E2E_SECRET: REAL_SECRET, VIGIL_LEDGER_PATH: LEDGER }, stdio: ["pipe", "pipe", "pipe"] });
+], { env: { ...process.env, VIGIL_E2E_SECRET: REAL_SECRET, VIGIL_LEDGER_PATH: LEDGER, VIGIL_LANG: "en" }, stdio: ["pipe", "pipe", "pipe"] });
 
 let stderrBuf = "";
 hub.stderr.on("data", (d) => { stderrBuf += d.toString(); });

--- a/tests/acceptance/daemon-regression.sh
+++ b/tests/acceptance/daemon-regression.sh
@@ -17,6 +17,7 @@ SBX="${TMPDIR:-/tmp}/vigil-dreg-$$"; rm -rf "$SBX"; mkdir -p "$SBX/home"
 export HOME="$SBX/home" XDG_DATA_HOME="$SBX/home/.local/share" \
        XDG_CONFIG_HOME="$SBX/home/.config" XDG_CACHE_HOME="$SBX/home/.cache" \
        VIGIL_DAEMON_SOCKET="$SBX/d.sock"
+export VIGIL_LANG=en   # 断言锚定英文文案(zh locale 下 status 输出中文,'running (pid' 失配)
 HUB="$SBX/ml/vigil-hub"; P=0; F=0
 ok(){ printf '  PASS %s\n' "$*"; P=$((P+1)); }; no(){ printf '  FAIL %s\n' "$*"; F=$((F+1)); }
 cleanup(){ pkill -f "$SBX/ml/vigil-hub" 2>/dev/null || true

--- a/tests/acceptance/functional-sweep.sh
+++ b/tests/acceptance/functional-sweep.sh
@@ -32,6 +32,7 @@ export HOME="$SBX/home" \
        XDG_CONFIG_HOME="$SBX/home/.config" \
        XDG_CACHE_HOME="$SBX/home/.cache"
 export VIGIL_LEDGER_PATH="$SBX/ledger.sqlite3"
+export VIGIL_LANG=en          # 断言锚定英文输出(与 locale 无关地稳定)
 trap 'rm -rf "$SBX"' EXIT
 
 P=0; F=0

--- a/tests/acceptance/ml-e2e.sh
+++ b/tests/acceptance/ml-e2e.sh
@@ -25,6 +25,9 @@ SBX="${TMPDIR:-/tmp}/vigil-acc-$$"; rm -rf "$SBX"; mkdir -p "$SBX/home"
 export HOME="$SBX/home" XDG_DATA_HOME="$SBX/home/.local/share" \
        XDG_CACHE_HOME="$SBX/home/.cache" XDG_CONFIG_HOME="$SBX/home/.config" \
        VIGIL_DAEMON_SOCKET="$SBX/d.sock"
+# 断言锚定英文输出:macOS 系统区域为 zh 时 sys-locale 读 AppleLocale(不看 SSH 空 LANG),
+# status 输出中文 → 'running (pid'/'pii_loaded=true' grep 失配误报 R1 不可达。
+export VIGIL_LANG=en
 HUB="$SBX/ml/vigil-hub"
 P=0; F=0
 ok(){ printf '  PASS %s\n' "$*"; P=$((P+1)); }; no(){ printf '  FAIL %s\n' "$*"; F=$((F+1)); }

--- a/tests/acceptance/win-acceptance.ps1
+++ b/tests/acceptance/win-acceptance.ps1
@@ -12,6 +12,7 @@ $djBak    = if (Test-Path $dj) { Get-Content $dj -Raw } else { $null }
 $preVigil = Test-Path $vigilDir
 $preModel = Test-Path "$vigilDir\models\privacy-filter-0.5.1"
 Get-Process vigil-hub -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+$env:VIGIL_LANG="en"   # pin assertions to English output regardless of system locale
 $sbx="$env:TEMP\vigil-acc-win"; Remove-Item -Recurse -Force $sbx -ErrorAction SilentlyContinue
 New-Item -ItemType Directory -Force -Path $sbx | Out-Null; Set-Location $sbx
 


### PR DESCRIPTION
## 问题

三机验收 v0.4.6-beta.2 时 macOS 段红(ml-e2e 8/2 + daemon-regression 0/2,报 daemon R1 不可达),但 hook 实际脱敏输出 `[REDACTED person]` 证明数据路径全通——产物无缺陷。

根因:测试机 AppleLocale=zh_CN 时 sys-locale 读系统区域(不看 SSH 空 LANG),`daemon status` 输出中文「运行中(pid=…)」,脚本英文契约 `'running (pid'` / `'pii_loaded=true'` grep 失配 → 误报。v0.4.5 同脚本全绿是因为 status 行当时尚未本地化。

## 修复

六个跑真二进制并断言文案的脚本统一钉 `VIGIL_LANG=en`(user-sim.sh 已有先例):ml-e2e / daemon-regression / functional-sweep / agent-compat / win-acceptance.ps1 / core-e2e.mjs。

## 验证

- 正反对照:mac 上自然 locale `daemon:运行中(…)` vs `VIGIL_LANG=en` → `daemon: running (pid=…)` 匹配契约
- macOS 段重跑:ml-e2e 13/13 + functional-sweep 18/18 + daemon-regression 2/2 全绿
- 全脚本 bash -n / node --check 通过