### PR TITLE
feat: daemon 暖载可观测 + setup --status 全 agent 覆盖明细 + GUI daemon 状态 locale 误判根治

### DIFF
--- a/apps/desktop/src/ml_control.rs
+++ b/apps/desktop/src/ml_control.rs
@@ -98,6 +98,9 @@ fn no_window(_cmd: &mut Command) {}
 fn run_cli_capture(engine: &Path, args: &[&str]) -> Result<String, String> {
     let mut cmd = Command::new(engine);
     cmd.args(args);
+    // 子进程输出只供 GUI 机器解析(如 `model status` 的 "installed" 行判定)—— 钉英文,
+    // 否则 CLI 按系统语言输出中文时行匹配恒 false(locale 事故面)。用户可见文案由前端 i18n 渲染。
+    cmd.env("VIGIL_LANG", "en");
     no_window(&mut cmd);
     let out = cmd
         .output()
@@ -123,9 +126,12 @@ fn status_line_installed(out: &str, prefix: &str) -> bool {
 /// daemon 运行态(GUI 守护卡)。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DaemonStatus {
-    /// daemon 是否在运行(`daemon status` 报 `running`)。
+    /// daemon 是否在运行(`daemon status --json` 的 `running`)。
     pub running: bool,
-    /// 隐私 PII 模型是否已暖载(running 时从 status 行解析;model-less daemon = false)。
+    /// start 已发出、模型暖载中(daemon.json 尚未就绪;`status --json` reason=warming)。
+    /// 暖载最长约 45s —— 前端据此显示「启动中」而非误导性的「未运行」。
+    pub warming: bool,
+    /// 隐私 PII 模型是否已暖载(model-less daemon = false)。
     pub pii_loaded: bool,
     /// 引擎二进制是否就位(false → 守护卡只读,提示先部署引擎)。
     pub engine_present: bool,
@@ -144,23 +150,25 @@ pub struct ModelStatus {
     pub engine_present: bool,
 }
 
-/// 只读:daemon 运行态。`vigil-hub daemon status` 退出码恒 0,解析 stdout 行。引擎缺失 →
-/// `running=false` + `engine_present=false`(不报错,前端优雅提示)。
+/// 只读:daemon 运行态。走 `daemon status --json` 稳定 schema(字段只增不删)—— 此前解析
+/// 英文人类行 `daemon: running (`,CLI 按系统语言输出中文时会恒判未运行(locale 事故面)。
+/// 引擎缺失 → `running=false` + `engine_present=false`(不报错,前端优雅提示)。
 pub fn daemon_status(app: &AppHandle) -> Result<DaemonStatus, String> {
     let Some(engine) = resolve_engine(app) else {
         return Ok(DaemonStatus {
             running: false,
+            warming: false,
             pii_loaded: false,
             engine_present: false,
         });
     };
-    let out = run_cli_capture(&engine, &["daemon", "status"]).unwrap_or_default();
-    // 精确匹配运行行 `daemon: running (pid=...` —— 区别于 `daemon: not running` / `not responding`。
-    let running = out.contains("daemon: running (");
-    let pii_loaded = running && out.contains("pii_loaded=true");
+    let out = run_cli_capture(&engine, &["daemon", "status", "--json"]).unwrap_or_default();
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap_or_default();
+    let running = v["running"] == true;
     Ok(DaemonStatus {
         running,
-        pii_loaded,
+        warming: !running && v["reason"] == "warming",
+        pii_loaded: running && v["pii_loaded"] == true,
         engine_present: true,
     })
 }

--- a/apps/desktop/ui/src/api/ipc.ts
+++ b/apps/desktop/ui/src/api/ipc.ts
@@ -627,6 +627,8 @@ export async function protectionSummary(): Promise<ProtectionSummary> {
 export interface DaemonStatus {
   /** daemon 是否在运行 */
   running: boolean;
+  /** start 已发出、模型暖载中（最长约 45s）—— 显示「启动中」而非「未运行」 */
+  warming: boolean;
   /** 隐私 PII 模型是否已暖载（running 且 status 行报 pii_loaded=true 时为 true） */
   pii_loaded: boolean;
   /** vigil-hub 引擎二进制是否就位（false → 守护卡只读，提示先部署引擎） */

--- a/apps/desktop/ui/src/i18n/locales/en-US.json
+++ b/apps/desktop/ui/src/i18n/locales/en-US.json
@@ -283,6 +283,7 @@
       "subtitle": "A resident daemon holds the warm AI model so the hook main path runs ML with zero cold-start. Start it to enable ML protection for your agent.",
       "subtitle_no_model": "No AI model installed yet: starting now runs model-less (the hook stays on the hard-fingerprint floor). Install the AI model above first so the daemon can warm ML protection.",
       "status_stopped": "STOPPED",
+      "status_warming": "STARTING · WARMING MODELS",
       "status_running": "RUNNING",
       "status_ml": "RUNNING · ML WARM",
       "start": "Start daemon",

--- a/apps/desktop/ui/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/ui/src/i18n/locales/zh-CN.json
@@ -283,6 +283,7 @@
       "subtitle": "常驻 daemon 守住已暖载的 AI 模型，让 hook 主路径零冷启动跑 ML。启动它即为你的 agent 开启 ML 防护。",
       "subtitle_no_model": "当前未安装 AI 模型：现在启动只会以无模型方式运行（hook 保持硬指纹底座）。先在上方安装 AI 模型，daemon 才能暖载 ML 防护。",
       "status_stopped": "未运行",
+      "status_warming": "启动中 · 暖载模型",
       "status_running": "运行中",
       "status_ml": "运行中 · ML 已暖",
       "start": "启动守护",

--- a/apps/desktop/ui/src/pages/Settings.vue
+++ b/apps/desktop/ui/src/pages/Settings.vue
@@ -394,6 +394,15 @@ function updatePollingInterval(v: number | null): void {
               }}
             </NTag>
             <NTag
+              v-else-if="daemon?.warming"
+              size="small"
+              :bordered="false"
+              type="warning"
+              data-testid="daemon-state"
+            >
+              {{ t("settings.daemon.status_warming") }}
+            </NTag>
+            <NTag
               v-else
               size="small"
               :bordered="false"
@@ -403,7 +412,7 @@ function updatePollingInterval(v: number | null): void {
               {{ t("settings.daemon.status_stopped") }}
             </NTag>
             <NButton
-              v-if="!daemon?.running"
+              v-if="!daemon?.running && !daemon?.warming"
               size="small"
               tertiary
               :loading="busy === 'daemon:start'"

--- a/apps/vigil-hub-cli/src/daemon/lifecycle.rs
+++ b/apps/vigil-hub-cli/src/daemon/lifecycle.rs
@@ -59,6 +59,15 @@ pub fn run_start(lang: Lang) -> Result<(), String> {
         Lang::Zh => format!("绑定 socket 失败(可能已有 daemon 在运行):{e}"),
     })?;
 
+    // 暖载可长达 ORT_INIT_TIMEOUT_SECS(45s),期间 daemon.json 尚未写入,`status` 会误报
+    // 「未运行」(用户刚敲完 start 却被告知什么都没发生)。bind 成功后先落 warming 标记,
+    // daemon.json 写成后移除;`status` 据此报「启动中」。崩溃 / 超时 abort 残留的标记由
+    // status 侧按 mtime(超过 WARMING_MARKER_FRESH_SECS 视为陈旧)自愈,不进任何安全路径。
+    let warming_marker = daemon_info_path().map(warming_marker_path);
+    if let Some(m) = &warming_marker {
+        let _ = std::fs::write(m, std::process::id().to_string());
+    }
+
     // ort 暖载层(ADR 0024):**在 serve spawn 任何线程之前**(进程仍单线程)暖载 PII scanner —— 复用
     // serve 的 ort init 纪律(dylib 稳源 + loader-lock 安全超时 abort)。best-effort:模型未缓存 /
     // init 失败 → None → model-less(hook 落硬指纹,**非 fail-open**)。非 ort 构建恒 None。
@@ -110,6 +119,11 @@ pub fn run_start(lang: Lang) -> Result<(), String> {
         Lang::En => format!("failed to write daemon.json: {e}"),
         Lang::Zh => format!("写入 daemon.json 失败:{e}"),
     })?;
+    // daemon.json 已就位 → 「启动中」窗口结束,移除 warming 标记(早期 Err 返回留下的
+    // 残留由 status 侧 mtime 规则自愈,见上)。
+    if let Some(m) = &warming_marker {
+        let _ = std::fs::remove_file(m);
+    }
 
     match lang {
         Lang::En => eprintln!(
@@ -144,9 +158,19 @@ pub fn run_start(lang: Lang) -> Result<(), String> {
     Ok(())
 }
 
-/// `daemon status --json` 的三态(与人类可读输出同一判定,只换 render)。
+/// warming 标记新鲜窗口:超过此秒数的标记视为崩溃 / 超时 abort 残留,按未运行处理并清理。
+const WARMING_MARKER_FRESH_SECS: u64 = 120;
+
+/// warming 标记路径:`daemon.json` 旁的 `daemon.json.warming`(bind 成功 → 暖载完成的窗口内存在)。
+fn warming_marker_path(info_path: std::path::PathBuf) -> std::path::PathBuf {
+    info_path.with_extension("json.warming")
+}
+
+/// `daemon status --json` 的状态(与人类可读输出同一判定,只换 render)。
 enum StatusState {
     NotRunning,
+    /// start 已 bind、模型暖载中(daemon.json 尚未写入,warming 标记新鲜)。
+    Warming,
     Running {
         pid: u32,
         pii_loaded: bool,
@@ -167,6 +191,10 @@ fn status_json(state: &StatusState) -> serde_json::Value {
         StatusState::NotRunning => serde_json::json!({
             "running": false,
             "reason": "not-running",
+        }),
+        StatusState::Warming => serde_json::json!({
+            "running": false,
+            "reason": "warming",
         }),
         StatusState::Running {
             pid,
@@ -196,6 +224,34 @@ fn status_json(state: &StatusState) -> serde_json::Value {
 /// `json=true` 输出 [`status_json`] 的稳定 schema(供脚本/CI;人类文案走 i18n 会随语言变)。
 pub fn run_status(lang: Lang, json: bool) -> Result<(), String> {
     let Some(info) = daemon_info_path().and_then(|p| read_daemon_info(&p)) else {
+        // daemon.json 缺失 ≠ 一定未运行:start 已 bind、模型暖载中的窗口(最长约 45s)里
+        // 标记文件存在。新鲜 → 如实报「启动中」;陈旧(崩溃 / 超时 abort 残留)→ 清理并按未运行。
+        let marker = daemon_info_path().map(warming_marker_path);
+        let warming_fresh = marker.as_deref().is_some_and(|m| {
+            std::fs::metadata(m)
+                .and_then(|md| md.modified())
+                .ok()
+                .and_then(|t| t.elapsed().ok())
+                .is_some_and(|age| age.as_secs() < WARMING_MARKER_FRESH_SECS)
+        });
+        if warming_fresh {
+            if json {
+                println!("{}", status_json(&StatusState::Warming));
+            } else {
+                println!(
+                    "{}",
+                    tr(
+                        lang,
+                        "daemon: starting (warming the ML models, typically a few seconds to ~1 minute) -- re-run this command to check progress",
+                        "daemon:启动中(正在暖载 ML 模型,通常几秒到约 1 分钟)—— 稍后再次运行本命令查看进展",
+                    )
+                );
+            }
+            return Ok(());
+        }
+        if let Some(m) = &marker {
+            let _ = std::fs::remove_file(m); // 陈旧残留自愈(文件不存在时删除无害)
+        }
         if json {
             println!("{}", status_json(&StatusState::NotRunning));
         } else {
@@ -203,8 +259,8 @@ pub fn run_status(lang: Lang, json: bool) -> Result<(), String> {
                 "{}",
                 tr(
                     lang,
-                    "daemon: not running (no daemon.json)",
-                    "daemon:未运行(无 daemon.json)",
+                    "daemon: not running (start it with `vigil-hub daemon start`)",
+                    "daemon:未运行(用 `vigil-hub daemon start` 启动)",
                 )
             );
         }
@@ -283,8 +339,8 @@ pub fn run_stop(lang: Lang) -> Result<(), String> {
             "{}",
             tr(
                 lang,
-                "daemon: not running (no daemon.json)",
-                "daemon:未运行(无 daemon.json)",
+                "daemon: not running; nothing to stop.",
+                "daemon:未运行,无需停止。",
             )
         );
         return Ok(());
@@ -353,7 +409,7 @@ fn kill_pid(lang: Lang, pid: u32) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{generate_token, status_json, StatusState};
+    use super::{generate_token, status_json, warming_marker_path, StatusState};
 
     #[test]
     fn generate_token_is_32_hex_chars_and_varies() {
@@ -364,8 +420,15 @@ mod tests {
         assert_ne!(a, b, "per-launch token 应随机不同");
     }
 
-    /// `--json` 稳定 schema 三态守门:脚本/CI 断言 `"running":true|false` + 各字段名。
-    /// 字段只增不删不改名 —— 本测试即该纪律的回归锚。
+    /// warming 标记路径派生:`daemon.json` → 同目录 `daemon.json.warming`。
+    #[test]
+    fn warming_marker_path_is_sibling_of_daemon_json() {
+        let p = warming_marker_path(std::path::PathBuf::from("/x/y/daemon.json"));
+        assert_eq!(p, std::path::PathBuf::from("/x/y/daemon.json.warming"));
+    }
+
+    /// `--json` 稳定 schema 守门:脚本/CI 断言 `"running":true|false` + 各字段名。
+    /// 字段只增不删不改名 —— 本测试即该纪律的回归锚(`warming` 为新增 reason 枚举值,合规)。
     #[test]
     fn status_json_stable_schema_three_states() {
         let running = status_json(&StatusState::Running {
@@ -390,5 +453,9 @@ mod tests {
         assert_eq!(stale["running"], false);
         assert_eq!(stale["reason"], "stale-or-unresponsive");
         assert_eq!(stale["recorded_pid"], 42);
+
+        let warming = status_json(&StatusState::Warming);
+        assert_eq!(warming["running"], false);
+        assert_eq!(warming["reason"], "warming");
     }
 }

--- a/apps/vigil-hub-cli/src/hook.rs
+++ b/apps/vigil-hub-cli/src/hook.rs
@@ -526,22 +526,22 @@ pub fn run<R: Read>(args: &HookArgs, stdin: &mut R) -> HookOutcome {
     let mut limited = stdin.by_ref().take(MAX_HOOK_INPUT_BYTES + 1);
     if limited.read_to_string(&mut buf).is_err() {
         return HookOutcome::Deny(
-            "Vigil hook: could not read PreToolUse input from stdin (blocked fail-closed).".into(),
+            "Vigil hook: could not read the hook event from stdin (blocked fail-closed).".into(),
         );
     }
     if buf.len() as u64 > MAX_HOOK_INPUT_BYTES {
         return HookOutcome::Deny(
-            "Vigil hook: PreToolUse input exceeds the safe size limit (blocked fail-closed)."
-                .into(),
+            "Vigil hook: the hook event exceeds the safe size limit (blocked fail-closed).".into(),
         );
     }
 
     // 2) 解析 JSON。解析失败 = 畸形事件 → fail-closed deny。
+    //    消息用「hook event」而非写死「PreToolUse」—— 同一入口也接 PostToolUse 等事件(F-12)。
     let raw: Value = match serde_json::from_str(&buf) {
         Ok(v) => v,
         Err(_) => {
             return HookOutcome::Deny(
-                "Vigil hook: malformed PreToolUse input (blocked fail-closed).".into(),
+                "Vigil hook: malformed hook event input (blocked fail-closed).".into(),
             );
         }
     };

--- a/apps/vigil-hub-cli/src/i18n/help.rs
+++ b/apps/vigil-hub-cli/src/i18n/help.rs
@@ -670,7 +670,7 @@ fn localize_posture(c: Command, lang: Lang) -> Command {
         .about(s(
             lang,
             "View or switch the security posture (low / medium / high)",
-            "查看或切换安全姿态(低 / 中 / 高)—— 即对 `secret://` 占位符的拦截力度",
+            "查看或切换安全姿态(宽松 / 适中 / 严格)—— 即对 `secret://` 占位符的拦截力度",
         ))
         .long_about(s(
             lang,
@@ -686,9 +686,9 @@ fn localize_posture(c: Command, lang: Lang) -> Command {
             ),
             concat!(
                 "控制 Vigil 对原生工具里 `secret://` 占位符的处置力度:\n",
-                "  low     放行(默认 —— 零摩擦)\n",
-                "  medium  交你确认\n",
-                "  high    拦截\n",
+                "  low     宽松:放行(默认 —— 零摩擦)\n",
+                "  medium  适中:交你确认\n",
+                "  high    严格:拦截\n",
                 "明文密钥在**任何**档位都恒被拦 —— 这条硬底线不可降级。\n",
                 "\n",
                 "  vigil-hub posture show\n",
@@ -702,7 +702,7 @@ fn localize_posture(c: Command, lang: Lang) -> Command {
         let sc = sc.about(s(
             lang,
             "Switch to a posture (low / medium / high)",
-            "切换到指定姿态档位(低 / 中 / 高)",
+            "切换到指定姿态档位(low=宽松 / medium=适中 / high=严格)",
         ));
         let sc = arg_help_enum(
             sc,

--- a/apps/vigil-hub-cli/src/main.rs
+++ b/apps/vigil-hub-cli/src/main.rs
@@ -589,11 +589,12 @@ fn main() -> std::process::ExitCode {
                 match setup::run(&setup_args) {
                     Ok(report) => {
                         // ISS-20260621-002:status 还需报告 MCP-wrap 保护层(只看 hook 会误报
-                        // `--mcp` turnkey 用户未保护)。best-effort 取 home 统计已 wrap 的 server 数。
-                        let mcp_wrapped = dirs::home_dir()
-                            .map(|h| setup_mcp::wrapped_server_count(&h))
-                            .unwrap_or(0);
-                        let code = print_setup_report(lang, &setup_args, &report, mcp_wrapped);
+                        // `--mcp` turnkey 用户未保护)。逐 agent 统计(F-6:只报 Claude 会让
+                        // setup --all 保护的 Codex/Cursor 覆盖面在 status 里不可见)。
+                        let mcp_counts = dirs::home_dir()
+                            .map(|h| setup_mcp::wrapped_server_counts_all_agents(&h))
+                            .unwrap_or_default();
+                        let code = print_setup_report(lang, &setup_args, &report, &mcp_counts);
                         // 其余 agent 的 hook 注册面(Codex/Gemini/Cursor):检测到才注册,逐面诚实
                         // 报告。ledger 用 Claude 面已解析出的同一路径(审计链单账本)。
                         let op = if setup_args.status {
@@ -2424,9 +2425,10 @@ fn print_setup_report(
     lang: Lang,
     args: &SetupArgs,
     r: &setup::SetupReport,
-    mcp_wrapped: usize,
+    mcp_counts: &[(&'static str, usize)],
 ) -> std::process::ExitCode {
     use setup::ProtectionState;
+    let mcp_wrapped: usize = mcp_counts.iter().map(|(_, n)| n).sum();
     if args.status {
         let self_test = setup::doctor_self_test();
         println!("{}", tr(lang, "Vigil status", "Vigil 状态"));
@@ -2485,9 +2487,16 @@ fn print_setup_report(
             "  {}{}",
             tr(lang, "MCP gateway:   ", "MCP 网关:     "),
             if mcp_wrapped > 0 {
+                // 逐 agent 明细(只列非零项):用户能一眼确认 setup --all 的全局覆盖面。
+                let detail = mcp_counts
+                    .iter()
+                    .filter(|(_, n)| *n > 0)
+                    .map(|(name, n)| format!("{name} {n}"))
+                    .collect::<Vec<_>>()
+                    .join(" / ");
                 match lang {
-                    Lang::En => format!("{mcp_wrapped} server(s) wrapped"),
-                    Lang::Zh => format!("已防护 {mcp_wrapped} 个服务器"),
+                    Lang::En => format!("{mcp_wrapped} server(s) wrapped ({detail})"),
+                    Lang::Zh => format!("已防护 {mcp_wrapped} 个服务器({detail})"),
                 }
             } else {
                 tr(lang, "no servers wrapped", "尚未防护任何服务器").to_string()
@@ -2578,12 +2587,14 @@ fn print_setup_report(
             Lang::En => {
                 println!("  Claude Code:   not detected (claude not on PATH; neither ~/.claude nor ~/.claude.json found)");
                 println!("  Nothing to do. Install Claude Code, then re-run `vigil-hub setup`.");
-                println!("  (For other agents, use the MCP gateway: `vigil-hub serve --stdio`.)");
+                println!(
+                    "  (For other agents (Codex/Gemini/Cursor), run `vigil-hub setup --all`.)"
+                );
             }
             Lang::Zh => {
                 println!("  Claude Code:   未检测到(claude 不在 PATH;~/.claude 与 ~/.claude.json 都不存在)");
                 println!("  无事可做。请先安装 Claude Code,再重跑 `vigil-hub setup`。");
-                println!("  (其它 agent 请用 MCP 网关:`vigil-hub serve --stdio`。)");
+                println!("  (其它 agent(Codex/Gemini/Cursor)请用:`vigil-hub setup --all`。)");
             }
         }
         return std::process::ExitCode::SUCCESS;

--- a/apps/vigil-hub-cli/src/setup_mcp.rs
+++ b/apps/vigil-hub-cli/src/setup_mcp.rs
@@ -455,6 +455,42 @@ pub fn wrapped_server_count(home: &Path) -> usize {
     user + local
 }
 
+/// `setup --status` 的逐 agent MCP 网关覆盖统计:`(agent 显示名, 已 wrap 数)`,恒含四个 agent
+/// (0 也返回,渲染层自行取舍)。此前 status 只报 Claude Code 的计数 —— `setup --all` 保护了
+/// Codex/Cursor 的二十余个 server 后,用户无从确认全局覆盖面。best-effort 只读:配置缺失 /
+/// 解析失败按 0 计,状态报告不因单个 agent 配置损坏而失败(与 [`wrapped_server_count`] 同口径)。
+pub fn wrapped_server_counts_all_agents(home: &Path) -> Vec<(&'static str, usize)> {
+    let wrapped_in = |cfg: &Value| {
+        classify_user_scope_servers(cfg)
+            .iter()
+            .filter(|c| matches!(c, McpServerClass::AlreadyWrapped { .. }))
+            .count()
+    };
+    let json_agent = |a: &JsonMcpAgent| {
+        read_claude_json(&a.config_path)
+            .ok()
+            .flatten()
+            .map(|cfg| wrapped_in(&cfg))
+            .unwrap_or(0)
+    };
+    let codex = read_codex_config(&codex_config_path(home))
+        .ok()
+        .flatten()
+        .map(|doc| {
+            classify_codex_servers(&doc)
+                .iter()
+                .filter(|c| matches!(c, McpServerClass::AlreadyWrapped { .. }))
+                .count()
+        })
+        .unwrap_or(0);
+    vec![
+        ("Claude Code", wrapped_server_count(home)),
+        ("Codex", codex),
+        ("Cursor", json_agent(&JsonMcpAgent::cursor(home))),
+        ("Windsurf", json_agent(&JsonMcpAgent::windsurf(home))),
+    ]
+}
+
 /// `setup --mcp`(只读)的预览报告 —— 供 CLI 层渲染。
 #[derive(Debug, Clone)]
 pub struct McpPreviewReport {


### PR DESCRIPTION
内部第四轮逐功能用户级验证(真机三端:Win10 重度开发机 CLI 全链 / 本地 WebView2 CDP / mac)修复移植。

## 变更

**CLI(批 1)**
- **daemon 暖载窗口可观测**:模型暖载最长 ~45s,期间 `daemon status` 此前误报「未运行」(用户刚敲完 start 被告知什么都没发生)。bind 后落 `daemon.json.warming` 标记、daemon.json 就绪后移除;status 冷态按 mtime<120s 报「启动中(正在暖载 ML 模型)」,陈旧残留自愈;`--json` 增 `reason:"warming"`(schema 只增,契约测试补断言)。
- **setup --status 全局覆盖可见**:MCP 网关行此前只计 Claude Code——`setup --all` 保护了 Codex/Cursor 二十余个 server 后 status 里不可见。新增逐 agent 统计,渲染「已防护 N 个(Claude Code a / Codex b / Cursor c)」。
- hook 读取/超限/畸形消息「PreToolUse」写死 →「hook event」中性化(同一入口也接 PostToolUse)。
- posture 中文档位词与 GUI 对齐(宽松/适中/严格);daemon 冷态/stop 幂等文案去「无 daemon.json」黑话。

**GUI(批 2,按本仓 ml_control.rs / NTag 结构适配)**
- **locale 误判根治**:`daemon_status` 此前解析英文人类行(`contains("daemon: running (")`),CLI 按系统语言输出中文时 GUI 恒判「未运行」。改走 `daemon status --json` 稳定 schema + `run_cli_capture` 统一钉 `VIGIL_LANG=en`(`model_status` 的 "installed" 行解析同族隐患一并根治)。
- DaemonStatus 增 `warming` 透传:守护卡 tag 三态(运行中/启动中·暖载模型/未运行),warming 期间隐藏 start 按钮防 bind 冲突;locale 双语补 key(mirror 零漂移)。

## 验证

- 本仓独立门禁:`cargo fmt --all --check` + `clippy --workspace --all-targets -D warnings` + `cargo test --workspace` = **1240 passed / 0 failed**;前端 vue-tsc + vite build 绿。
- 内部同源改动真机复验:start 后 1.5s 即见「启动中」、11s 暖完双模型、stop 干净、warming 标记零残留;`setup --status` 实测「已防护 23 个(Claude Code 2 / Codex 11 / Cursor 10)」;mock warming 标记 + CDP 实测 GUI tag=「启动中 · 暖载模型」。

不适用跳过:内部 guardian 卡文案与 servers 空态话术(本仓无对应结构)、warm-poll 参数(本仓无该轮询)。