### PR TITLE
release: v0.4.6-beta.4 —— hook 路径 Command Guard + daemon 暖载可观测 + GUI locale 误判修复

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ All notable changes to Vigils are documented here. The format follows
 
 ---
 
+## [v0.4.6-beta.4] — 2026-07-03 — Command Guard on the hook path + daemon warm-up observability + GUI locale fix
+
+A beta adding one new protection line, plus observability/locale gaps closed by a fourth
+feature-by-feature user-level verification pass (real binaries on all three platforms).
+Hard floors are untouched.
+
+### Added
+
+- **Command Guard — a dangerous-command line of defense on the hook path** (#53, #54). The MCP
+  gateway already classified destructive shell commands, but the hook path (Claude Code / Cursor /
+  Codex `Bash` tools) previously only scanned for secrets/placeholders — with "allow all commands"
+  enabled, an agent gone sideways (intent drift, prompt injection, parameter accidents) could run
+  `rm -rf ~`, `curl … | sh`, or write a crontab entry without tripping anything. The guard
+  classifies **effects, not intent** (denylist, no ML): catastrophic actions (filesystem wipe,
+  raw device writes, fork bombs) are always denied at any posture — a hard floor like raw
+  secrets — while dangerous ones (persistence/autostart, remote-exec installs, deletions outside
+  the project root, `rm -rf $VAR/` empty-expansion accidents) get posture-graded Ask (High=Deny).
+  Project-root awareness keeps false positives down: `rm -rf ./node_modules` inside the project
+  passes; the same command aimed at `~` is caught. Honest boundary: a guardrail against accidents
+  and low-effort injection, not a sandbox — deep obfuscation can evade it.
+- **Daemon warm-up is now observable** (#55): model warm-up can take up to ~45s, during which
+  `daemon status` used to claim "not running" right after `daemon start`. A warming marker makes
+  the window visible: status reports "starting (warming the ML models)", `--json` gains
+  `reason:"warming"` (fields are only ever added), and stale markers self-heal.
+- **`setup --status` shows gateway coverage across all agents** (#55): previously only Claude
+  Code's count was shown — after `setup --all` wrapped 20+ servers for Codex/Cursor, status gave
+  no way to confirm the global footprint. Now:
+  `23 server(s) wrapped (Claude Code 2 / Codex 11 / Cursor 10)`.
+
+### Fixed
+
+- **The desktop app could permanently show the daemon as "not running" on non-English systems**
+  (#55): it parsed the English human-readable `daemon status` line, which localizes with the
+  system language. It now consumes `daemon status --json` and pins `VIGIL_LANG=en` for
+  machine-parsed subprocess output (the "installed" line parsing in model status had the same
+  latent issue). The daemon card also gained a third state — "STARTING · WARMING MODELS" —
+  instead of a misleading "STOPPED" during warm-up, with the start button hidden to avoid a
+  bind conflict.
+- Hook fail-closed messages no longer hardcode "PreToolUse" (the same entry also serves
+  PostToolUse events); daemon cold-state/stop wording dropped the internal "no daemon.json"
+  jargon; Chinese posture level names are now consistent between CLI help and the GUI
+  (宽松 / 适中 / 严格).
+
 ## [v0.4.6-beta.3] — 2026-07-03 — robustness round: OAuth scope wiring fix, `status --json`, dual-engine parity, remote-MCP e2e
 
 A hardening beta. One real gateway fix; everything else strengthens verification coverage.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -8,6 +8,41 @@ Vigils 的所有重要变更记录于此。格式遵循
 
 ---
 
+## [v0.4.6-beta.4] — 2026-07-03 — hook 路径 Command Guard + daemon 暖载可观测 + GUI locale 误判修复
+
+新增一条防护线的 beta;其余为第四轮逐功能用户级验证(三平台真二进制)收敛的可观测性
+与 locale 缺口。硬地板不受影响。
+
+### 新增
+
+- **Command Guard —— hook 路径的危险命令防线**(#53、#54)。MCP 网关路径本就会分类破坏性
+  shell 命令,但 hook 路径(Claude Code / Cursor / Codex 的 `Bash` 工具)此前只扫
+  secret / 占位符 —— 用户开「允许所有命令」时,agent 因意图漂移 / 提示注入 / 参数事故跑出的
+  `rm -rf ~`、`curl … | sh`、写 crontab 等命令会直接穿过。本防线**只判效果、不判意图**
+  (denylist,无 ML):灾难级动作(文件系统清除、裸写块设备、fork bomb)任何姿态恒拒 ——
+  与明文密钥同级的硬地板;高危动作(持久化 / 自启、远程下载直灌 shell、项目根之外的递归删除、
+  `rm -rf $VAR/` 空展开事故)按姿态分级 Ask(High=Deny)。项目根感知压误报:项目内的
+  `rm -rf ./node_modules` 放行,同一命令指向 `~` 则被拦。诚实边界:这是防事故与低成本注入的
+  护栏,不是沙箱 —— 深度混淆可以绕过。
+- **daemon 暖载窗口可观测**(#55):模型暖载最长约 45s,此前这段时间里 `daemon status`
+  会在你刚执行 `daemon start` 后报「未运行」。现在 warming 标记让窗口可见:status 报
+  「启动中(正在暖载 ML 模型)」,`--json` 增 `reason:"warming"`(字段只增不删),
+  陈旧标记自愈。
+- **`setup --status` 显示全 agent 网关覆盖**(#55):此前只显示 Claude Code 的计数 ——
+  `setup --all` 为 Codex/Cursor 包好二十多个 server 后,status 里无从确认全局覆盖面。
+  现在:`已防护 23 个服务器(Claude Code 2 / Codex 11 / Cursor 10)`。
+
+### 修复
+
+- **非英文系统上桌面应用可能恒判 daemon「未运行」**(#55):它解析的是英文人类可读
+  `daemon status` 行,而该行随系统语言本地化。现改走 `daemon status --json` 稳定 schema,
+  并对机器解析的子进程输出统一钉 `VIGIL_LANG=en`(model status 的 "installed" 行解析存在
+  同族隐患,一并根治)。守护卡同时新增第三态「启动中 · 暖载模型」,替代暖载期间误导性的
+  「未运行」,并隐藏启动按钮避免 bind 冲突。
+- hook fail-closed 消息不再写死「PreToolUse」(同一入口也接 PostToolUse 事件);daemon
+  冷态 / stop 文案去掉内部黑话「无 daemon.json」;posture 中文档位词在 CLI help 与 GUI
+  之间对齐(宽松 / 适中 / 严格)。
+
 ## [v0.4.6-beta.3] — 2026-07-03 — 稳健性打磨:OAuth scope 接线修复、`status --json`、双引擎 parity、远程 MCP e2e
 
 加固向 beta:一个真实网关修复,其余全部是验证覆盖面的加强。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5790,7 +5790,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vigil-audit"
-version = "0.4.6-beta.3"
+version = "0.4.6-beta.4"
 dependencies = [
  "criterion",
  "hex",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-browser"
-version = "0.4.6-beta.3"
+version = "0.4.6-beta.4"
 dependencies = [
  "once_cell",
  "regex",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-desktop"
-version = "0.4.6-beta.3"
+version = "0.4.6-beta.4"
 dependencies = [
  "base64 0.22.1",
  "blake2",
@@ -5858,7 +5858,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-firewall"
-version = "0.4.6-beta.3"
+version = "0.4.6-beta.4"
 dependencies = [
  "dunce",
  "hex",
@@ -5882,7 +5882,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-http-auth"
-version = "0.4.6-beta.3"
+version = "0.4.6-beta.4"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -5899,7 +5899,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-http-transport"
-version = "0.4.6-beta.3"
+version = "0.4.6-beta.4"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-hub-cli"
-version = "0.4.6-beta.3"
+version = "0.4.6-beta.4"
 dependencies = [
  "clap",
  "dirs 6.0.0",
@@ -5941,12 +5941,15 @@ dependencies = [
  "hex",
  "interprocess",
  "oauth2",
+ "once_cell",
+ "regex",
  "rusqlite",
  "rustix 1.1.4",
  "serde",
  "serde_jcs",
  "serde_json",
  "sha2",
+ "shlex 1.3.0",
  "sys-locale",
  "tempfile",
  "thiserror 1.0.69",
@@ -5969,7 +5972,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-lease"
-version = "0.4.6-beta.3"
+version = "0.4.6-beta.4"
 dependencies = [
  "hex",
  "keyring",
@@ -5987,7 +5990,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-mcp"
-version = "0.4.6-beta.3"
+version = "0.4.6-beta.4"
 dependencies = [
  "hex",
  "once_cell",
@@ -6012,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-native-host"
-version = "0.4.6-beta.3"
+version = "0.4.6-beta.4"
 dependencies = [
  "clap",
  "dirs 6.0.0",
@@ -6026,7 +6029,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-policy"
-version = "0.4.6-beta.3"
+version = "0.4.6-beta.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -6036,7 +6039,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-redaction"
-version = "0.4.6-beta.3"
+version = "0.4.6-beta.4"
 dependencies = [
  "criterion",
  "dirs 5.0.1",
@@ -6058,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-runner"
-version = "0.4.6-beta.3"
+version = "0.4.6-beta.4"
 dependencies = [
  "cap-std",
  "dunce",
@@ -6079,7 +6082,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-runner-types"
-version = "0.4.6-beta.3"
+version = "0.4.6-beta.4"
 dependencies = [
  "dunce",
  "serde",
@@ -6088,7 +6091,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-sandbox-linux"
-version = "0.4.6-beta.3"
+version = "0.4.6-beta.4"
 dependencies = [
  "landlock",
  "libc",
@@ -6098,7 +6101,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-sdk"
-version = "0.4.6-beta.3"
+version = "0.4.6-beta.4"
 dependencies = [
  "serde_json",
  "uuid",
@@ -6112,7 +6115,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-types"
-version = "0.4.6-beta.3"
+version = "0.4.6-beta.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -6120,7 +6123,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-ui-protocol"
-version = "0.4.6-beta.3"
+version = "0.4.6-beta.4"
 dependencies = [
  "serde",
  "serde_jcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.6-beta.3"
+version = "0.4.6-beta.4"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Vigils",
-  "version": "0.4.6-beta.3",
+  "version": "0.4.6-beta.4",
   "identifier": "ai.vigils.desktop",
   "mainBinaryName": "vigils",
   "build": {

--- a/crates/vigil-audit/Cargo.toml
+++ b/crates/vigil-audit/Cargo.toml
@@ -19,10 +19,10 @@ workspace = true
 test-util = []
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.4.6-beta.3" }
+vigil-types = { path = "../vigil-types", version = "0.4.6-beta.4" }
 # I01 扩展依赖:fail-closed 入口自检(ADR 0002 §D1)。
 # I00 的 "只能依赖 vigil-types" 约束是 I00 阶段性规则,I01 按 ADR 0002 明确放开。
-vigil-redaction = { path = "../vigil-redaction", version = "0.4.6-beta.3" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.4.6-beta.4" }
 
 # I01 核心依赖
 rusqlite = { workspace = true }

--- a/crates/vigil-firewall/Cargo.toml
+++ b/crates/vigil-firewall/Cargo.toml
@@ -14,12 +14,12 @@ categories = ["api-bindings", "authentication"]
 workspace = true
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.4.6-beta.3" }
-vigil-policy = { path = "../vigil-policy", version = "0.4.6-beta.3" }
-vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.3" }
+vigil-types = { path = "../vigil-types", version = "0.4.6-beta.4" }
+vigil-policy = { path = "../vigil-policy", version = "0.4.6-beta.4" }
+vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.4" }
 # ISS-010: T0 preflight 扫描(vigil-firewall 在 evaluate 前调 scan_text 产 PII findings)。
 # 依赖方向 T1 → T0 合法(vigil-redaction 纯函数、无反向依赖)。
-vigil-redaction = { path = "../vigil-redaction", version = "0.4.6-beta.3" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.4.6-beta.4" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/vigil-lease/Cargo.toml
+++ b/crates/vigil-lease/Cargo.toml
@@ -20,8 +20,8 @@ default = []
 os-keychain = ["dep:keyring"]
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.4.6-beta.3" }
-vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.3" }
+vigil-types = { path = "../vigil-types", version = "0.4.6-beta.4" }
+vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.4" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/vigil-mcp/Cargo.toml
+++ b/crates/vigil-mcp/Cargo.toml
@@ -20,24 +20,24 @@ workspace = true
 ort = ["vigil-redaction/ort"]
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.4.6-beta.3" }
-vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.3" }
-vigil-firewall = { path = "../vigil-firewall", version = "0.4.6-beta.3" }
-vigil-redaction = { path = "../vigil-redaction", version = "0.4.6-beta.3" }
+vigil-types = { path = "../vigil-types", version = "0.4.6-beta.4" }
+vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.4" }
+vigil-firewall = { path = "../vigil-firewall", version = "0.4.6-beta.4" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.4.6-beta.4" }
 # I07.5+ (ADR 0007 §I-7.1):共享 Native spawn env 政策 helper(apply_native_env_policy)。
 # ADR 0018 v0.13 split:改依赖 vigil-runner-types(pure types + env policy,0 vigil
 # deps,unblock SDK publish chain),不再拉 vigil-runner concrete impl(wasmtime 等)。
-vigil-runner-types = { path = "../vigil-runner-types", version = "0.4.6-beta.3" }
+vigil-runner-types = { path = "../vigil-runner-types", version = "0.4.6-beta.4" }
 # v0.5 P1 ADR 0014 α2:`pub fn Hub::resolve_approval` 用到的 typed 协议结构
 # (ResolveApprovalReq / ApprovalAction / ApprovalResolutionDto)。
 # vigil-ui-protocol 自身只依赖 vigil-types / vigil-audit / vigil-runner,
 # 与 vigil-mcp 现有 deps 无循环。
-vigil-ui-protocol = { path = "../vigil-ui-protocol", version = "0.4.6-beta.3" }
+vigil-ui-protocol = { path = "../vigil-ui-protocol", version = "0.4.6-beta.4" }
 # 可逆脱敏 Slice 2:复用 `SecretValue`(Zeroizing/non-Debug/单一 expose)的值卫生装
 # Hub-owned `SecretAliasMap`。**只取值包装**,不引 LeaseBroker 审批门控语义(设计 D2:
 # broker mint-time 3-tuple 绑定与"运行时选 tool"现实冲突)。不启 os-keychain feature
 # —— keyring 读取在 vigil-hub-cli(已带该 feature)。
-vigil-lease = { path = "../vigil-lease", version = "0.4.6-beta.3" }
+vigil-lease = { path = "../vigil-lease", version = "0.4.6-beta.4" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -52,7 +52,7 @@ once_cell = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 rusqlite = { workspace = true }
-vigil-policy = { path = "../vigil-policy", version = "0.4.6-beta.3" }
+vigil-policy = { path = "../vigil-policy", version = "0.4.6-beta.4" }
 # α2 集成测试 `tests/resolve_approval.rs` 用 Ledger 真实建 approval + 调
 # `Hub::resolve_approval` 全链路验证 approve / deny / cancel(已是 main dep,
 # 此处显式声明仅为 IDE / `cargo metadata` 可读性)。

--- a/crates/vigil-policy/Cargo.toml
+++ b/crates/vigil-policy/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["api-bindings", "authentication"]
 workspace = true
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.4.6-beta.3" }
+vigil-types = { path = "../vigil-types", version = "0.4.6-beta.4" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/vigil-sdk/Cargo.toml
+++ b/crates/vigil-sdk/Cargo.toml
@@ -23,14 +23,14 @@ ort = ["vigil-firewall/ort", "vigil-redaction/ort"]
 
 [dependencies]
 # Stable SDK re-exports;path-dep,locked to workspace version
-vigil-types = { path = "../vigil-types", version = "0.4.6-beta.3" }
-vigil-firewall = { path = "../vigil-firewall", version = "0.4.6-beta.3" }
-vigil-redaction = { path = "../vigil-redaction", version = "0.4.6-beta.3" }
-vigil-mcp = { path = "../vigil-mcp", version = "0.4.6-beta.3" }
+vigil-types = { path = "../vigil-types", version = "0.4.6-beta.4" }
+vigil-firewall = { path = "../vigil-firewall", version = "0.4.6-beta.4" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.4.6-beta.4" }
+vigil-mcp = { path = "../vigil-mcp", version = "0.4.6-beta.4" }
 # v0.16 FirewallBuilder facade:内部装配用(Ledger / PolicyEngine + default_ruleset)。
 # **不** re-export —— 仅 firewall_builder 内化使用,守 SDK 边界。
-vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.3" }
-vigil-policy = { path = "../vigil-policy", version = "0.4.6-beta.3" }
+vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.4" }
+vigil-policy = { path = "../vigil-policy", version = "0.4.6-beta.4" }
 # decide_call 便捷方法生成 invocation_id(UUIDv4);内部用,不进 SDK public API。
 uuid = { workspace = true }
 # decide_call 的 args 形参类型(serde_json::Value 已是 ToolInvocation.args 的公开类型,不扩面)。

--- a/crates/vigil-ui-protocol/Cargo.toml
+++ b/crates/vigil-ui-protocol/Cargo.toml
@@ -14,11 +14,11 @@ categories = ["data-structures", "api-bindings"]
 workspace = true
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.4.6-beta.3" }
-vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.3" }
+vigil-types = { path = "../vigil-types", version = "0.4.6-beta.4" }
+vigil-audit = { path = "../vigil-audit", version = "0.4.6-beta.4" }
 # ADR 0018 v0.13 split:改依赖 vigil-runner-types(pure types,0 vigil deps),
 # 不再拉 vigil-runner concrete(wasmtime/sandbox-linux),unblock SDK publish。
-vigil-runner-types = { path = "../vigil-runner-types", version = "0.4.6-beta.3" }
+vigil-runner-types = { path = "../vigil-runner-types", version = "0.4.6-beta.4" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
Cut prerelease **v0.4.6-beta.4**。

## 自 beta.3 的增量
- **Command Guard**(#53/#54):hook 路径危险命令防线——效果分类(非意图)denylist;灾难级(文件系统清除/裸写块设备/fork bomb)任何姿态恒拒(硬地板);高危(持久化/远程直灌 shell/项目外删除/空变量展开)按姿态 Ask;项目根感知压误报;诚实边界=护栏非沙箱。
- **第四轮用户级验证修复**(#55):daemon 暖载窗口可观测(warming 标记 + `--json reason:"warming"`)、`setup --status` 全 agent MCP 覆盖明细、GUI daemon 状态 locale 误判根治(`--json` + `VIGIL_LANG=en`)+ 三态守护卡。

## 本 PR 内容
版本 bump(28 处 path-dep/workspace/tauri.conf + `cargo update --workspace` 刷 lock)+ CHANGELOG 双语 beta.4 段。

## 验证
bump 后独立门禁:`cargo fmt --all --check` + `clippy --workspace --all-targets -D warnings` + `cargo test --workspace` = **1240 passed / 0 failed**。

合并后将 tag `v0.4.6-beta.4` 触发 Release workflow(27+ 资产),并由 workflow_run 自动触发三平台值守验收(user-sim + functional-sweep + desktop-smoke + local-audit)。