### PR TITLE
style: rustfmt lifecycle.rs(release Pre-flight Format check 补漏)

### DIFF
--- a/apps/vigil-hub-cli/src/daemon/lifecycle.rs
+++ b/apps/vigil-hub-cli/src/daemon/lifecycle.rs
@@ -155,7 +155,9 @@ enum StatusState {
         inflight: u32,
     },
     /// daemon.json 有记录但 query 联系不上(已退出 / pid 被重用 / 超时)。
-    Stale { recorded_pid: u32 },
+    Stale {
+        recorded_pid: u32,
+    },
 }
 
 /// `--json` 的稳定输出 schema:机器可读、与界面语言无关(locale 事故根治面)。


### PR DESCRIPTION
beta.3 tag 的 Release 在 Pre-flight Format check 挂(lifecycle.rs:155 `Stale` 变体单行不合 rustfmt)。纯格式,无内容变化。合并后重打 v0.4.6-beta.3。