### PR TITLE
feat(browser): native host joins the daemon as its second ML client (engine link)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5822,6 +5822,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "vigil-daemon-ipc"
+version = "0.4.6"
+dependencies = [
+ "dirs 6.0.0",
+ "interprocess",
+ "rustix 1.1.4",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "vigil-desktop"
 version = "0.4.6"
 dependencies = [
@@ -5944,7 +5957,6 @@ dependencies = [
  "once_cell",
  "regex",
  "rusqlite",
- "rustix 1.1.4",
  "serde",
  "serde_jcs",
  "serde_json",
@@ -5957,6 +5969,7 @@ dependencies = [
  "url",
  "uuid",
  "vigil-audit",
+ "vigil-daemon-ipc",
  "vigil-desktop",
  "vigil-firewall",
  "vigil-http-auth",
@@ -6023,6 +6036,7 @@ dependencies = [
  "tempfile",
  "vigil-audit",
  "vigil-browser",
+ "vigil-daemon-ipc",
  "vigil-redaction",
  "winreg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/vigil-redaction",
     "crates/vigil-ui-protocol",
     "crates/vigil-browser",
+    "crates/vigil-daemon-ipc",
     "crates/vigil-http-auth",
     "crates/vigil-http-transport",
     "crates/vigil-sandbox-linux",

--- a/apps/native-host/Cargo.toml
+++ b/apps/native-host/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "vigil-native-host"
+publish = false  # 非 SDK publish set(app / wasmtime / http / sandbox)— 不上 crates.io;cargo-deny path-dep wildcard 守门
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -20,7 +21,11 @@ path = "src/lib.rs"
 [dependencies]
 vigil-browser = { path = "../../crates/vigil-browser" }
 vigil-audit = { path = "../../crates/vigil-audit" }
+# ML 增强基底重算(scrub_text_with_spans)+ 改写后纵深 re-scan(scan_hard_findings)。
 vigil-redaction = { path = "../../crates/vigil-redaction" }
+# daemon 第二客户端(ADR 0024;hook 之后):RedactScan 协议 + R1/R2 fail-closed 传输 +
+# WireFinding 安全应用原语。零 ort —— 模型只在 daemon,本 host 保持轻量。
+vigil-daemon-ipc = { path = "../../crates/vigil-daemon-ipc" }
 serde_json = { workspace = true }
 # β1:install/uninstall/status CLI + 跨平台 Chrome Native Messaging Host manifest 注册
 clap = { workspace = true }

--- a/apps/native-host/src/lib.rs
+++ b/apps/native-host/src/lib.rs
@@ -1,8 +1,15 @@
 //! Vigil Native Messaging Host —— lib 层:纯 I/O 循环供集成测试直接调。
 //!
-//! bin 入口在 `main.rs`:打开默认 Ledger 路径,调用 `run(stdin, stdout, ledger, session)`。
+//! bin 入口在 `main.rs`:打开默认 Ledger 路径,调用 `run(stdin, stdout, ledger, session, ml)`。
 //! 集成测试在 `tests/` 中注入 `Cursor<Vec<u8>>` 作 stdin / stdout,验证 framing + 分类器 + 审计。
-
+//!
+//! # ML 增强(daemon 第二客户端;Phase 1「引擎连接」)
+//!
+//! 硬指纹分类([`vigil_browser::classify`])仍是**无条件底座**;其上叠加一层可选的 daemon
+//! ML PII 增强([`ml_augment`]):daemon(ADR 0024)可用 → 把模型命中的语义 PII
+//! (email/person/phone/…)追加脱敏;daemon 缺席/超时/畸形/被 engine.json 关闭 → 行为
+//! **逐字节等于**纯硬指纹现状(fail-closed,零回归)。**ML 只能收紧**(Allow→Redact),
+//! 绝不放宽(Allow/Block 语义由硬指纹层独占)。
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
@@ -30,15 +37,247 @@ pub fn is_admin_subcommand(args: &[String]) -> bool {
         .unwrap_or(false)
 }
 
+/// Ledger 落点解析(纯函数,DI 可测;审核 P1 EXT-01 修复)。优先级:
+///
+/// 1. `VIGIL_LEDGER_PATH` —— 全产品 canonical 环境变量(与 `vigil-hub-cli` `setup.rs`
+///    `default_ledger_path` 一致);此前本 host 只认 `VIGIL_DB_PATH`,与 CLI/桌面分裂,
+///    文档所述的对齐方式对 host 无效。
+/// 2. `VIGIL_DB_PATH` —— 本 host 历史环境变量,保留为向后兼容别名。
+/// 3. 默认 `<data_local_dir>/Vigil/ledger.sqlite3` —— canonical 共享账本(与 CLI/桌面
+///    同文件),浏览器审计事件由此在桌面 Activity Feed 可见。此前默认 in-memory,
+///    事件随 Chrome 停止 host 即丢(审计链断)。
+/// 4. 连 `data_local_dir` 都取不到 → `None`(调用方回退 in-memory:分类防护优先于
+///    审计持久化,绝不因审计初始化失败拒绝守门)。
+///
+/// 空/纯空白的环境变量值按未设置处理(不落进当前目录的空名文件)。
+pub fn resolve_ledger_path(
+    ledger_env: Option<&str>,
+    db_env: Option<&str>,
+    data_local: Option<std::path::PathBuf>,
+) -> Option<std::path::PathBuf> {
+    if let Some(p) = ledger_env.map(str::trim).filter(|s| !s.is_empty()) {
+        return Some(std::path::PathBuf::from(p));
+    }
+    if let Some(p) = db_env.map(str::trim).filter(|s| !s.is_empty()) {
+        return Some(std::path::PathBuf::from(p));
+    }
+    data_local.map(|d| d.join("Vigil").join("ledger.sqlite3"))
+}
+
 use std::io::{Read, Write};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 use vigil_audit::Ledger;
 use vigil_browser::{
-    build_audit_payload, classify, event_type_for, read_frame, write_frame, BrowserAuditMeta,
-    BrowserCheckRequest, BrowserErrorCode, BrowserErrorFrame, ClassifyOutcome,
+    build_audit_payload, classify, event_type_for, read_frame, write_frame, BrowserAction,
+    BrowserAuditMeta, BrowserCheckRequest, BrowserCheckResponse, BrowserErrorCode,
+    BrowserErrorFrame, ClassifyOutcome,
 };
+use vigil_daemon_ipc::protocol::{Request, Response, ScanKind, WireFinding};
+use vigil_daemon_ipc::transport::query_daemon;
+use vigil_daemon_ipc::wire::{apply_wire_spans, cap_to_char_boundary, safe_label};
 
-/// 主循环:反复 read_frame → 分类 → write_frame;返 `()` 表示正常 EOF。
+// ─────────────────────────── daemon ML 增强层(Phase 1「引擎连接」) ───────────────────────────
+
+/// 单次 daemon 查询截止(对齐 hook `ML_QUERY_DEADLINE`;paste 路径最坏 +800ms,可接受)。
+const ML_QUERY_DEADLINE: Duration = Duration::from_millis(800);
+
+/// 送 ML 的文本前缀上限(对齐 hook `ML_SCAN_TEXT_CAP`;绝大多数 paste 远小于此。
+/// 超出前缀的 suffix 无 ML,硬指纹底座在 classify 已全文扫过)。
+const ML_SCAN_TEXT_CAP: usize = 16 * 1024;
+
+/// 低于此长度不查 daemon(对齐 hook `ML_MIN_SEG_LEN`;超短文本无语义 PII 意义,省 RTT)。
+const ML_MIN_TEXT_LEN: usize = 8;
+
+/// daemon 查询失败后的冷却窗口:窗口内不再发起查询(降级纯硬指纹)。
+///
+/// hook 是 one-shot 进程(阻塞 worker 随进程回收);本 host 是 **Chrome 长驻进程**,
+/// 慢/挂死 daemon 下若每次 paste 都查询,`query_daemon` 的 detached worker 会逐次累积、
+/// 且每次白付 deadline 延迟。首次失败即静默 60s,窗口过后自动重试(daemon 恢复可自愈)。
+const ML_FAILURE_COOLDOWN: Duration = Duration::from_secs(60);
+
+/// 失败冷却状态(纯逻辑,DI 可测)。`record_failure` 记时刻;`in_cooldown` 查询窗口。
+#[derive(Debug)]
+struct FailureCooldown {
+    window: Duration,
+    last_failure: Mutex<Option<Instant>>,
+}
+
+impl FailureCooldown {
+    const fn new(window: Duration) -> Self {
+        Self {
+            window,
+            last_failure: Mutex::new(None),
+        }
+    }
+
+    fn in_cooldown(&self, now: Instant) -> bool {
+        let guard = self.last_failure.lock().unwrap_or_else(|e| e.into_inner());
+        matches!(*guard, Some(t) if now.duration_since(t) < self.window)
+    }
+
+    fn record_failure(&self, now: Instant) {
+        let mut guard = self.last_failure.lock().unwrap_or_else(|e| e.into_inner());
+        *guard = Some(now);
+    }
+}
+
+/// engine.json(`{"version":1,"engine":"hardfp"|"ml"|"auto"}`,SSOT 见 vigil-hub-cli
+/// `engine_config.rs`)是否允许查 daemon。**纯函数**(`raw` = 文件内容;`None` = 文件缺失):
+///
+/// - 缺失 → `true`(未配置 = auto 语义:查 daemon,缺席自然降级,零成本零回归);
+/// - 显式 `"hardfp"` → `false`(尊重用户显式选择,与 hook 消费同一 SSOT 一致);
+/// - `"ml"` / `"auto"` → `true`;
+/// - 损坏 / 版本不识别 / 未知值 → `false`(对齐 engine_config「损坏收敛 hardfp」的
+///   fail-closed 方向;本层解析独立于 SSOT 实现,字段漂移时最多退化为不启 ML,不影响防护)。
+pub fn engine_allows_ml(raw: Option<&str>) -> bool {
+    let Some(raw) = raw else {
+        return true; // 文件缺失 = 未配置 → auto
+    };
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(raw) else {
+        return false; // 损坏 → 收敛 hardfp
+    };
+    if v.get("version").and_then(serde_json::Value::as_u64) != Some(1) {
+        return false; // 版本不识别 → 不按旧语义猜
+    }
+    matches!(
+        v.get("engine").and_then(serde_json::Value::as_str),
+        Some("ml") | Some("auto")
+    )
+}
+
+/// ML 探针(DI 边界,production-logic-testable):`scan` 返 `None` = 本次不可用
+/// (daemon 缺席/超时/协议错/被禁用/冷却中),`Some(findings)` = 扫描成功(可为空 = 无命中)。
+pub trait MlProbe {
+    /// 对 `text` 做一次 daemon ML PII 扫描。
+    fn scan(&self, text: &str) -> Option<Vec<WireFinding>>;
+}
+
+/// 生产实现:engine.json 门控 + 失败冷却 + `query_daemon(RedactScan)`。
+///
+/// 每请求现读 engine.json(host 为 Chrome 长驻进程,现读避免配置陈旧;文件极小,
+/// paste 为人手频率,成本可忽略)。
+#[derive(Debug)]
+pub struct DaemonProbe {
+    cooldown: FailureCooldown,
+}
+
+impl DaemonProbe {
+    /// 新建(冷却窗口 [`ML_FAILURE_COOLDOWN`])。
+    pub fn new() -> Self {
+        Self {
+            cooldown: FailureCooldown::new(ML_FAILURE_COOLDOWN),
+        }
+    }
+}
+
+impl Default for DaemonProbe {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MlProbe for DaemonProbe {
+    fn scan(&self, text: &str) -> Option<Vec<WireFinding>> {
+        if self.cooldown.in_cooldown(Instant::now()) {
+            return None;
+        }
+        let engine_raw = dirs::data_local_dir()
+            .map(|d| d.join("Vigil").join("engine.json"))
+            .and_then(|p| std::fs::read_to_string(p).ok());
+        if !engine_allows_ml(engine_raw.as_deref()) {
+            return None;
+        }
+        match query_daemon(
+            Request::RedactScan {
+                kind: ScanKind::Args,
+                text: text.to_string(),
+            },
+            ML_QUERY_DEADLINE,
+        ) {
+            Some(Response::Findings { findings }) => Some(findings),
+            // 缺席/超时/Error/非预期响应 → 记失败进冷却(防长驻进程 worker 累积),降级硬指纹。
+            _ => {
+                self.cooldown.record_failure(Instant::now());
+                None
+            }
+        }
+    }
+}
+
+/// 恒不可用探针:集成测试 / 显式关闭用(行为 = 纯硬指纹现状)。
+#[derive(Debug)]
+pub struct DisabledMlProbe;
+
+impl MlProbe for DisabledMlProbe {
+    fn scan(&self, _text: &str) -> Option<Vec<WireFinding>> {
+        None
+    }
+}
+
+/// findings → 去重升序的 sanitize 标签表(进 `BrowserCheckResponse.ml_labels` 与审计;
+/// 只含类别名,不含任何 span 文本)。
+fn collect_ml_labels(findings: &[WireFinding]) -> Vec<String> {
+    let set: std::collections::BTreeSet<String> =
+        findings.iter().map(|f| safe_label(&f.label)).collect();
+    set.into_iter().collect()
+}
+
+/// daemon ML PII 增强(fail-closed 纯加性)。返回参与审计的引擎标识:
+/// `"hardfp"`(未查/不可用/Block 短路)或 `"hardfp+ml"`(daemon 扫描成功,含无命中)。
+///
+/// 语义(与 hook `MlScrub` 同构,ADR 0024 D2):
+/// - `Block` 短路:硬指纹已最严,不查(省 RTT);
+/// - 基底 = 硬指纹层最终文本(`Redact` → `scrub_text_with_spans` 的占位符文本 + 其
+///   **自产占位符区间**作 `protected`;`Allow` → 原文、无保护区),ML 在**基底**上扫 →
+///   span 坐标系一致;[`apply_wire_spans`] 做并集合并 + 受保护区减法(VIGIL-SEC-OVERLAP/-PH);
+/// - ML 命中露出区间 → `Allow` 升级 `Redact` / `Redact` 文本再遮盖(**只收紧**);
+///   全部命中都落在占位符内 → 响应原样;
+/// - 纵深防御:ML 改写后再跑一遍硬指纹扫描,残留即 `Block`(与 §I-9.6 同精神;
+///   基底已过 classify 的 re-scan,此分支理论不可达,保留作防御层)。
+fn ml_augment(text: &str, resp: &mut BrowserCheckResponse, ml: &dyn MlProbe) -> &'static str {
+    if matches!(resp.action, BrowserAction::Block) {
+        return "hardfp";
+    }
+    if text.len() < ML_MIN_TEXT_LEN {
+        return "hardfp";
+    }
+    // 基底与保护区:Redact 时重算带区间的 scrub(`scrub_text_with_spans().0 == scrub_text()`
+    // 有 vigil-redaction 单测守恒,与 classify 已产出的 redacted_text 一致)。
+    let (base, protected) = match resp.action {
+        BrowserAction::Redact => vigil_redaction::scrub_text_with_spans(text),
+        _ => (text.to_string(), Vec::new()),
+    };
+    let capped = cap_to_char_boundary(&base, ML_SCAN_TEXT_CAP);
+    let scanned_len = capped.len();
+    let Some(findings) = ml.scan(capped) else {
+        return "hardfp";
+    };
+    if findings.is_empty() {
+        return "hardfp+ml";
+    }
+    let (out, hits) = apply_wire_spans(&base, scanned_len, &findings, &protected);
+    if hits == 0 {
+        // 全部 ML 命中都在硬指纹占位符内(已脱敏)→ 响应原样。
+        return "hardfp+ml";
+    }
+    // 纵深防御(§I-9.6 同精神):改写后残留硬指纹 → Block,绝不让半成品进 DOM。
+    if !vigil_redaction::scan_hard_findings(&out).is_empty() {
+        resp.action = BrowserAction::Block;
+        resp.redacted_text = None;
+        resp.ml_labels = collect_ml_labels(&findings);
+        return "hardfp+ml";
+    }
+    resp.action = BrowserAction::Redact; // Allow→Redact 升级;Redact 保持
+    resp.redacted_text = Some(out);
+    resp.ml_labels = collect_ml_labels(&findings);
+    "hardfp+ml"
+}
+
+// ─────────────────────────── stdin/stdout 主循环 ───────────────────────────
+
+/// 主循环:反复 read_frame → 分类(+ ML 增强)→ write_frame;返 `()` 表示正常 EOF。
 ///
 /// 任何协议错都以 `BrowserErrorFrame` 形式回写给 peer,**不**让错误冒泡到
 /// stdout raw bytes(Chrome native messaging 一旦 stdout 写坏就会断连接)。
@@ -47,11 +286,12 @@ pub fn run<R: Read, W: Write>(
     stdout: &mut W,
     ledger: &Ledger,
     session_id: &str,
+    ml: &dyn MlProbe,
 ) -> Result<(), std::io::Error> {
     loop {
         match read_frame(stdin) {
             Ok(Some(payload)) => {
-                handle_one(&payload, stdout, ledger, session_id)?;
+                handle_one(&payload, stdout, ledger, session_id, ml)?;
             }
             Ok(None) => return Ok(()), // 扩展断开
             Err(code) => {
@@ -70,6 +310,7 @@ fn handle_one<W: Write>(
     stdout: &mut W,
     ledger: &Ledger,
     session_id: &str,
+    ml: &dyn MlProbe,
 ) -> Result<(), std::io::Error> {
     // 解析请求
     let req: BrowserCheckRequest = match serde_json::from_slice(payload) {
@@ -79,18 +320,21 @@ fn handle_one<W: Write>(
         }
     };
 
-    // 分类
+    // 分类(硬指纹底座)
     match classify(&req) {
         ClassifyOutcome::Error(code) => {
             write_error(stdout, code, Some(req.request_id.clone()))?;
         }
-        ClassifyOutcome::Response(resp) => {
+        ClassifyOutcome::Response(mut resp) => {
+            // daemon ML 增强(fail-closed 纯加性;daemon 缺席时本行为恒等于现状)。
+            let engine = ml_augment(&req.text, &mut resp, ml);
             // 审计(metadata only)—— 用 `BrowserAuditMeta` 接口边界编码"不得含 raw text"
             let meta = BrowserAuditMeta {
                 origin: &req.origin,
                 event_kind: req.event_kind,
                 request_id: &req.request_id,
                 text_len: req.text.len(),
+                engine,
             };
             let audit_payload = build_audit_payload(&meta, &resp);
             let event_type = event_type_for(req.event_kind);
@@ -196,5 +440,256 @@ mod argv_dispatch_tests {
                 "{bad} should NOT be recognized as admin subcommand (fallback run)"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod ledger_path_tests {
+    use super::resolve_ledger_path;
+    use std::path::PathBuf;
+
+    #[test]
+    fn canonical_env_wins_over_alias_and_default() {
+        let got = resolve_ledger_path(
+            Some("C:/custom/ledger.sqlite3"),
+            Some("C:/legacy/db.sqlite"),
+            Some(PathBuf::from("C:/data-local")),
+        );
+        assert_eq!(got, Some(PathBuf::from("C:/custom/ledger.sqlite3")));
+    }
+
+    #[test]
+    fn legacy_alias_still_honored_when_canonical_unset() {
+        let got = resolve_ledger_path(
+            None,
+            Some("C:/legacy/db.sqlite"),
+            Some(PathBuf::from("C:/data-local")),
+        );
+        assert_eq!(got, Some(PathBuf::from("C:/legacy/db.sqlite")));
+    }
+
+    #[test]
+    fn default_is_canonical_shared_ledger_under_data_local() {
+        // 与 vigil-hub-cli setup.rs default_ledger_path 同构:<data_local>/Vigil/ledger.sqlite3
+        let got = resolve_ledger_path(None, None, Some(PathBuf::from("/home/u/.local/share")));
+        assert_eq!(
+            got,
+            Some(PathBuf::from("/home/u/.local/share/Vigil/ledger.sqlite3"))
+        );
+    }
+
+    #[test]
+    fn blank_env_values_treated_as_unset() {
+        let got = resolve_ledger_path(Some("  "), Some(""), Some(PathBuf::from("/dl")));
+        assert_eq!(got, Some(PathBuf::from("/dl/Vigil/ledger.sqlite3")));
+    }
+
+    #[test]
+    fn no_env_no_data_local_falls_back_none_for_in_memory() {
+        assert_eq!(resolve_ledger_path(None, None, None), None);
+    }
+}
+
+#[cfg(test)]
+mod ml_augment_tests {
+    use super::{engine_allows_ml, ml_augment, FailureCooldown, MlProbe};
+    use std::cell::Cell;
+    use std::time::{Duration, Instant};
+    use vigil_browser::{classify, BrowserAction, BrowserCheckRequest, ClassifyOutcome};
+    use vigil_daemon_ipc::protocol::WireFinding;
+
+    /// 固定返回 findings 的探针 + 调用计数(验证短路路径确实不查)。
+    struct FixedProbe {
+        findings: Option<Vec<WireFinding>>,
+        calls: Cell<usize>,
+    }
+    impl FixedProbe {
+        fn new(findings: Option<Vec<WireFinding>>) -> Self {
+            Self {
+                findings,
+                calls: Cell::new(0),
+            }
+        }
+    }
+    impl MlProbe for FixedProbe {
+        fn scan(&self, _text: &str) -> Option<Vec<WireFinding>> {
+            self.calls.set(self.calls.get() + 1);
+            self.findings.clone()
+        }
+    }
+
+    fn wf(label: &str, start: usize, end: usize) -> WireFinding {
+        WireFinding {
+            label: label.to_string(),
+            start,
+            end,
+        }
+    }
+
+    fn classified(text: &str) -> vigil_browser::BrowserCheckResponse {
+        let req = BrowserCheckRequest {
+            request_id: "11111111-1111-1111-1111-111111111111".into(),
+            origin: "https://chatgpt.com".into(),
+            event_kind: vigil_browser::BrowserEventKind::Paste,
+            text: text.into(),
+        };
+        match classify(&req) {
+            ClassifyOutcome::Response(r) => r,
+            ClassifyOutcome::Error(e) => panic!("unexpected classify error: {e:?}"),
+        }
+    }
+
+    #[test]
+    fn daemon_unavailable_is_byte_identical_to_hardfp_baseline() {
+        // 黄金对照:probe 恒 None → 响应与纯硬指纹现状逐字段相等(fail-closed 零回归)。
+        let text = "please check alice@example.com and ghp_0123456789abcdefghijABCDEFGHIJ123456";
+        let baseline = classified(text);
+        let mut resp = classified(text);
+        let engine = ml_augment(text, &mut resp, &FixedProbe::new(None));
+        assert_eq!(engine, "hardfp");
+        assert_eq!(resp.action, baseline.action);
+        assert_eq!(resp.redacted_text, baseline.redacted_text);
+        assert_eq!(resp.findings, baseline.findings);
+        assert!(resp.ml_labels.is_empty());
+    }
+
+    #[test]
+    fn ml_only_hit_upgrades_allow_to_redact_with_labels() {
+        // 硬指纹 Allow + ML 命中语义 PII → 收紧为 Redact,占位符含 sanitize 标签。
+        let text = "contact alice@example.com please";
+        let mut resp = classified(text);
+        assert_eq!(resp.action, BrowserAction::Allow, "前置:硬指纹应放行");
+        let probe = FixedProbe::new(Some(vec![wf("private_email", 8, 25)]));
+        let engine = ml_augment(text, &mut resp, &probe);
+        assert_eq!(engine, "hardfp+ml");
+        assert_eq!(resp.action, BrowserAction::Redact, "ML 命中应收紧为 Redact");
+        let out = resp.redacted_text.as_deref().unwrap();
+        assert!(!out.contains("alice@example.com"), "PII 应被遮盖:{out}");
+        assert!(out.contains("[REDACTED private_email]"));
+        assert_eq!(resp.ml_labels, vec!["private_email".to_string()]);
+    }
+
+    #[test]
+    fn ml_scan_clean_keeps_allow_and_marks_engine() {
+        // daemon 扫过但无命中 → Allow 保持;engine 标 hardfp+ml(审计可区分"没扫"与"扫了没中")。
+        let text = "just a plain sentence";
+        let mut resp = classified(text);
+        let engine = ml_augment(text, &mut resp, &FixedProbe::new(Some(vec![])));
+        assert_eq!(engine, "hardfp+ml");
+        assert_eq!(resp.action, BrowserAction::Allow);
+        assert!(resp.ml_labels.is_empty());
+    }
+
+    #[test]
+    fn redact_base_protects_hardfp_placeholders_from_ml_overcapture() {
+        // 硬指纹 Redact 基底上,ML span over-capture 进占位符 → 减法保占位符完整,露出部分被遮。
+        let text = "mail bob@x.io token ghp_0123456789abcdefghijABCDEFGHIJ123456";
+        let mut resp = classified(text);
+        assert_eq!(resp.action, BrowserAction::Redact, "前置:硬指纹应 Redact");
+        let base = vigil_redaction::scrub_text_with_spans(text).0;
+        // ML 声称从 0 覆盖到占位符内部(over-capture):email "mail bob@x.io" + 深入占位符 3 字节。
+        let placeholder_start = base.find("[REDACTED").expect("应有硬指纹占位符");
+        let probe = FixedProbe::new(Some(vec![wf("private_email", 0, placeholder_start + 3)]));
+        let engine = ml_augment(text, &mut resp, &probe);
+        assert_eq!(engine, "hardfp+ml");
+        let out = resp.redacted_text.as_deref().unwrap();
+        assert!(!out.contains("bob@x.io"), "露出区 PII 应被遮:{out}");
+        assert!(
+            out.contains("[REDACTED github_token]") || out.contains("[REDACTED "),
+            "硬指纹占位符不得被切碎:{out}"
+        );
+        assert!(
+            !out.contains("ghp_0123456789"),
+            "硬指纹脱敏不得被 ML 改写回退:{out}"
+        );
+    }
+
+    #[test]
+    fn ml_hits_fully_inside_placeholder_leave_response_unchanged() {
+        // ML 命中全落在硬指纹占位符内(已脱敏)→ 减法后零替换,响应原样(仅 engine 标记)。
+        let text = "k ghp_0123456789abcdefghijABCDEFGHIJ123456";
+        let mut resp = classified(text);
+        let before = resp.clone();
+        let base = vigil_redaction::scrub_text_with_spans(text).0;
+        let ph_start = base.find("[REDACTED").unwrap();
+        let probe = FixedProbe::new(Some(vec![wf("secret", ph_start + 2, ph_start + 8)]));
+        let engine = ml_augment(text, &mut resp, &probe);
+        assert_eq!(engine, "hardfp+ml");
+        assert_eq!(resp.action, before.action);
+        assert_eq!(resp.redacted_text, before.redacted_text);
+        assert!(resp.ml_labels.is_empty(), "零实际替换不应标注 ml_labels");
+    }
+
+    #[test]
+    fn block_short_circuits_without_probing_daemon() {
+        // 硬指纹 Block(PEM)已最严 → 不查 daemon(省 RTT),engine=hardfp。
+        let text = "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBg\n-----END PRIVATE KEY-----";
+        let mut resp = classified(text);
+        assert_eq!(resp.action, BrowserAction::Block, "前置:PEM 应 Block");
+        let probe = FixedProbe::new(Some(vec![wf("x", 0, 5)]));
+        let engine = ml_augment(text, &mut resp, &probe);
+        assert_eq!(engine, "hardfp");
+        assert_eq!(probe.calls.get(), 0, "Block 短路不得查 daemon");
+        assert_eq!(resp.action, BrowserAction::Block);
+    }
+
+    #[test]
+    fn short_text_skips_probe() {
+        let text = "hi";
+        let mut resp = classified(text);
+        let probe = FixedProbe::new(Some(vec![wf("x", 0, 2)]));
+        let engine = ml_augment(text, &mut resp, &probe);
+        assert_eq!(engine, "hardfp");
+        assert_eq!(probe.calls.get(), 0);
+    }
+
+    #[test]
+    fn malicious_labels_are_sanitized_and_deduped() {
+        // daemon 响应按不可信处理:label 注入字符被滤、重复去重、输出升序。
+        let text = "contact alice@example.com and bob@example.com now";
+        let mut resp = classified(text);
+        let probe = FixedProbe::new(Some(vec![
+            wf("e]mail[inj", 8, 25),
+            wf("e]mail[inj", 30, 45),
+        ]));
+        ml_augment(text, &mut resp, &probe);
+        assert_eq!(
+            resp.ml_labels,
+            vec!["emailinj".to_string()],
+            "sanitize + 去重"
+        );
+        let out = resp.redacted_text.as_deref().unwrap();
+        assert!(
+            !out.contains(']') || !out.contains("e]mail"),
+            "标签注入字符不得入占位符:{out}"
+        );
+    }
+
+    #[test]
+    fn engine_gate_semantics() {
+        // 缺失 → auto(查);hardfp 显式关;ml/auto 开;损坏/坏版本/未知值 → fail-closed 关。
+        assert!(engine_allows_ml(None));
+        assert!(!engine_allows_ml(Some(
+            r#"{"version":1,"engine":"hardfp"}"#
+        )));
+        assert!(engine_allows_ml(Some(r#"{"version":1,"engine":"ml"}"#)));
+        assert!(engine_allows_ml(Some(r#"{"version":1,"engine":"auto"}"#)));
+        assert!(!engine_allows_ml(Some("not json")));
+        assert!(!engine_allows_ml(Some(r#"{"version":2,"engine":"ml"}"#)));
+        assert!(!engine_allows_ml(Some(r#"{"version":1,"engine":"turbo"}"#)));
+        assert!(!engine_allows_ml(Some(r#"{"version":1}"#)));
+    }
+
+    #[test]
+    fn failure_cooldown_window_gates_and_expires() {
+        let cd = FailureCooldown::new(Duration::from_secs(60));
+        let t0 = Instant::now();
+        assert!(!cd.in_cooldown(t0), "初始无失败 → 不在冷却");
+        cd.record_failure(t0);
+        assert!(cd.in_cooldown(t0 + Duration::from_secs(30)), "窗口内跳过");
+        assert!(
+            !cd.in_cooldown(t0 + Duration::from_secs(61)),
+            "窗口过后自动恢复(daemon 复活可自愈)"
+        );
     }
 }

--- a/apps/native-host/src/main.rs
+++ b/apps/native-host/src/main.rs
@@ -101,11 +101,32 @@ fn main() -> ExitCode {
 // ─────────────────────────── default subcommand: run(Chrome exec) ─────────────────────
 
 fn run_stdio_loop() -> ExitCode {
-    // Ledger 路径:环境变量 VIGIL_DB_PATH 优先;否则用用户目录下默认路径
-    let db_path = std::env::var("VIGIL_DB_PATH").ok().map(PathBuf::from);
+    // Ledger 路径(审核 P1 EXT-01 修复):VIGIL_LEDGER_PATH(全产品 canonical)→
+    // VIGIL_DB_PATH(历史别名)→ 默认 <data_local_dir>/Vigil/ledger.sqlite3(与 CLI/桌面
+    // 同账本,浏览器审计事件从此桌面 Activity Feed 可见)。解析为纯函数进 lib 单测守门。
+    let db_path = vigil_native_host::resolve_ledger_path(
+        std::env::var("VIGIL_LEDGER_PATH").ok().as_deref(),
+        std::env::var("VIGIL_DB_PATH").ok().as_deref(),
+        dirs::data_local_dir(),
+    );
+    // 持久账本打不开(锁/权限/目录建不出)→ 降级 in-memory 并继续服务:分类防护优先于
+    // 审计持久化(与 hook/daemon 的 audit best-effort 先例一致),绝不因审计初始化失败
+    // 拒绝守门。警告走 stderr(Chrome 收集到扩展日志;stdout 是 framing 通道,禁止字面量)。
     let ledger = match db_path {
-        Some(p) => Ledger::open(&p),
-        None => Ledger::open_in_memory(), // Chrome 每次启动 host 会新建;I09b 补真实路径
+        Some(p) => {
+            if let Some(parent) = p.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            Ledger::open(&p).or_else(|e| {
+                eprintln!(
+                    "vigil-native-host: persistent ledger unavailable at {} ({e}); \
+                     falling back to in-memory audit (protection unaffected)",
+                    p.display()
+                );
+                Ledger::open_in_memory()
+            })
+        }
+        None => Ledger::open_in_memory(),
     };
     let ledger = match ledger {
         Ok(l) => l,
@@ -123,7 +144,9 @@ fn run_stdio_loop() -> ExitCode {
     let mut stdin = std::io::stdin().lock();
     let mut stdout = std::io::stdout().lock();
 
-    match vigil_native_host::run(&mut stdin, &mut stdout, &ledger, &session_id) {
+    // daemon ML 探针:engine.json 门控 + 失败冷却;daemon 缺席 → 行为恒等纯硬指纹(fail-closed)。
+    let ml = vigil_native_host::DaemonProbe::new();
+    match vigil_native_host::run(&mut stdin, &mut stdout, &ledger, &session_id, &ml) {
         Ok(()) => ExitCode::SUCCESS,
         Err(_) => ExitCode::from(1),
     }
@@ -155,7 +178,7 @@ fn cmd_install(
     };
     match install::install(&cfg, allow_missing_exe, None) {
         Ok(out) => {
-            println!("✓ Vigil Native Host installed");
+            println!("[OK] Vigil Native Host installed");
             println!("  manifest: {}", out.manifest_path.display());
             if let Some(reg) = out.registry_key {
                 println!("  registry: {reg}");
@@ -176,7 +199,7 @@ fn cmd_install(
 fn cmd_uninstall() -> ExitCode {
     match install::uninstall(None) {
         Ok(()) => {
-            println!("✓ Vigil Native Host uninstalled (manifest / registry cleared, 幂等)");
+            println!("[OK] Vigil Native Host uninstalled (manifest / registry cleared, 幂等)");
             ExitCode::SUCCESS
         }
         Err(err) => {

--- a/apps/native-host/tests/acceptance.rs
+++ b/apps/native-host/tests/acceptance.rs
@@ -50,7 +50,14 @@ fn run_once(req: &BrowserCheckRequest) -> (Ledger, String, serde_json::Value) {
     let input = encode_request(req);
     let mut stdin = Cursor::new(input);
     let mut stdout: Vec<u8> = Vec::new();
-    vigil_native_host::run(&mut stdin, &mut stdout, &ledger, &sid).unwrap();
+    vigil_native_host::run(
+        &mut stdin,
+        &mut stdout,
+        &ledger,
+        &sid,
+        &vigil_native_host::DisabledMlProbe,
+    )
+    .unwrap();
     let frames = decode_responses(&stdout);
     assert_eq!(frames.len(), 1, "每个 request 应产一个 frame");
     (ledger, sid, frames.into_iter().next().unwrap())
@@ -193,7 +200,14 @@ fn oversized_length_prefix_returns_too_large() {
     // 不写 payload(host 应直接 reject 不读 body)
     let mut stdin = Cursor::new(input);
     let mut stdout: Vec<u8> = Vec::new();
-    vigil_native_host::run(&mut stdin, &mut stdout, &ledger, &sid).unwrap();
+    vigil_native_host::run(
+        &mut stdin,
+        &mut stdout,
+        &ledger,
+        &sid,
+        &vigil_native_host::DisabledMlProbe,
+    )
+    .unwrap();
     let frames = decode_responses(&stdout);
     assert_eq!(frames.len(), 1);
     let ef: BrowserErrorFrame = serde_json::from_value(frames[0].clone()).unwrap();
@@ -211,7 +225,14 @@ fn bad_json_payload_returns_bad_json() {
     input.extend_from_slice(body);
     let mut stdin = Cursor::new(input);
     let mut stdout: Vec<u8> = Vec::new();
-    vigil_native_host::run(&mut stdin, &mut stdout, &ledger, &sid).unwrap();
+    vigil_native_host::run(
+        &mut stdin,
+        &mut stdout,
+        &ledger,
+        &sid,
+        &vigil_native_host::DisabledMlProbe,
+    )
+    .unwrap();
     let frames = decode_responses(&stdout);
     assert_eq!(frames.len(), 1);
     let ef: BrowserErrorFrame = serde_json::from_value(frames[0].clone()).unwrap();
@@ -238,7 +259,14 @@ fn multi_frame_sequence_roundtrip() {
     input.extend(encode_request(&req3));
     let mut stdin = Cursor::new(input);
     let mut stdout: Vec<u8> = Vec::new();
-    vigil_native_host::run(&mut stdin, &mut stdout, &ledger, &sid).unwrap();
+    vigil_native_host::run(
+        &mut stdin,
+        &mut stdout,
+        &ledger,
+        &sid,
+        &vigil_native_host::DisabledMlProbe,
+    )
+    .unwrap();
     let frames = decode_responses(&stdout);
     assert_eq!(frames.len(), 3);
     let r1: BrowserCheckResponse = serde_json::from_value(frames[0].clone()).unwrap();

--- a/apps/vigil-hub-cli/Cargo.toml
+++ b/apps/vigil-hub-cli/Cargo.toml
@@ -68,20 +68,16 @@ toml_edit = "0.25"
 vigil-desktop = { path = "../desktop", default-features = false }
 vigil-runner = { path = "../../crates/vigil-runner" }
 vigil-ui-protocol = { path = "../../crates/vigil-ui-protocol" }
-# P2.3 daemon IPC(ADR 0024):跨平台本地 socket(UDS / Windows named pipe)的瘦客户端 +
-# 服务端 transport。用成熟 crate 而非手写 named-pipe FFI(安全边界,减少 unsafe 出错面);
-# R1 peer-credential + R2 读截止 在其 raw fd/handle 上另加(见 daemon/transport.rs)。
+# P2.3 daemon IPC(ADR 0024):协议 + 瘦客户端(R1 peer-credential / R2 读截止 / daemon.json
+# 契约)已抽至 vigil-daemon-ipc(供 hook 与 vigil-native-host 共用);本 crate 保留服务端
+# (`daemon::server` accept 循环需 interprocess Listener 类型,与 ipc crate 同版本 "2" 同源解析)。
+vigil-daemon-ipc = { path = "../../crates/vigil-daemon-ipc" }
 interprocess = "2"
 
 # CLI/帮助文本国际化(i18n):按系统语言(Windows 用户默认 UI 语言 / Unix LANG 等)选择
 # 中/英输出。workspace `unsafe_code = "forbid"` 禁止自写 Windows `GetUserDefaultLocaleName`
 # FFI;sys-locale 封装各平台 locale 探测(纯封装,MIT OR Apache-2.0,跨平台)。
 sys-locale = "0.3"
-
-# macOS daemon R1:`peer_creds().pid()` 在 macOS UDS 恒 None(无 SO_PEERCRED),euid 可用。
-# 用 rustix(安全封装,本 crate 仍 forbid unsafe)取自身 euid 与对端比对。版本对齐 lock 既有 1.x。
-[target.'cfg(target_os = "macos")'.dependencies]
-rustix = { version = "1", features = ["process"] }
 
 [dev-dependencies]
 # CLI 级集成测试用(β R1 MUST-FIX 4):InMemorySecretStore 注入 + mock AS

--- a/apps/vigil-hub-cli/src/daemon/lifecycle.rs
+++ b/apps/vigil-hub-cli/src/daemon/lifecycle.rs
@@ -13,8 +13,8 @@ use std::time::Duration;
 
 use super::client::{daemon_info_path, read_daemon_info, write_daemon_info, DaemonInfo};
 use super::protocol::{Request, Response, PROTOCOL_VERSION};
-use super::server::DaemonCaps;
-use super::transport::{bind, default_socket_name, query_daemon, serve};
+use super::server::{serve, DaemonCaps};
+use super::transport::{bind, default_socket_name, query_daemon};
 use crate::i18n::Lang;
 
 /// 按语言取静态文案(中 / 英并排)。用户直面命令(`daemon start|status|stop`),输出按系统语言本地化。

--- a/apps/vigil-hub-cli/src/daemon/mod.rs
+++ b/apps/vigil-hub-cli/src/daemon/mod.rs
@@ -14,7 +14,8 @@
 //! - [`server`]:服务端**单连接处理逻辑**(`handle_connection`,可单测)+ fail-closed 握手 +
 //!   model-less dispatch。**零 ort / 零平台**。
 //! - [`transport`]:`interprocess` 本地 socket + **R1** peer-credential + **R2** 总读截止 +
-//!   单实例(bind 失败守门)。**零 ort**;`query_daemon`(hook 端)+ `bind`/`serve`(daemon 端)。
+//!   单实例(bind 失败守门)。**零 ort**;`query_daemon`(客户端)+ `bind`(daemon 端);
+//!   accept 循环 `serve` 在 [`server`](需 `DaemonCaps`)。
 //!
 //! **已落**:ort 暖载层(`lifecycle::run_start` 暖载 PII scanner + 注入分类器 + R3 绑定自有 canonical
 //! ledger;dispatch 出真 findings / 软信号 risk bump)、`daemon start|stop|status` 子命令、hook 接
@@ -26,8 +27,11 @@
 //! daemon = **无状态推理 oracle**(D2:返 findings,merge/decision 全留 hook)→ 缺/超时/冒充/
 //! 畸形响应 **只抑制 ML recall**,动不了硬指纹 deny 与 PostToolUse withhold → **永不 fail-open**。
 
-pub mod client;
+// protocol / client / transport / wire 已抽至独立 crate `vigil-daemon-ipc`(纯移动,
+// 逻辑与安全不变量不变),使 daemon 瘦客户端不再绑定 Hub CLI 依赖图(首个受益方:
+// vigil-native-host)。此处 re-export 保持 `crate::daemon::*` 既有路径,消费侧零改动;
+// 服务端(handle_connection/DaemonCaps/serve,须持模型与 ledger)与生命周期编排留本地。
+pub use vigil_daemon_ipc::{client, protocol, transport, wire};
+
 pub mod lifecycle;
-pub mod protocol;
 pub mod server;
-pub mod transport;

--- a/apps/vigil-hub-cli/src/daemon/server.rs
+++ b/apps/vigil-hub-cli/src/daemon/server.rs
@@ -138,6 +138,20 @@ pub fn handle_connection<S: Read + Write>(stream: &mut S, caps: &DaemonCaps) {
     }
 }
 
+/// server accept 循环:每连接 spawn [`handle_connection`](thread-per-conn,简化;bounded 后续)。
+/// 原居 transport 层;随 transport 抽至 `vigil-daemon-ipc`(纯客户端)后归位服务端本模块。
+pub fn serve(listener: interprocess::local_socket::Listener, caps: DaemonCaps) {
+    use interprocess::local_socket::prelude::*;
+    for conn in listener.incoming() {
+        let mut stream = match conn {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let caps = caps.clone();
+        std::thread::spawn(move || handle_connection(&mut stream, &caps));
+    }
+}
+
 /// 请求 → 响应分发。
 ///
 /// `RedactScan`:有暖载 scanner → 真 `scan` → [`WireFinding`];无 scanner(model-less) → 空 findings
@@ -466,5 +480,99 @@ mod tests {
         let mut s = MockStream::new(Vec::new());
         handle_connection(&mut s, &caps());
         assert!(s.outbound.is_empty(), "无握手 → 不回任何东西,不 panic");
+    }
+
+    // ── 真 socket e2e(bind + serve + R1 + 握手;原居 transport.rs tests,随 serve 归位)──
+
+    fn unique_sock(tag: &str) -> String {
+        // 唯一名(进程 id + tag):防与真 daemon / 并行测试碰撞;**不碰真 daemon.json**。
+        // macOS 用 GenericFilePath(文件路径)→ 落 temp 绝对路径,避免污染 CWD。
+        #[cfg(target_os = "macos")]
+        {
+            std::env::temp_dir()
+                .join(format!("vigil-itest-{}-{}.sock", tag, std::process::id()))
+                .to_string_lossy()
+                .into_owned()
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            format!("vigil-itest-{}-{}.sock", tag, std::process::id())
+        }
+    }
+
+    fn spawn_daemon(sock: &str, token: &str, up: u64) {
+        let caps = DaemonCaps {
+            token: token.to_string(),
+            scanner: None,
+            ledger: None,
+            #[cfg(feature = "ort")]
+            injection: None,
+            pii_loaded: false,
+            inj_loaded: false,
+            started: std::time::Instant::now() - std::time::Duration::from_secs(up),
+        };
+        let listener = crate::daemon::transport::bind(sock).unwrap();
+        std::thread::spawn(move || super::serve(listener, caps));
+    }
+
+    /// 同进程 daemon 的 DaemonInfo:`pid = 本进程` → R1 匹配(对端 server pid 即本进程)。
+    fn info_for(sock: &str, token: &str) -> crate::daemon::client::DaemonInfo {
+        crate::daemon::client::DaemonInfo {
+            pid: std::process::id(),
+            socket_path: sock.to_string(),
+            token: token.to_string(),
+            protocol_version: PROTOCOL_VERSION,
+            pii_loaded: false,
+            inj_loaded: false,
+        }
+    }
+
+    #[test]
+    fn end_to_end_query_with_real_socket_r1_and_exchange() {
+        // 真 socket 全路径:connect + **R1**(同进程 server pid 匹配)+ 握手 + Status dispatch。
+        let sock = unique_sock("e2e");
+        spawn_daemon(&sock, "itest-token", 1);
+        let resp =
+            crate::daemon::transport::query_with(&info_for(&sock, "itest-token"), &Request::Status);
+        assert!(
+            matches!(resp, Some(Response::Status { uptime_secs: 1, .. })),
+            "真 socket 全路径 Status 往返应成功,got {resp:?}"
+        );
+    }
+
+    #[test]
+    fn r1_accepts_same_process_server_pid() {
+        // R1:对端(同进程 server)pid == expected → query_with 返 Some。
+        let sock = unique_sock("r1ok");
+        spawn_daemon(&sock, "t", 0);
+        let resp = crate::daemon::transport::query_with(&info_for(&sock, "t"), &Request::Status);
+        assert!(resp.is_some(), "R1:对端 server pid == 本进程 pid → 通过");
+    }
+
+    // pid 版 R1 仅非 macOS;macOS 走 euid(同进程必同 euid,无法用 pid 构造拒绝用例)。
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn r1_rejects_wrong_expected_pid() {
+        // R1:对端真实 pid = 本进程;expected 设不可能值 → fail-closed None(防冒充 daemon)。
+        let sock = unique_sock("r1bad");
+        spawn_daemon(&sock, "t", 0);
+        let mut info = info_for(&sock, "t");
+        info.pid = u32::MAX;
+        assert!(
+            crate::daemon::transport::query_with(&info, &Request::Status).is_none(),
+            "R1:对端 pid != expected_pid → None(防冒充)"
+        );
+    }
+
+    #[test]
+    fn handshake_bad_token_over_real_socket_rejected() {
+        // R1 通过(同进程)但 token 错 → 服务端回 Error → query_with 返 None(fail-closed)。
+        let sock = unique_sock("badtok");
+        spawn_daemon(&sock, "right-token", 0);
+        assert!(
+            crate::daemon::transport::query_with(&info_for(&sock, "wrong-token"), &Request::Status)
+                .is_none(),
+            "错 token → 服务端 Error → None"
+        );
     }
 }

--- a/apps/vigil-hub-cli/src/hook.rs
+++ b/apps/vigil-hub-cli/src/hook.rs
@@ -97,8 +97,9 @@ use vigil_lease::{LeaseBroker, MintRequest, ResolveContext, SecretStore, SecretV
 use vigil_types::{ApprovalStatus, DecisionKind, DecisionRecord, EffectVector, InjectionMethod};
 
 use crate::command_guard;
-use crate::daemon::protocol::{Request, Response, ScanKind, WireFinding};
+use crate::daemon::protocol::{Request, Response, ScanKind};
 use crate::daemon::transport;
+use crate::daemon::wire::{apply_wire_spans, cap_to_char_boundary};
 use crate::posture::{self, PostureAction, RiskClass};
 use crate::serve::EngineMode;
 
@@ -2091,7 +2092,12 @@ impl MlScrub {
                     return seg.to_string();
                 }
                 // span 相对 capped 前缀;仅在该前缀范围内 apply(suffix 无 ML,硬指纹已兜)。
-                apply_wire_spans(seg, capped.len(), &findings, protected, report)
+                let (out, hits) = apply_wire_spans(seg, capped.len(), &findings, protected);
+                if hits > 0 {
+                    report.ml_hits += hits;
+                    report.changed = true;
+                }
+                out
             }
             // daemon 不可用 / Error / 超时 / 畸形 → 降级 + **give_up**(首次失败即认定本 response
             // daemon 不可用,余下叶子不再查;封死 N×deadline 累积楔死。硬指纹底座已兜,非 fail-open)。
@@ -2102,143 +2108,6 @@ impl MlScrub {
             }
         }
     }
-}
-
-/// 字节 `cap` 处向下取整到 UTF-8 char boundary,返回 `&s[..n]`(`n ≤ cap`),避免切碎多字节字符。
-fn cap_to_char_boundary(s: &str, cap: usize) -> &str {
-    if s.len() <= cap {
-        return s;
-    }
-    let mut n = cap;
-    while n > 0 && !s.is_char_boundary(n) {
-        n -= 1;
-    }
-    &s[..n]
-}
-
-/// label 来自 daemon [`WireFinding`](应为 `PrivacyLabel` 闭集);防御性 sanitize:仅留 ascii 字母
-/// 数字 + 下划线、截断 ≤32、空则 `pii`。**绝不**把 daemon 响应原样嵌进返模型的输出
-/// (untrusted-input-not-in-errors 同理:即便 R1 已验对端,响应内容仍按不可信处理)。
-fn safe_label(label: &str) -> String {
-    let cleaned: String = label
-        .chars()
-        .filter(|c| c.is_ascii_alphanumeric() || *c == '_')
-        .take(32)
-        .collect();
-    if cleaned.is_empty() {
-        "pii".to_string()
-    } else {
-        cleaned
-    }
-}
-
-/// 把 daemon 的 [`WireFinding`] span(相对前 `scanned_len` 字节前缀)应用到 `seg`,命中处替换为
-/// `[REDACTED <label>]`。空/逆序、越出扫描前缀、非 char-boundary 的 span 先剔除(防 panic + 防御),
-/// **并集合并**成互不重叠区间,再减去 `protected`(真实占位符区间)后右→左替换露出的子区间。
-///
-/// **为何并集而非"重叠跳过"(VIGIL-SEC-OVERLAP)**:daemon 可能对相邻实体吐嵌套/重叠 span。旧实现
-/// 右→左 + "与已处理区间重叠则跳过"会漏掉外层 span 独有的 PII 前缀 —— 例如 `[3,7)` 与已处理 `[5,9)`
-/// 重叠被整条跳过,其独有的 `[3,5)` 明文 PII **残留泄漏**;且嵌套场景产生破碎嵌套占位符。并集合并
-/// 保证每个被任一 span 命中的字节都落入某替换区间。
-///
-/// **受保护区减法(VIGIL-SEC-OVERLAP-PH,已修)**:daemon 在已脱敏(含 `[REDACTED …]` 占位符)的
-/// 文本上扫描,其 ML span 可 over-capture 延伸进占位符。`protected` 携带脱敏流程**自产**的真实占位符
-/// 字节区间;对每个 ML 并集区间减去 `protected`,只替换露在占位符之外的子区间 → 不再切碎成破碎嵌套
-/// (旧 macOS 实测 `[[REDACTED address]DACTED email]`)。**安全**:`protected` 不靠正则识别 `[REDACTED …]`
-/// 形态(工具输出可伪造假占位符把 PII 包进去),只信脱敏流程自产区间 → 伪造的占位符不在 `protected`、
-/// 其包裹的真 PII 仍被替换。`report.ml_hits` 计减法后实际替换的子区间数。
-fn apply_wire_spans(
-    seg: &str,
-    scanned_len: usize,
-    findings: &[WireFinding],
-    protected: &[(usize, usize)],
-    report: &mut RedactReport,
-) -> String {
-    // 剔除非法 span(空/逆序、越出扫描前缀、非 char-boundary),保留 (start, end, label)。
-    let mut spans: Vec<(usize, usize, &str)> = findings
-        .iter()
-        .filter(|f| {
-            f.start < f.end
-                && f.end <= scanned_len
-                && seg.is_char_boundary(f.start)
-                && seg.is_char_boundary(f.end)
-        })
-        .map(|f| (f.start, f.end, f.label.as_str()))
-        .collect();
-    if spans.is_empty() {
-        return seg.to_string();
-    }
-    // start 升序、同 start 时 end 降序(长 span 作并集代表名)。
-    spans.sort_by(|a, b| a.0.cmp(&b.0).then(b.1.cmp(&a.1)));
-    // 并集合并成互不重叠区间(代表 label 取并集内 start 最小→最长者)。
-    let mut merged: Vec<(usize, usize, &str)> = Vec::with_capacity(spans.len());
-    for (start, end, label) in spans {
-        match merged.last_mut() {
-            Some(last) if start < last.1 => {
-                if end > last.1 {
-                    last.1 = end;
-                }
-            }
-            _ => merged.push((start, end, label)),
-        }
-    }
-    // 受保护区减法(VIGIL-SEC-OVERLAP-PH):从每个 ML 并集区间减去真实占位符区间,只替换**露在占位符
-    // 之外**的子区间。安全不变量:① 任何不在 protected 内、且被某 ML span 命中的字节,必落入某个被替换
-    // 子区间(真 PII 不漏);② protected 内字节永不被 replace_range 触碰(已脱敏占位符不切碎)。
-    let mut final_spans: Vec<(usize, usize, &str)> = Vec::new();
-    for &(start, end, label) in &merged {
-        for (ss, se) in subtract_ranges(start, end, protected) {
-            final_spans.push((ss, se, label));
-        }
-    }
-    // final_spans 全局升序(merged 升序且互不重叠 + 每个减法子区间升序)→ 右→左替换不漂移 index。
-    let mut out = seg.to_string();
-    for &(start, end, label) in final_spans.iter().rev() {
-        // 锁定 char-boundary 不变量:子区间端点来自 ML span(已过 is_char_boundary 滤)与 protected
-        // 占位符端点(均为 push_str 处 len() 采样 → 必落 char 边界),故 replace_range 不会切碎多字节
-        // 字符。debug_assert 防未来 protected 改由偏移算术得出(可能落 mid-char)而静默重引 panic 风险。
-        debug_assert!(
-            seg.is_char_boundary(start) && seg.is_char_boundary(end),
-            "apply_wire_spans 子区间非 char-boundary: ({start},{end}) in {seg:?}"
-        );
-        out.replace_range(start..end, &format!("[REDACTED {}]", safe_label(label)));
-        report.ml_hits += 1;
-        report.changed = true;
-    }
-    out
-}
-
-/// 返回 `[start, end)` 减去 `protected` 中所有区间后剩余的子区间(升序、互不重叠)。
-/// `protected` 为脱敏流程自产的真实占位符区间(可乱序/重叠,内部先 clamp 到 `[start,end)` 再规整)。
-/// 用于 [`apply_wire_spans`] 把 ML 并集区间裁掉与已脱敏占位符重叠的部分(VIGIL-SEC-OVERLAP-PH)。
-fn subtract_ranges(start: usize, end: usize, protected: &[(usize, usize)]) -> Vec<(usize, usize)> {
-    if start >= end {
-        return Vec::new();
-    }
-    // 取与 [start,end) 相交的受保护区间(clamp 到窗口内),按 start 升序。
-    let mut blocks: Vec<(usize, usize)> = protected
-        .iter()
-        .map(|&(a, b)| (a.max(start), b.min(end)))
-        .filter(|&(a, b)| a < b)
-        .collect();
-    if blocks.is_empty() {
-        return vec![(start, end)];
-    }
-    blocks.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
-    let mut out = Vec::new();
-    let mut cursor = start;
-    for (a, b) in blocks {
-        if a > cursor {
-            out.push((cursor, a)); // 占位符之前露出的段
-        }
-        if b > cursor {
-            cursor = b; // 跳过占位符(含重叠部分),游标前移到其右界
-        }
-    }
-    if cursor < end {
-        out.push((cursor, end)); // 末尾露出段
-    }
-    out
 }
 
 /// 单串自检:`s` 是否仍含某个 resolved 真值(逆向替换遗漏)。空真值不计。
@@ -2542,183 +2411,7 @@ mod tests {
     use super::*;
     use crate::posture::PostureProfile;
 
-    // ── ADR 0024 hook-ML PII 增强:纯 helper 单测(daemon 查询路径走 e2e / P2.5)──
-
-    fn wf(label: &str, start: usize, end: usize) -> WireFinding {
-        WireFinding {
-            label: label.to_string(),
-            start,
-            end,
-        }
-    }
-
-    #[test]
-    fn apply_wire_spans_single_span_redacts_with_label() {
-        let mut report = RedactReport::default();
-        let out = apply_wire_spans(
-            "alice@example.com here",
-            22,
-            &[wf("email", 0, 17)],
-            &[],
-            &mut report,
-        );
-        assert_eq!(out, "[REDACTED email] here");
-        assert_eq!(report.ml_hits, 1);
-        assert!(report.changed);
-    }
-
-    #[test]
-    fn apply_wire_spans_multiple_spans_right_to_left_keep_offsets() {
-        // 两个 span 降序应用,不挪未处理前缀 offset。
-        let seg = "a alice@x.io b bob@y.io c";
-        let mut report = RedactReport::default();
-        let out = apply_wire_spans(
-            seg,
-            seg.len(),
-            &[wf("email", 2, 12), wf("email", 15, 23)],
-            &[],
-            &mut report,
-        );
-        assert_eq!(out, "a [REDACTED email] b [REDACTED email] c");
-        assert_eq!(report.ml_hits, 2);
-    }
-
-    #[test]
-    fn apply_wire_spans_out_of_bounds_and_beyond_scanned_skipped() {
-        let seg = "hello world";
-        let mut report = RedactReport::default();
-        // end > scanned_len(5) / end > seg.len() / start>=end(逆序)→ 全跳过。
-        let out = apply_wire_spans(
-            seg,
-            5,
-            &[wf("x", 0, 9), wf("y", 100, 200), wf("z", 4, 2)],
-            &[],
-            &mut report,
-        );
-        assert_eq!(out, "hello world");
-        assert_eq!(report.ml_hits, 0);
-        assert!(!report.changed);
-    }
-
-    #[test]
-    fn apply_wire_spans_non_char_boundary_skipped() {
-        // "héllo":é(U+00E9)= 2 字节占 [1,3);byte 2 落 é 中间 → 非 boundary → 跳过(防 panic)。
-        let seg = "héllo";
-        let mut report = RedactReport::default();
-        let out = apply_wire_spans(seg, seg.len(), &[wf("x", 0, 2)], &[], &mut report);
-        assert_eq!(out, seg);
-        assert_eq!(report.ml_hits, 0);
-    }
-
-    #[test]
-    fn apply_wire_spans_overlap_union_merged_no_leak() {
-        // 重叠 span 并集合并(VIGIL-SEC-OVERLAP):[3,7) 与 [5,9) → 并集 [3,9),全覆盖。
-        // 旧"重叠跳过"实现会留下 [3,7) 独有的 "de"(残留泄漏 "abcde[REDACTED a]j");并集后无残留。
-        let seg = "abcdefghij";
-        let mut report = RedactReport::default();
-        let out = apply_wire_spans(
-            seg,
-            seg.len(),
-            &[wf("a", 5, 9), wf("b", 3, 7)],
-            &[],
-            &mut report,
-        );
-        assert_eq!(out, "abc[REDACTED b]j", "重叠应并集为单一占位符,覆盖 [3,9)");
-        assert!(!out.contains("de"), "[3,7) 独有前缀 de 不得残留:{out}");
-        assert_eq!(report.ml_hits, 1);
-    }
-
-    #[test]
-    fn apply_wire_spans_nested_no_leak() {
-        // 嵌套 span:外 [0,40] 套内 [15,40](内层长)。旧右→左 + 重叠跳过会跳过外层 →
-        // 外层前缀 "Jonathan Whitfi" 明文泄漏("Jonathan Whitfi[REDACTED person]")。
-        let seg = "Jonathan Whitfield Robert Smith Junior!!"; // 40 字节(ASCII)
-        let mut report = RedactReport::default();
-        let out = apply_wire_spans(
-            seg,
-            seg.len(),
-            &[wf("person", 0, 40), wf("person", 15, 40)],
-            &[],
-            &mut report,
-        );
-        assert!(!out.contains("Jonathan"), "外层 PII 前缀泄漏:{out}");
-        assert_eq!(out, "[REDACTED person]", "嵌套应并集为单一占位符");
-        assert_eq!(report.ml_hits, 1);
-    }
-
-    #[test]
-    fn apply_wire_spans_subtracts_protected_no_split() {
-        // VIGIL-SEC-OVERLAP-PH:ML span over-capture 延伸进真实占位符 → 减法只替换露出部分,占位符不切碎。
-        let seg = "x [REDACTED email] y"; // 占位符 "[REDACTED email]" 在 [2,18)
-        let mut report = RedactReport::default();
-        let out = apply_wire_spans(
-            seg,
-            seg.len(),
-            &[wf("address", 0, 10)],
-            &[(2, 18)],
-            &mut report,
-        );
-        assert_eq!(out, "[REDACTED address][REDACTED email] y");
-        assert!(out.contains("[REDACTED email]"), "真实占位符不得被切碎");
-        assert_eq!(report.ml_hits, 1);
-    }
-
-    #[test]
-    fn apply_wire_spans_span_fully_in_protected_dropped() {
-        // ML span 完全落在真实占位符内 → 减法后空 → 不替换,占位符原样、无 hit、不置 changed。
-        let seg = "x [REDACTED email] y";
-        let mut report = RedactReport::default();
-        let out = apply_wire_spans(seg, seg.len(), &[wf("pii", 4, 12)], &[(2, 18)], &mut report);
-        assert_eq!(out, seg);
-        assert_eq!(report.ml_hits, 0);
-        assert!(!report.changed);
-    }
-
-    #[test]
-    fn apply_wire_spans_span_spanning_protected_splits() {
-        // ML span 跨越整个占位符 → 减法切成左右两段各替换,占位符夹中间完整。
-        let seg = "aa [REDACTED email] bb"; // 占位符 [3,19)
-        let mut report = RedactReport::default();
-        let out = apply_wire_spans(seg, seg.len(), &[wf("p", 0, 22)], &[(3, 19)], &mut report);
-        assert_eq!(out, "[REDACTED p][REDACTED email][REDACTED p]");
-        assert_eq!(report.ml_hits, 2);
-    }
-
-    #[test]
-    fn apply_wire_spans_forged_placeholder_not_protected() {
-        // 工具输出伪造 `[REDACTED x]` 包裹真 PII。伪造占位符**不在** protected(只含脱敏自产区间)→
-        // ML span 命中其中真 PII 仍被替换,伪造无法让 ML 跳过(绕过脱敏)。
-        let seg = "[REDACTED x]alice@evil.com[REDACTED y]"; // 真 PII alice@evil.com 在 [12,26)
-        let mut report = RedactReport::default();
-        let out = apply_wire_spans(seg, seg.len(), &[wf("email", 12, 26)], &[], &mut report);
-        assert!(
-            !out.contains("alice@evil.com"),
-            "伪造占位符不得保护其包裹的真 PII"
-        );
-        assert!(out.contains("[REDACTED email]"));
-        assert_eq!(report.ml_hits, 1);
-    }
-
-    #[test]
-    fn subtract_ranges_cases() {
-        let empty = Vec::<(usize, usize)>::new();
-        assert_eq!(subtract_ranges(0, 10, &[]), vec![(0, 10)]); // 无保护 → 原区间
-        assert_eq!(subtract_ranges(0, 10, &[(2, 5)]), vec![(0, 2), (5, 10)]); // 中间挖洞
-        assert_eq!(subtract_ranges(0, 10, &[(0, 10)]), empty); // 全保护 → 空
-        assert_eq!(subtract_ranges(0, 10, &[(0, 4)]), vec![(4, 10)]); // 头部
-        assert_eq!(subtract_ranges(0, 10, &[(6, 10)]), vec![(0, 6)]); // 尾部
-        assert_eq!(
-            subtract_ranges(0, 10, &[(3, 5), (6, 8)]),
-            vec![(0, 3), (5, 6), (8, 10)]
-        ); // 多洞
-        assert_eq!(
-            subtract_ranges(0, 10, &[(2, 6), (4, 8)]),
-            vec![(0, 2), (8, 10)]
-        ); // 重叠 block
-        assert_eq!(subtract_ranges(0, 10, &[(5, 5), (8, 4)]), vec![(0, 10)]); // 空/逆序 block 过滤
-        assert_eq!(subtract_ranges(5, 5, &[]), empty); // 空窗口
-        assert_eq!(subtract_ranges(2, 8, &[(0, 4), (6, 20)]), vec![(4, 6)]); // protected 越界 → clamp
-    }
+    // ── ADR 0024 hook-ML PII 增强(wire 应用原语单测已随函数移至 vigil-daemon-ipc::wire)──
 
     #[test]
     fn scrub_preserving_placeholders_reports_real_placeholder_spans() {
@@ -2740,27 +2433,6 @@ mod tests {
                 "受保护区应正好是某真实占位符: {slice}"
             );
         }
-    }
-
-    #[test]
-    fn cap_to_char_boundary_floors_to_boundary() {
-        assert_eq!(cap_to_char_boundary("hello", 100), "hello");
-        assert_eq!(cap_to_char_boundary("hello", 3), "hel");
-        // "aéb":é 占 [1,3);cap=2 落 é 中间 → 退到 1 → "a"。
-        assert_eq!(cap_to_char_boundary("aéb", 2), "a");
-    }
-
-    #[test]
-    fn safe_label_sanitizes_and_caps() {
-        assert_eq!(safe_label("email"), "email");
-        assert_eq!(safe_label("private_phone"), "private_phone");
-        // 非白名单字符(空格/分号/方括号/连字符)全过滤(防把 daemon 响应原样嵌进返模型输出)。
-        assert_eq!(safe_label("e]mail[injection"), "emailinjection");
-        assert_eq!(safe_label("a b;c"), "abc");
-        assert_eq!(safe_label("na-me"), "name");
-        assert_eq!(safe_label(""), "pii");
-        assert_eq!(safe_label("!!!"), "pii");
-        assert_eq!(safe_label(&"x".repeat(100)).len(), 32);
     }
 
     #[test]

--- a/crates/vigil-browser/src/audit.rs
+++ b/crates/vigil-browser/src/audit.rs
@@ -1,7 +1,9 @@
 //! 审计 payload 构造(ADR 0009 §D5)。
 //!
 //! 固定字段白名单:`origin / event_kind / finding_kinds / finding_count /
-//! length_bucket / action / redacted / request_id / rule_profile_version`。
+//! length_bucket / action / redacted / request_id / rule_profile_version /
+//! engine / ml_labels`(后两者:参与本次决策的引擎标识 + ML 命中标签,均为
+//! 类别级 metadata,不含任何 span 文本)。
 //!
 //! **严禁**:原文 / redacted_text / 全量文本 sha256。新增字段须同步更新
 //! `audit_payload_schema_whitelist` 测试。
@@ -35,6 +37,9 @@ pub struct BrowserAuditMeta<'a> {
     pub request_id: &'a str,
     /// 原文字节长度 —— `audit_payload` 只用桶化值
     pub text_len: usize,
+    /// 参与本次决策的引擎:`"hardfp"`(纯硬指纹;daemon 缺席/禁用/Block 短路)或
+    /// `"hardfp+ml"`(daemon ML 扫描成功参与,含"扫过但无命中")。由 host 层填。
+    pub engine: &'static str,
 }
 
 /// 给定 `meta` + `response` 组装审计 payload(仅 metadata,**严格不含** raw text / redacted_text)。
@@ -60,6 +65,8 @@ pub fn build_audit_payload(meta: &BrowserAuditMeta<'_>, response: &BrowserCheckR
         "redacted": matches!(response.action, BrowserAction::Redact),
         "request_id": meta.request_id,
         "rule_profile_version": RULE_PROFILE_VERSION,
+        "engine": meta.engine,
+        "ml_labels": response.ml_labels,
     })
 }
 
@@ -93,6 +100,7 @@ mod tests {
             event_kind: BrowserEventKind::Paste,
             request_id: "rid-1",
             text_len: 42,
+            engine: "hardfp",
         }
     }
 
@@ -105,6 +113,7 @@ mod tests {
                 BrowserAction::Redact => Some("[REDACTED x]".into()),
                 _ => None,
             },
+            ml_labels: Vec::new(),
         }
     }
 
@@ -127,6 +136,8 @@ mod tests {
             "redacted",
             "request_id",
             "rule_profile_version",
+            "engine",
+            "ml_labels",
         ]
         .into_iter()
         .collect();
@@ -154,6 +165,7 @@ mod tests {
             event_kind: BrowserEventKind::Input,
             request_id: "rid-input",
             text_len: 42,
+            engine: "hardfp",
         };
         let resp = mk_resp(BrowserAction::Redact, vec![FindingKind::EnvAssignment]);
         let payload = build_audit_payload(&meta, &resp);
@@ -174,12 +186,14 @@ mod tests {
             event_kind: BrowserEventKind::Paste,
             request_id: "rid-1",
             text_len: SENTINEL.len(),
+            engine: "hardfp+ml",
         };
         let resp = BrowserCheckResponse {
             request_id: "rid-1".into(),
             action: BrowserAction::Redact,
             findings: vec![FindingKind::GithubToken],
             redacted_text: Some("[REDACTED github_token]".into()),
+            ml_labels: vec!["private_email".into()],
         };
         let p = build_audit_payload(&meta, &resp);
         let s = serde_json::to_string(&p).unwrap();

--- a/crates/vigil-browser/src/classifier.rs
+++ b/crates/vigil-browser/src/classifier.rs
@@ -94,6 +94,8 @@ pub fn classify(request: &BrowserCheckRequest) -> ClassifyOutcome {
         action,
         findings: kinds,
         redacted_text,
+        // classify 是纯硬指纹层;ML 标签由 host 层(native-host ml_augment)按 daemon 可用性追加。
+        ml_labels: Vec::new(),
     })
 }
 

--- a/crates/vigil-browser/src/protocol.rs
+++ b/crates/vigil-browser/src/protocol.rs
@@ -131,6 +131,12 @@ pub struct BrowserCheckResponse {
     /// action=Redact 时为 Some(已经过 scrub + 硬指纹 re-scan 兜底,§I-9.6)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub redacted_text: Option<String>,
+    /// ML(daemon)命中的 PII 标签(经 sanitize 的闭集字符串,如 `private_email`;去重升序)。
+    /// **仅展示层增强**:不参与扩展 tier / action 决策(决策仍由 `findings`/`action` 承载,
+    /// ML 只能把 Allow 收紧为 Redact,由 host 侧完成)。旧扩展忽略未知字段;缺省反序列化为
+    /// 空(`default`,向后兼容 hardfp-only host 的响应)。
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ml_labels: Vec<String>,
 }
 
 /// Core 层错误码(Host 在 framing 层也会用相同 error schema 返扩展)。

--- a/crates/vigil-daemon-ipc/Cargo.toml
+++ b/crates/vigil-daemon-ipc/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "vigil-daemon-ipc"
+publish = false  # 非 SDK publish set(内部 IPC 契约)— 不上 crates.io;cargo-deny path-dep wildcard 守门
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+# daemon IPC(ADR 0024):跨平台本地 socket(UDS / Windows named pipe)。用成熟 crate 而非
+# 手写 named-pipe FFI(安全边界,减少 unsafe 出错面);R1 peer-credential + R2 读截止在其
+# raw fd/handle 上另加(见 transport.rs)。版本与 vigil-hub-cli 服务端同源("2"),cargo
+# 统一解析为同一实例 —— `bind` 返回的 Listener 类型跨 crate 兼容。
+interprocess = "2"
+# daemon.json 规范路径(<data_local>/Vigil/daemon.json)定位。
+dirs = "6"
+
+# macOS daemon R1:`peer_creds().pid()` 在 macOS UDS 恒 None(无 SO_PEERCRED),euid 可用。
+# 用 rustix(安全封装,本 crate 仍 forbid unsafe)取自身 euid 与对端比对。版本对齐 lock 既有 1.x。
+[target.'cfg(target_os = "macos")'.dependencies]
+rustix = { version = "1", features = ["process"] }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/vigil-daemon-ipc/src/client.rs
+++ b/crates/vigil-daemon-ipc/src/client.rs
@@ -5,7 +5,7 @@
 //! - [`exchange`]:握手 → 校验 HelloOk 版本 → 请求 → 响应的**序列逻辑**;**任何** IO 错误 /
 //!   版本不符 / 非 HelloOk / `Error` 响应 → `None`(调用方据此降级硬指纹,永不 fail-open)。
 //!
-//! 平台 + 安全层在 [`super::transport`] 实现(`interprocess` 跨平台本地 socket):`connect_and_verify`
+//! 平台 + 安全层在 [`crate::transport`] 实现(`interprocess` 跨平台本地 socket):`connect_and_verify`
 //! 做 **R1** peer-credential 校验(对端 server pid == `daemon.json.pid`,经 `peer_creds`)、`query_daemon`
 //! 用工作线程 + `recv_timeout` 做 **R2** 总读截止。公共 `query_daemon` = `read_daemon_info` →
 //! `connect_and_verify`(R1)→ [`exchange`],全程 fail-closed。
@@ -15,7 +15,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use super::protocol::{read_frame, write_frame, Hello, Request, Response, PROTOCOL_VERSION};
+use crate::protocol::{read_frame, write_frame, Hello, Request, Response, PROTOCOL_VERSION};
 
 /// `daemon.json` 契约(daemon 启动期原子写,`0600`;hook 同用户可读)。
 ///
@@ -94,8 +94,9 @@ pub fn write_daemon_info(path: &Path, info: &DaemonInfo) -> std::io::Result<()> 
 /// **fail-closed**:写/读 IO 错误、HelloOk 版本不符、首响应非 HelloOk、或任何 [`Response::Error`]
 /// → `None`。调用方(hook)收到 `None` 即用纯硬指纹结果继续(ADR 0024 D3/D7,**永不 fail-open**)。
 ///
-/// 注:R2 总读截止由**连接层**在调用前对 `stream` 设好(`set_read_timeout` + 单调预算);本函数
-/// 的 `read_frame` 阻塞受该截止约束,截止触发经 `FrameError::Io` → `None`。
+/// 注:本函数的 `read_frame` **自身可无限阻塞**(stream 未设 `set_read_timeout`);R2 总读
+/// 截止由调用方 `transport::query_daemon` 强制 —— 本函数跑在其 detached 工作线程内,主线程
+/// `recv_timeout(deadline)` 到期即弃结果返 `None`(worker 随 one-shot hook 进程退出回收)。
 pub fn exchange<S: Read + Write>(
     stream: &mut S,
     token: &str,
@@ -125,10 +126,10 @@ pub fn exchange<S: Read + Write>(
 
 #[cfg(test)]
 mod tests {
-    use super::super::protocol::{
+    use super::{exchange, read_daemon_info, DaemonInfo};
+    use crate::protocol::{
         read_frame, write_frame, Hello, Request, Response, ScanKind, WireFinding, PROTOCOL_VERSION,
     };
-    use super::{exchange, read_daemon_info, DaemonInfo};
     use std::io::{Cursor, Read, Write};
 
     /// 预载 inbound(模拟 daemon 响应)+ 捕获 outbound(client 实际写出),验序列逻辑。

--- a/crates/vigil-daemon-ipc/src/lib.rs
+++ b/crates/vigil-daemon-ipc/src/lib.rs
@@ -1,0 +1,30 @@
+//! Vigil daemon 本地 IPC —— 协议 + 瘦客户端(ADR 0024)。
+//!
+//! daemon 常驻持暖 ML 模型(PII NER + 注入分类器),各**瘦客户端**经本地 socket
+//! (UDS / Windows named pipe)查询;任何异常(缺席/超时/版本不符/畸形帧)一律
+//! fail-closed 降级为「无 ML」,由调用方的硬指纹底座兜底,**永不 fail-open**。
+//!
+//! 本 crate 从 `vigil-hub-cli` 的 `daemon::{protocol,client,transport}` 抽出(纯移动,
+//! 逻辑与安全不变量不变),使 daemon 客户端不再绑定 Hub CLI 的完整依赖图 —— 首个受益方
+//! 是 `vigil-native-host`(浏览器扩展的本机进程,Chrome 常驻,须保持轻量)。
+//!
+//! # 模块
+//! - [`protocol`]:线协议(serde 类型 + `u32 LE` 长度前缀帧)。零 ort。
+//! - [`client`]:`daemon.json` 发现契约(读/写)+ fail-closed 握手/请求序列。
+//! - [`transport`]:`interprocess` 本地 socket + **R1** peer-credential + **R2** 总读截止
+//!   + 单实例 bind 守门。服务端 accept 循环(需持模型的 `DaemonCaps`)留在 `vigil-hub-cli`。
+//! - [`wire`]:daemon [`protocol::WireFinding`] 的**安全应用原语**(span 校验/并集合并/
+//!   受保护区减法/label sanitize)—— hook 与 native-host 共用,防各自重实现漂移。
+//!
+//! # 安全不变量(ADR 0024 Revised)
+//! daemon = 无状态推理 oracle:返 findings,merge/decision 全留客户端 → 缺/冒充/畸形
+//! **只抑制 ML recall**,动不了调用方的硬指纹底线。
+
+#![deny(missing_docs)]
+#![forbid(unsafe_code)]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
+
+pub mod client;
+pub mod protocol;
+pub mod transport;
+pub mod wire;

--- a/crates/vigil-daemon-ipc/src/protocol.rs
+++ b/crates/vigil-daemon-ipc/src/protocol.rs
@@ -9,8 +9,10 @@
 //! 安全不变量(由**连接层**强制,见 ADR 0024 Revised;本模块只管编解码):
 //! - **R1**:握手后必校验对端进程凭据(socket/pipe owner == 当前用户 + server pid ==
 //!   `daemon.json.pid` + 镜像名 = `vigil-hub`);不符 → 当 daemon 不可用 → 硬指纹。
-//! - **R2**:读必须有**覆盖整段流式读的总截止**(单调 `Instant` 预算 + `set_read_timeout`),
-//!   防"握手后挤牙膏"楔死 hook;截止触发的 `WouldBlock`/`TimedOut` 经 [`FrameError::Io`] 上抛。
+//! - **R2**:读必须有**覆盖整段流式读的总截止** —— 由调用方 `transport::query_daemon` 强制:
+//!   连接+exchange 全程跑在 detached 工作线程,主线程 `mpsc::recv_timeout(deadline)` 到期
+//!   即返 `None` 降级硬指纹。流本身**不设** `set_read_timeout`;"握手后挤牙膏"至多滞留
+//!   worker 线程(one-shot hook 进程退出即被 OS 回收),绝不楔死决策路径。
 //! - **R3**:[`Request::ClassifyInjection`] **不含** 任何 ledger/路径字段 —— daemon 用启动期
 //!   绑定的 ledger,绝不打开客户端命名的文件(杜绝任意写 / 跨 session risk 投毒)。
 
@@ -125,7 +127,8 @@ pub struct WireFinding {
 /// 帧错误。**所有变体在客户端侧都收敛为"daemon 不可用 → 硬指纹"**(fail-closed)。
 #[derive(Debug, thiserror::Error)]
 pub enum FrameError {
-    /// 底层 IO(含连接层 `set_read_timeout` 触发的 `WouldBlock`/`TimedOut` —— R2 总截止)。
+    /// 底层 IO(读写失败/对端断开)。注:R2 总截止**不**经本变体 —— 它由
+    /// `transport::query_daemon` 的 `recv_timeout` 在调用方强制(worker 里的阻塞读被整体弃结果)。
     #[error("frame io: {0}")]
     Io(#[from] io::Error),
     /// 声明的 body 长度超过 [`MAX_FRAME_BYTES`](拒绝,不分配、不读 body)。
@@ -153,9 +156,10 @@ pub fn write_frame<W: Write, T: Serialize>(w: &mut W, msg: &T) -> Result<(), Fra
 
 /// 读一帧并反序列化为 `T`:先读 4 字节长度 → 校验 ≤ cap → 读满 body → 反序列化。
 ///
-/// **R2 注**:本函数用 `read_exact` 读满声明字节;真正的**总截止**(防"挤牙膏"逐字节拖死 hook)
-/// 由**连接层**在调用前用单调 `Instant` 预算设 `set_read_timeout` 强制 —— 截止触发的
-/// `WouldBlock`/`TimedOut` 经 [`FrameError::Io`] 上抛,调用方据此降级硬指纹。
+/// **R2 注**:本函数用 `read_exact` 读满声明字节,**自身可无限阻塞**(stream 未设读超时);
+/// 真正的**总截止**(防"挤牙膏"逐字节拖死 hook)由 `transport::query_daemon` 强制 ——
+/// 本函数跑在其 detached 工作线程内,主线程 `mpsc::recv_timeout(deadline)` 到期直接
+/// 弃结果返 `None` 降级硬指纹(阻塞中的 worker 随 one-shot hook 进程退出被 OS 回收)。
 pub fn read_frame<R: Read, T: DeserializeOwned>(r: &mut R) -> Result<T, FrameError> {
     let mut len_buf = [0u8; 4];
     r.read_exact(&mut len_buf)?;

--- a/crates/vigil-daemon-ipc/src/transport.rs
+++ b/crates/vigil-daemon-ipc/src/transport.rs
@@ -23,9 +23,8 @@ use interprocess::local_socket::GenericFilePath;
 use interprocess::local_socket::GenericNamespaced;
 use interprocess::local_socket::{ListenerOptions, Stream as LocalStream};
 
-use super::client::{daemon_info_path, exchange, read_daemon_info, DaemonInfo};
-use super::protocol::{Request, Response};
-use super::server::{handle_connection, DaemonCaps};
+use crate::client::{daemon_info_path, exchange, read_daemon_info, DaemonInfo};
+use crate::protocol::{Request, Response};
 
 /// 默认 daemon socket 标识。
 ///
@@ -148,18 +147,6 @@ fn check_macos_sun_path_len(socket_name: &str) -> io::Result<()> {
     Ok(())
 }
 
-/// server accept 循环:每连接 spawn [`handle_connection`](thread-per-conn,简化;bounded 后续)。
-pub fn serve(listener: interprocess::local_socket::Listener, caps: DaemonCaps) {
-    for conn in listener.incoming() {
-        let mut stream = match conn {
-            Ok(s) => s,
-            Err(_) => continue,
-        };
-        let caps = caps.clone();
-        thread::spawn(move || handle_connection(&mut stream, &caps));
-    }
-}
-
 /// **R1 peer-credential**:取连接对端(server)进程 PID,经 interprocess **原生** `peer_creds()`
 /// (其内部封装平台 unsafe `SO_PEERCRED` / `GetNamedPipeServerProcessId`;故本 crate 仍满足
 /// `forbid(unsafe_code)`,无需自有 FFI)。取不到 → `None`(上游 fail-closed)。
@@ -217,14 +204,21 @@ fn peer_is_current_user(stream: &LocalStream) -> bool {
 }
 
 /// 用一个 [`DaemonInfo`] 跑一次查询(连接其 socket_path + R1 核 pid + exchange)。fail-closed。
-fn query_with(info: &DaemonInfo, request: &Request) -> Option<Response> {
+/// 公开供已持有 `DaemonInfo` 的调用方(如服务端 crate 的真 socket 集成测试)复用;
+/// 常规客户端一律走 [`query_daemon`](R2 总截止在那层)。
+pub fn query_with(info: &DaemonInfo, request: &Request) -> Option<Response> {
     let mut stream = connect_and_verify(&info.socket_path, info.pid)?;
     exchange(&mut stream, &info.token, request)
 }
 
 /// hook 公共入口:read daemon.json → connect + R1 → exchange,**整体 R2 总截止**
 /// (工作线程 + `recv_timeout`;超时 → `None` → 硬指纹)。任何环节失败均 fail-closed。
-/// **消费方(已 live)**:hook PostToolUse ML PII 增强(engine=ml/auto)+ `vigil-hub daemon status`。
+/// worker 为 **detached**:慢(非死)daemon 下它可能仍阻塞在读上 —— one-shot 进程(hook)
+/// 决策后即退出,阻塞 worker 随进程被 OS 回收(单次调用至多滞留一个线程,无累积/无死锁)。
+/// **长驻调用方**(如 vigil-native-host)必须自带失败冷却/限流,防慢 daemon 下 worker 线程
+/// 逐次累积(见其 DaemonProbe 冷却窗口)。
+/// **消费方(已 live)**:hook PostToolUse ML PII 增强(engine=ml/auto)+ `vigil-hub daemon status`
+/// + vigil-native-host(浏览器 paste 守门 ML 增强)。
 pub fn query_daemon(request: Request, deadline: Duration) -> Option<Response> {
     let (tx, rx) = mpsc::channel();
     thread::spawn(move || {
@@ -240,105 +234,12 @@ pub fn query_daemon(request: Request, deadline: Duration) -> Option<Response> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::client::DaemonInfo;
-    use super::super::protocol::{Request, Response, PROTOCOL_VERSION};
-    use super::super::server::DaemonCaps;
     #[cfg(target_os = "macos")]
     use super::check_macos_sun_path_len;
-    use super::{
-        bind, connect_and_verify, platform_default_socket_name, query_with, resolve_socket_name,
-        serve,
-    };
+    use super::{platform_default_socket_name, resolve_socket_name};
 
-    fn unique_sock(tag: &str) -> String {
-        // 唯一名(进程 id + tag):防与真 daemon / 并行测试碰撞;**不碰真 daemon.json**。
-        // macOS 用 GenericFilePath(文件路径)→ 落 temp 绝对路径,避免污染 CWD。
-        #[cfg(target_os = "macos")]
-        {
-            std::env::temp_dir()
-                .join(format!("vigil-itest-{}-{}.sock", tag, std::process::id()))
-                .to_string_lossy()
-                .into_owned()
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
-            format!("vigil-itest-{}-{}.sock", tag, std::process::id())
-        }
-    }
-
-    fn spawn_daemon(sock: &str, token: &str, up: u64) {
-        let caps = DaemonCaps {
-            token: token.to_string(),
-            scanner: None,
-            ledger: None,
-            #[cfg(feature = "ort")]
-            injection: None,
-            pii_loaded: false,
-            inj_loaded: false,
-            started: std::time::Instant::now() - std::time::Duration::from_secs(up),
-        };
-        let listener = bind(sock).unwrap();
-        std::thread::spawn(move || serve(listener, caps));
-    }
-
-    /// 同进程 daemon 的 DaemonInfo:`pid = 本进程` → R1 匹配(对端 server pid 即本进程)。
-    fn info_for(sock: &str, token: &str) -> DaemonInfo {
-        DaemonInfo {
-            pid: std::process::id(),
-            socket_path: sock.to_string(),
-            token: token.to_string(),
-            protocol_version: PROTOCOL_VERSION,
-            pii_loaded: false,
-            inj_loaded: false,
-        }
-    }
-
-    #[test]
-    fn end_to_end_query_with_real_socket_r1_and_exchange() {
-        // 真 socket 全路径:connect + **R1**(同进程 server pid 匹配)+ 握手 + Status dispatch。
-        let sock = unique_sock("e2e");
-        spawn_daemon(&sock, "itest-token", 1);
-        let resp = query_with(&info_for(&sock, "itest-token"), &Request::Status);
-        assert!(
-            matches!(resp, Some(Response::Status { uptime_secs: 1, .. })),
-            "真 socket 全路径 Status 往返应成功,got {resp:?}"
-        );
-    }
-
-    #[test]
-    fn r1_accepts_same_process_server_pid() {
-        // R1:对端(同进程 server)pid == expected → connect_and_verify 返 Some。
-        let sock = unique_sock("r1ok");
-        spawn_daemon(&sock, "t", 0);
-        assert!(
-            connect_and_verify(&sock, std::process::id()).is_some(),
-            "R1:对端 server pid == 本进程 pid → 通过"
-        );
-    }
-
-    // pid 版 R1 仅非 macOS;macOS 走 euid(同进程必同 euid,无法用 pid 构造拒绝用例)。
-    #[cfg(not(target_os = "macos"))]
-    #[test]
-    fn r1_rejects_wrong_expected_pid() {
-        // R1:对端真实 pid = 本进程;expected 设不可能值 → fail-closed None(防冒充 daemon)。
-        let sock = unique_sock("r1bad");
-        spawn_daemon(&sock, "t", 0);
-        assert!(
-            connect_and_verify(&sock, u32::MAX).is_none(),
-            "R1:对端 pid != expected_pid → None(防冒充)"
-        );
-    }
-
-    #[test]
-    fn handshake_bad_token_over_real_socket_rejected() {
-        // R1 通过(同进程)但 token 错 → 服务端回 Error → query_with 返 None(fail-closed)。
-        let sock = unique_sock("badtok");
-        spawn_daemon(&sock, "right-token", 0);
-        assert!(
-            query_with(&info_for(&sock, "wrong-token"), &Request::Status).is_none(),
-            "错 token → 服务端 Error → None"
-        );
-    }
+    // 真 socket e2e(bind + serve + R1 + 握手)随 `serve`/`DaemonCaps` 留在 vigil-hub-cli
+    // `daemon::server` 测试(那里才有服务端 dispatch);本 crate 只测纯逻辑。
 
     #[test]
     fn explicit_socket_override_is_honored() {

--- a/crates/vigil-daemon-ipc/src/wire.rs
+++ b/crates/vigil-daemon-ipc/src/wire.rs
@@ -1,0 +1,317 @@
+//! daemon [`WireFinding`] 的安全应用原语(自 `vigil-hub-cli` hook.rs 抽出,纯移动)。
+//!
+//! 这些纯函数承载两条已修安全不变量,**任何 daemon 客户端(hook / native-host)必须共用**,
+//! 防各自重实现漂移:
+//!
+//! - **VIGIL-SEC-OVERLAP(并集合并)**:daemon 可能对相邻实体吐嵌套/重叠 span;
+//!   「重叠跳过」式实现会让外层 span 独有的 PII 前缀明文残留。[`apply_wire_spans`]
+//!   先并集合并成互不重叠区间,保证被任一 span 命中的字节都落入某替换区间。
+//! - **VIGIL-SEC-OVERLAP-PH(受保护区减法)**:daemon 在已脱敏(含 `[REDACTED …]`
+//!   占位符)文本上扫描时,ML span 可 over-capture 延伸进占位符;直接替换会把真实
+//!   占位符切碎成破碎嵌套。`protected` 携带脱敏流程**自产**的占位符字节区间,
+//!   [`apply_wire_spans`] 对每个 ML 并集区间做 [`subtract_ranges`] 减法,只替换露在
+//!   占位符之外的子区间。**安全**:不靠正则识别占位符形态(不可信文本可伪造假占位符
+//!   把 PII 包进去)——只信调用方自产区间,伪造占位符包裹的真 PII 仍被替换。
+
+use crate::protocol::WireFinding;
+
+/// 字节 `cap` 处向下取整到 UTF-8 char boundary,返回 `&s[..n]`(`n ≤ cap`),避免切碎多字节字符。
+pub fn cap_to_char_boundary(s: &str, cap: usize) -> &str {
+    if s.len() <= cap {
+        return s;
+    }
+    let mut n = cap;
+    while n > 0 && !s.is_char_boundary(n) {
+        n -= 1;
+    }
+    &s[..n]
+}
+
+/// label 来自 daemon [`WireFinding`](应为 `PrivacyLabel` 闭集);防御性 sanitize:仅留 ascii 字母
+/// 数字 + 下划线、截断 ≤32、空则 `pii`。**绝不**把 daemon 响应原样嵌进任何输出
+/// (untrusted-input-not-in-errors 同理:即便 R1 已验对端,响应内容仍按不可信处理)。
+pub fn safe_label(label: &str) -> String {
+    let cleaned: String = label
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '_')
+        .take(32)
+        .collect();
+    if cleaned.is_empty() {
+        "pii".to_string()
+    } else {
+        cleaned
+    }
+}
+
+/// 把 daemon 的 [`WireFinding`] span(相对前 `scanned_len` 字节前缀)应用到 `seg`,命中处替换为
+/// `[REDACTED <label>]`。空/逆序、越出扫描前缀、非 char-boundary 的 span 先剔除(防 panic + 防御),
+/// **并集合并**成互不重叠区间,再减去 `protected`(真实占位符区间)后右→左替换露出的子区间。
+///
+/// 返回 `(替换后文本, 实际替换的子区间数)`;计数为 0 表示无任何改写(调用方据此决定
+/// changed/审计标记)。并集/减法语义见模块级文档(VIGIL-SEC-OVERLAP / -PH)。
+pub fn apply_wire_spans(
+    seg: &str,
+    scanned_len: usize,
+    findings: &[WireFinding],
+    protected: &[(usize, usize)],
+) -> (String, usize) {
+    // 剔除非法 span(空/逆序、越出扫描前缀、非 char-boundary),保留 (start, end, label)。
+    let mut spans: Vec<(usize, usize, &str)> = findings
+        .iter()
+        .filter(|f| {
+            f.start < f.end
+                && f.end <= scanned_len
+                && seg.is_char_boundary(f.start)
+                && seg.is_char_boundary(f.end)
+        })
+        .map(|f| (f.start, f.end, f.label.as_str()))
+        .collect();
+    if spans.is_empty() {
+        return (seg.to_string(), 0);
+    }
+    // start 升序、同 start 时 end 降序(长 span 作并集代表名)。
+    spans.sort_by(|a, b| a.0.cmp(&b.0).then(b.1.cmp(&a.1)));
+    // 并集合并成互不重叠区间(代表 label 取并集内 start 最小→最长者)。
+    let mut merged: Vec<(usize, usize, &str)> = Vec::with_capacity(spans.len());
+    for (start, end, label) in spans {
+        match merged.last_mut() {
+            Some(last) if start < last.1 => {
+                if end > last.1 {
+                    last.1 = end;
+                }
+            }
+            _ => merged.push((start, end, label)),
+        }
+    }
+    // 受保护区减法(VIGIL-SEC-OVERLAP-PH):从每个 ML 并集区间减去真实占位符区间,只替换**露在占位符
+    // 之外**的子区间。安全不变量:① 任何不在 protected 内、且被某 ML span 命中的字节,必落入某个被替换
+    // 子区间(真 PII 不漏);② protected 内字节永不被 replace_range 触碰(已脱敏占位符不切碎)。
+    let mut final_spans: Vec<(usize, usize, &str)> = Vec::new();
+    for &(start, end, label) in &merged {
+        for (ss, se) in subtract_ranges(start, end, protected) {
+            final_spans.push((ss, se, label));
+        }
+    }
+    // final_spans 全局升序(merged 升序且互不重叠 + 每个减法子区间升序)→ 右→左替换不漂移 index。
+    let mut hits = 0usize;
+    let mut out = seg.to_string();
+    for &(start, end, label) in final_spans.iter().rev() {
+        // 锁定 char-boundary 不变量:子区间端点来自 ML span(已过 is_char_boundary 滤)与 protected
+        // 占位符端点(均为 push_str 处 len() 采样 → 必落 char 边界),故 replace_range 不会切碎多字节
+        // 字符。debug_assert 防未来 protected 改由偏移算术得出(可能落 mid-char)而静默重引 panic 风险。
+        debug_assert!(
+            seg.is_char_boundary(start) && seg.is_char_boundary(end),
+            "apply_wire_spans 子区间非 char-boundary: ({start},{end}) in {seg:?}"
+        );
+        out.replace_range(start..end, &format!("[REDACTED {}]", safe_label(label)));
+        hits += 1;
+    }
+    (out, hits)
+}
+
+/// 返回 `[start, end)` 减去 `protected` 中所有区间后剩余的子区间(升序、互不重叠)。
+/// `protected` 为脱敏流程自产的真实占位符区间(可乱序/重叠,内部先 clamp 到 `[start,end)` 再规整)。
+/// 用于 [`apply_wire_spans`] 把 ML 并集区间裁掉与已脱敏占位符重叠的部分(VIGIL-SEC-OVERLAP-PH)。
+pub fn subtract_ranges(
+    start: usize,
+    end: usize,
+    protected: &[(usize, usize)],
+) -> Vec<(usize, usize)> {
+    if start >= end {
+        return Vec::new();
+    }
+    // 取与 [start,end) 相交的受保护区间(clamp 到窗口内),按 start 升序。
+    let mut blocks: Vec<(usize, usize)> = protected
+        .iter()
+        .map(|&(a, b)| (a.max(start), b.min(end)))
+        .filter(|&(a, b)| a < b)
+        .collect();
+    if blocks.is_empty() {
+        return vec![(start, end)];
+    }
+    blocks.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+    let mut out = Vec::new();
+    let mut cursor = start;
+    for (a, b) in blocks {
+        if a > cursor {
+            out.push((cursor, a)); // 占位符之前露出的段
+        }
+        if b > cursor {
+            cursor = b; // 跳过占位符(含重叠部分),游标前移到其右界
+        }
+    }
+    if cursor < end {
+        out.push((cursor, end)); // 末尾露出段
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{apply_wire_spans, cap_to_char_boundary, safe_label, subtract_ranges};
+    use crate::protocol::WireFinding;
+
+    fn wf(label: &str, start: usize, end: usize) -> WireFinding {
+        WireFinding {
+            label: label.to_string(),
+            start,
+            end,
+        }
+    }
+
+    #[test]
+    fn apply_wire_spans_single_span_redacts_with_label() {
+        let (out, hits) =
+            apply_wire_spans("alice@example.com here", 22, &[wf("email", 0, 17)], &[]);
+        assert_eq!(out, "[REDACTED email] here");
+        assert_eq!(hits, 1);
+    }
+
+    #[test]
+    fn apply_wire_spans_multiple_spans_right_to_left_keep_offsets() {
+        // 两个 span 降序应用,不挪未处理前缀 offset。
+        let seg = "a alice@x.io b bob@y.io c";
+        let (out, hits) = apply_wire_spans(
+            seg,
+            seg.len(),
+            &[wf("email", 2, 12), wf("email", 15, 23)],
+            &[],
+        );
+        assert_eq!(out, "a [REDACTED email] b [REDACTED email] c");
+        assert_eq!(hits, 2);
+    }
+
+    #[test]
+    fn apply_wire_spans_out_of_bounds_and_beyond_scanned_skipped() {
+        let seg = "hello world";
+        // end > scanned_len(5) / end > seg.len() / start>=end(逆序)→ 全跳过。
+        let (out, hits) = apply_wire_spans(
+            seg,
+            5,
+            &[wf("x", 0, 9), wf("y", 100, 200), wf("z", 4, 2)],
+            &[],
+        );
+        assert_eq!(out, "hello world");
+        assert_eq!(hits, 0);
+    }
+
+    #[test]
+    fn apply_wire_spans_non_char_boundary_skipped() {
+        // "héllo":é(U+00E9)= 2 字节占 [1,3);byte 2 落 é 中间 → 非 boundary → 跳过(防 panic)。
+        let seg = "héllo";
+        let (out, hits) = apply_wire_spans(seg, seg.len(), &[wf("x", 0, 2)], &[]);
+        assert_eq!(out, seg);
+        assert_eq!(hits, 0);
+    }
+
+    #[test]
+    fn apply_wire_spans_overlap_union_merged_no_leak() {
+        // 重叠 span 并集合并(VIGIL-SEC-OVERLAP):[3,7) 与 [5,9) → 并集 [3,9),全覆盖。
+        // 旧"重叠跳过"实现会留下 [3,7) 独有的 "de"(残留泄漏 "abcde[REDACTED a]j");并集后无残留。
+        let seg = "abcdefghij";
+        let (out, hits) = apply_wire_spans(seg, seg.len(), &[wf("a", 5, 9), wf("b", 3, 7)], &[]);
+        assert_eq!(out, "abc[REDACTED b]j", "重叠应并集为单一占位符,覆盖 [3,9)");
+        assert!(!out.contains("de"), "[3,7) 独有前缀 de 不得残留:{out}");
+        assert_eq!(hits, 1);
+    }
+
+    #[test]
+    fn apply_wire_spans_nested_no_leak() {
+        // 嵌套 span:外 [0,40] 套内 [15,40](内层长)。旧右→左 + 重叠跳过会跳过外层 →
+        // 外层前缀 "Jonathan Whitfi" 明文泄漏("Jonathan Whitfi[REDACTED person]")。
+        let seg = "Jonathan Whitfield Robert Smith Junior!!"; // 40 字节(ASCII)
+        let (out, hits) = apply_wire_spans(
+            seg,
+            seg.len(),
+            &[wf("person", 0, 40), wf("person", 15, 40)],
+            &[],
+        );
+        assert!(!out.contains("Jonathan"), "外层 PII 前缀泄漏:{out}");
+        assert_eq!(out, "[REDACTED person]", "嵌套应并集为单一占位符");
+        assert_eq!(hits, 1);
+    }
+
+    #[test]
+    fn apply_wire_spans_subtracts_protected_no_split() {
+        // VIGIL-SEC-OVERLAP-PH:ML span over-capture 延伸进真实占位符 → 减法只替换露出部分,占位符不切碎。
+        let seg = "x [REDACTED email] y"; // 占位符 "[REDACTED email]" 在 [2,18)
+        let (out, hits) = apply_wire_spans(seg, seg.len(), &[wf("address", 0, 10)], &[(2, 18)]);
+        assert_eq!(out, "[REDACTED address][REDACTED email] y");
+        assert!(out.contains("[REDACTED email]"), "真实占位符不得被切碎");
+        assert_eq!(hits, 1);
+    }
+
+    #[test]
+    fn apply_wire_spans_span_fully_in_protected_dropped() {
+        // ML span 完全落在真实占位符内 → 减法后空 → 不替换,占位符原样、无 hit。
+        let seg = "x [REDACTED email] y";
+        let (out, hits) = apply_wire_spans(seg, seg.len(), &[wf("pii", 4, 12)], &[(2, 18)]);
+        assert_eq!(out, seg);
+        assert_eq!(hits, 0);
+    }
+
+    #[test]
+    fn apply_wire_spans_span_spanning_protected_splits() {
+        // ML span 跨越整个占位符 → 减法切成左右两段各替换,占位符夹中间完整。
+        let seg = "aa [REDACTED email] bb"; // 占位符 [3,19)
+        let (out, hits) = apply_wire_spans(seg, seg.len(), &[wf("p", 0, 22)], &[(3, 19)]);
+        assert_eq!(out, "[REDACTED p][REDACTED email][REDACTED p]");
+        assert_eq!(hits, 2);
+    }
+
+    #[test]
+    fn apply_wire_spans_forged_placeholder_not_protected() {
+        // 不可信文本伪造 `[REDACTED x]` 包裹真 PII。伪造占位符**不在** protected(只含脱敏自产区间)→
+        // ML span 命中其中真 PII 仍被替换,伪造无法让 ML 跳过(绕过脱敏)。
+        let seg = "[REDACTED x]alice@evil.com[REDACTED y]"; // 真 PII alice@evil.com 在 [12,26)
+        let (out, hits) = apply_wire_spans(seg, seg.len(), &[wf("email", 12, 26)], &[]);
+        assert!(
+            !out.contains("alice@evil.com"),
+            "伪造占位符不得保护其包裹的真 PII"
+        );
+        assert!(out.contains("[REDACTED email]"));
+        assert_eq!(hits, 1);
+    }
+
+    #[test]
+    fn subtract_ranges_cases() {
+        let empty = Vec::<(usize, usize)>::new();
+        assert_eq!(subtract_ranges(0, 10, &[]), vec![(0, 10)]); // 无保护 → 原区间
+        assert_eq!(subtract_ranges(0, 10, &[(2, 5)]), vec![(0, 2), (5, 10)]); // 中间挖洞
+        assert_eq!(subtract_ranges(0, 10, &[(0, 10)]), empty); // 全保护 → 空
+        assert_eq!(subtract_ranges(0, 10, &[(0, 4)]), vec![(4, 10)]); // 头部
+        assert_eq!(subtract_ranges(0, 10, &[(6, 10)]), vec![(0, 6)]); // 尾部
+        assert_eq!(
+            subtract_ranges(0, 10, &[(3, 5), (6, 8)]),
+            vec![(0, 3), (5, 6), (8, 10)]
+        ); // 多洞
+        assert_eq!(
+            subtract_ranges(0, 10, &[(2, 6), (4, 8)]),
+            vec![(0, 2), (8, 10)]
+        ); // 重叠 block
+        assert_eq!(subtract_ranges(0, 10, &[(5, 5), (8, 4)]), vec![(0, 10)]); // 空/逆序 block 过滤
+        assert_eq!(subtract_ranges(5, 5, &[]), empty); // 空窗口
+        assert_eq!(subtract_ranges(2, 8, &[(0, 4), (6, 20)]), vec![(4, 6)]); // protected 越界 → clamp
+    }
+
+    #[test]
+    fn cap_to_char_boundary_floors_to_boundary() {
+        assert_eq!(cap_to_char_boundary("hello", 100), "hello");
+        assert_eq!(cap_to_char_boundary("hello", 3), "hel");
+        // "aéb":é 占 [1,3);cap=2 落 é 中间 → 退到 1 → "a"。
+        assert_eq!(cap_to_char_boundary("aéb", 2), "a");
+    }
+
+    #[test]
+    fn safe_label_sanitizes_and_caps() {
+        assert_eq!(safe_label("email"), "email");
+        assert_eq!(safe_label("private_phone"), "private_phone");
+        // 非白名单字符(空格/分号/方括号/连字符)全过滤(防把 daemon 响应原样嵌进输出)。
+        assert_eq!(safe_label("e]mail[injection"), "emailinjection");
+        assert_eq!(safe_label("a b;c"), "abc");
+        assert_eq!(safe_label("na-me"), "name");
+        assert_eq!(safe_label(""), "pii");
+        assert_eq!(safe_label("!!!"), "pii");
+        assert_eq!(safe_label(&"x".repeat(100)).len(), 32);
+    }
+}

--- a/docs/adr/0009-browser-extension-mvp.md
+++ b/docs/adr/0009-browser-extension-mvp.md
@@ -351,3 +351,50 @@ pub enum FindingKind {
 | AWS secret key(`[A-Za-z0-9/+=]{40}`)| 熵过低,当前 vigil-redaction 仅硬指纹无熵门控 → 高误报 | 待熵评分框架(同上与 email/phone) |
 | IPv6 literal / 下划线 host 形 DB URL | 第三批 regex 有意收紧;后续 DSN 形态扩展时重新评估 | 待真实泄漏样本驱动 |
 | 运维驱动 finding-level 域分离 hash | 非规则扩展,是 audit payload 结构 | I09c 运维反馈驱动 |
+
+## Revised 2026-07-06(Phase 1「引擎连接」:native host 成为 daemon 第二瘦客户端)
+
+背景与全量评估(现状客观评价 / 外部生态 / 四断裂系统分析 / 能力增量矩阵 / 三阶段方案)
+见引入本段的 PR 描述。本段固化 Phase 1 决策与不变量。
+
+### P1. 决策
+
+1. **连接方式 = daemon(ADR 0024)第二瘦客户端**:host 每请求
+   `query_daemon(RedactScan{kind: Args, text=基底前缀≤16KiB}, 800ms)`;复用 R1(peer-cred)/
+   R2(总截止)/R3(无路径注入)。否决项:扩展内跑 ML(CWS 远程代码禁令 + 模型体积)、
+   host 自持 ort(内存×N / 冷启动 45s / ML 变体分发复杂)。**零 daemon 端改动**
+   (server dispatch 忽略 `kind`,cap 由客户端裁)。
+2. **IPC 抽 crate `vigil-daemon-ipc`**(纯移动):protocol / client / transport(客户端侧;
+   `serve` 归位 `daemon/server.rs`)/ **wire**(hook 的 `apply_wire_spans` 等四个 WireFinding
+   安全应用原语,签名改返 `(String, usize)`)。hub-cli `daemon/mod.rs` re-export 保路径,
+   消费侧零改动;hook 与 native-host 共用 wire 原语,防 VIGIL-SEC-OVERLAP/-PH 修复漂移。
+3. **协议扩展(只加可选字段)**:`BrowserCheckResponse.ml_labels: Vec<String>`
+   (serde default + skip empty,双向兼容;**纯展示层**,不进扩展 tier 决策);
+   审计 payload 白名单 +`engine`("hardfp" | "hardfp+ml")+`ml_labels`(§I-9.2 白名单
+   测试双向同步;均类别级 metadata,无 span 文本)。
+
+### P2. 新增不变量
+
+- **ML 只收紧**:`ml_augment` 仅 Allow→Redact(或纵深 re-scan 触 Block);Block 短路不查;
+  daemon 缺席/超时/Error/engine.json 关闭 → 响应**逐字节等于**纯硬指纹现状(单测黄金对照)。
+- **坐标系结构性守恒**:ML 基底 = 硬指纹层最终文本(Redact→`scrub_text_with_spans`,其
+  `.0 == scrub_text()` 与 `classify` 同源);spans 相对基底前缀,`protected` 减法保占位符完整。
+- **长驻进程失败冷却**:hook 的"one-shot 进程回收阻塞 worker"假设对 Chrome 常驻 host 不成立;
+  `DaemonProbe` 失败后 60s 静默(防 detached worker 累积 + 重复 deadline 延迟),窗口过后自愈。
+- **engine.json 门控**(独立解析,同 SSOT fail-closed 方向):缺失=auto(查,缺席自然降级);
+  显式 hardfp=不查;损坏/坏版本=不查。
+- **daemon 输出按不可信处理**:label 经 `safe_label` sanitize(≤32 alnum+_)去重升序;
+  SW 层再加限长(≤16)+ 仅字符串纵深守门。
+
+### P3. 审查与量化
+
+- hostile sub-agent 审查(2026-07-06)**SOUND**:A(移植保真,与 HEAD 逐逻辑 diff)/
+  B(fail-open 面)/C(坐标系)/D(资源)/E(审计白名单)/F(JS 层)/G(协议兼容)全 OK;
+  0 CRITICAL/HIGH/MED;3 个 LOW/信息级非阻断(慢滴漏 ≤1 worker/60s 已文档化、daemon 可控
+  label 字节入本地账本有界、JS 尺寸上限——第三项已当场加固)。
+- 远端(192.168.252.20,cargo 1.96)`fmt --check` / `clippy --workspace --all-targets
+  -D warnings` / `test --workspace` 全绿:**1270 passed / 0 failed**(基线 1260,+10:
+  wire 13 全量随迁+2 补、native-host ml_augment 10、server e2e 4 随迁)。
+- 后续:Phase 2(posture→tier 统一 + GUI 观测)、Phase 3(setup 编排 + 文档一致性)。
+  Chrome Web Store 消费版扩展(0.2.0,纯 JS consumer 模式)已独立上架;本轮 native host
+  ML 能力对应其 enterprise 模式的 provider 接缝,接线属 Phase 2+ 产品决策。

--- a/docs/adr/0024-resident-daemon-ml-hook.md
+++ b/docs/adr/0024-resident-daemon-ml-hook.md
@@ -199,3 +199,14 @@ hook.run(event):
 **§9 测试矩阵追加(进默认矩阵)**:R2 流式读截止降级测试、R6 Windows DACL 拒绝测试、R3 daemon 绑定固定 ledger(忽略请求路径)测试、R1 peer-credential 不符 → 降级测试。
 
 **实施前必决 gate(P2.3)= R1 + R2 + R3 + R5 + R6**(R4/R7 同批落)。评审定论:对"传输+鉴权+fail-closed"这类 ADR,这四问**就是**交付物,必须实施前解决而非延后 —— 已照办。
+
+## Revised 2026-07-06 — 第二客户端(browser native host)+ IPC 抽 crate
+
+- daemon 客户端面从 hook(+ `daemon status`)扩到 **vigil-native-host**(浏览器 paste 守门
+  ML 增强;ADR 0009 Revised 2026-07-06)。D2(无状态推理 oracle / merge 留客户端)与
+  R1-R3 不变量**原样适用**,零 daemon 端改动。
+- protocol / client / transport(客户端侧)/ wire(WireFinding 应用原语)抽至
+  `crates/vigil-daemon-ipc`(纯移动;hub-cli `daemon/mod.rs` re-export 保路径);`serve`
+  accept 循环归位 `daemon/server.rs`(需 `DaemonCaps`)。
+- 长驻客户端新纪律:R2 的 detached-worker 模式假设 one-shot 进程回收;**长驻调用方必须自带
+  失败冷却/限流**(native host:60s 冷却)。已注记于 `transport::query_daemon` doc。

--- a/docs/adr/STATUS.md
+++ b/docs/adr/STATUS.md
@@ -30,7 +30,7 @@
 | 0006 | Secret Lease Broker | I06 | **Accepted(Done)** | R2 ACCEPT(R1 REJECT) | 178 |
 | 0007 | Sandbox Runner | I07 + I07.5 + I07.5+ | **Accepted** | R3 ACCEPT(R1/R2 REJECT)/ I07.5 R3 ACCEPT(R1/R2 REJECT)/ **I07.5+ R1 ACCEPT** | 378(I07 基线 + I07.5 Linux-gated + **I07.5+ +3 helper 单测**) |
 | 0008 | Desktop UI | I08a + I08b α1-α5 + β1 + β3 + β5 | **Accepted(I08a Done;α1-α5 MVP 四页;β1 真白名单;β3 EffectKind 强类型;β5 Ledger 磁盘持久化 + 审计跨会话不变量)** | I08a R3 / α1 R3 / α2 R2 / α3 R3 / α4 R1 / α5 R2 / β1 R2 / β3 R2 / **β5 R2 ACCEPT** | 213(I08a,workspace **408** 零 regression)|
-| 0009 | Browser Extension MVP | I09a + I09b α1/α2/α3/α4/β1 + **I09c 规则扩展第一+第二+第三批** + **ISS-021 跨 crate sync** | **Accepted(I09a + I09b 全 α+β1 全 Codex ACCEPT;I09c 第一/二/三批全 Codex ACCEPT;ISS-021 RULE_PROFILE_VERSION v4 → v5 + 跨 crate PrivacyLabel sync 守门)** | I09a R3 / I09b α1 R2 / α2 R2 / α3 R1 / α4 R1 / β1 R2 / I09c 一批 R2 / 二批 R3 / 三批 R1 ACCEPT / **ISS-021 R2 ACCEPT(R1 CONDITIONAL → R2 ACCEPT)** | 258(I09a);workspace **536**(一批 +3 + 二批 +3 + 三批 +3 classifier tests + rule_sync/golden 同步;I09c RULE_PROFILE_VERSION v1 → v2 → v3 → v4;FindingKind 8 → 13;**+ ISS-021 RULE_PROFILE_VERSION v4 → v5,rule_sync.rs +2(alias 表 + count 守门),merge.rs +4(全 14 Hard kind × PrivacyLabel × 重叠/非重叠 矩阵 golden)**)|
+| 0009 | Browser Extension MVP | I09a + I09b α1/α2/α3/α4/β1 + **I09c 规则扩展第一+第二+第三批** + **ISS-021 跨 crate sync** | **Accepted(I09a + I09b 全 α+β1 全 Codex ACCEPT;I09c 第一/二/三批全 Codex ACCEPT;ISS-021 RULE_PROFILE_VERSION v4 → v5 + 跨 crate PrivacyLabel sync 守门)** | I09a R3 / I09b α1 R2 / α2 R2 / α3 R1 / α4 R1 / β1 R2 / I09c 一批 R2 / 二批 R3 / 三批 R1 ACCEPT / **ISS-021 R2 ACCEPT(R1 CONDITIONAL → R2 ACCEPT)** | 258(I09a);workspace **536**(一批 +3 + 二批 +3 + 三批 +3 classifier tests + rule_sync/golden 同步;I09c RULE_PROFILE_VERSION v1 → v2 → v3 → v4;FindingKind 8 → 13;**+ ISS-021 RULE_PROFILE_VERSION v4 → v5,rule_sync.rs +2(alias 表 + count 守门),merge.rs +4(全 14 Hard kind × PrivacyLabel × 重叠/非重叠 矩阵 golden)**;**+ Phase 1 引擎连接 2026-07-06(daemon 第二客户端,workspace 1270)**)|
 | 0010 | HTTP MCP Auth | I10a | **Accepted(Done — 仅 I10a 认证核心 + mock transport)** | R2 ACCEPT(R1 REJECT) | 294 |
 | 0011 | HTTP Transport + JWKS 验签 | I10b 全段 + I10c-α1/α2/α3/α3+/β2 | **Accepted** | 设计 R4 / I10b α1 R2 / α2 R3 / β R2 / I10c-α1 R4 / α2 R2 / β2 R3 / α3 R2 / **α3+ R3** 全 ACCEPT | 375(α1 +18 / α2 +15 / β +17 / I10c-α1 +5 / α2 +5 / β2 +9 / α3 +6 / **α3+ +3**) |
 | 0012 | 模型分发策略 | ISS-001 spike + ISS-004 + ISS-022(Phase 2 forward 实测)+ **v0.5 P2 bootstrap 实施**(commit `b5419b5`)| **Accepted(Implemented)** | ISS-004 R0 直接 ACCEPT(决策表 + 9 决策 + 反馈固化)/ ISS-022 R0(forward 实测验证 §3.6 并发下载规则)/ **v0.5 P2 R0**(§3.2-§3.7 全实施,placeholder URL/sha256 待 v0.5.1 注入)| 10(`crates/vigil-redaction/src/bootstrap/tests.rs`:happy / sha256 mismatch / ETag 304 / fallback / all-fail / manifest parse / disk full / partial resume / verify-skip / mirror order)|
@@ -659,6 +659,12 @@ ADR 0012 §3.2-§3.7 全实施(commit `b5419b5`):
 - R1 BLOCKER:API 边界未收 "token-resource 绑定" → 新 `resolve_access_token` 封闭入口
 - R1 MUST-FIX:`token_type=Bearer` 未校 → `eq_ignore_ascii_case("Bearer")`
 - R2 NICE-TO-HAVE(2026-04-21 横向清理已消化):`list_metadata` 遇未知 `token_kind` 已改为 `return Err("unknown_token_kind")`,与 `get_metadata` 对齐,`tests/integration.rs::list_metadata_fails_closed_on_unknown_token_kind` 回归覆盖
+
+### ADR 0009 Phase 1「引擎连接」+ ADR 0024 第二客户端(2026-07-06)
+
+- **交付**:`crates/vigil-daemon-ipc` 抽取(protocol/client/transport 客户端侧/wire 四原语,纯移动;hub-cli re-export 保路径)+ native-host `ml_augment`(daemon ML PII 增强,fail-closed 纯加性)+ `BrowserCheckResponse.ml_labels` + 审计 `engine`/`ml_labels`(白名单同步)+ 扩展 JS 透传(不进 tier 决策)
+- **审查**:hostile sub-agent SOUND(A-G 全 OK,0 Crit/High/Med;3 LOW 非阻断,其一 JS 限长已当场加固);远端 fmt/clippy(-D warnings)/test 全绿 **1270/0**(+10)
+- **评估依据**:见引入 PR 描述(四断裂分析 + 能力增量矩阵 + 三阶段方案);Phase 2/3 后续推进
 
 ## 维护约定
 


### PR DESCRIPTION
## What

The browser-side native messaging host (`vigil-native-host`) becomes the daemon's (ADR 0024) **second thin ML client**, after the hook. With a running ML daemon, paste/input/submit checks on AI sites gain semantic PII detection (email / person / phone / address / …) on top of the unconditional hard-fingerprint baseline. Without a daemon the behavior is **byte-identical to today** (golden test enforced).

### Why (evaluation summary)

A full professional review of the extension subsystem found it to be a "half-island": solid fail-closed security core, but four systemic breaks with the rest of Vigil — **engine** (hardfp-only while hook/serve are dual-engine), **policy** (its own third posture vocabulary, non-persistent), **observability** (browser.* audit events land in the shared ledger but nothing surfaces them), **orchestration** (`setup` doesn't know the host exists). Browser paste is the single largest real-world leak channel for AI usage, and the local-ML-behind-native-host design is the only Chrome-Web-Store-compliant way to bring the real engine there (remote-code policy rules out in-extension ML). This PR closes the **engine** break; policy/observability/orchestration are staged follow-ups.

### Changes

- **New crate `vigil-daemon-ipc`** (pure move): daemon wire protocol + thin client — R1 peer-credential and R2 overall-deadline semantics preserved verbatim — plus the `WireFinding` application primitives (`apply_wire_spans` & friends) moved out of `hook.rs` so hook and native-host share one implementation of the VIGIL-SEC-OVERLAP/-PH fixes. `vigil-hub-cli` re-exports keep every `crate::daemon::*` path compiling; the accept loop (`serve`) moves next to `DaemonCaps` in `daemon/server.rs`. Side effect: the R2 doc drift in this repo (text described `set_read_timeout`, implementation uses detached worker + `recv_timeout`) is corrected by the moved, accurate docs.
- **native-host ML augmentation** (`ml_augment`): Block short-circuits (never queried); scan base = the hardfp layer's final text (placeholder spans protected from ML over-capture); ML can only tighten (Allow → Redact); post-rewrite hard-fingerprint re-scan as defense in depth; `DaemonProbe` = `engine.json` gate (missing=auto, explicit hardfp=off, corrupt=off) + **60s failure cooldown** (Chrome keeps the host resident, so the hook's one-shot worker-reclaim assumption doesn't hold) + 800ms deadline.
- **Also ports the canonical-ledger resolution this repo was missing** (`VIGIL_LEDGER_PATH` → `VIGIL_DB_PATH` → `<data_local>/Vigil/ledger.sqlite3`, fail-open to in-memory): browser audit events now reach the shared ledger by default.
- **vigil-browser**: optional `BrowserCheckResponse.ml_labels` (display-only; never feeds tier decisions; `serde(default)` keeps both old-host/new-extension and new-host/old-extension pairs working) + audit payload `engine` / `ml_labels` with the strict §I-9.2 whitelist test extended.
- ADR 0009 / ADR 0024 Revised sections + STATUS.md.

### Deliberately NOT in this PR

- **Extension JS is untouched.** The store extension (0.2.0) is consumer-mode JS with an enterprise-provider seam; this native-host capability is the natural implementation behind that seam, but wiring it up (optional `nativeMessaging` permission, enterprise-mode semantics) is a product decision for a follow-up. Note: the docs line "pairing with the desktop app's native host unlocks deep redaction" currently has no code path in 0.2.0 — this PR builds the capability that makes it true once wired.
- `crates/vigil-daemon-ipc` is `publish = false` (not in the vigil-sdk closure; publish-crates.yml untouched).

### Verification

- `cargo fmt --all --check` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace`: **1255 passed, 0 failed** (win64, cargo 1.96).
- Hostile security review (adversarial, 7 attack surfaces: port fidelity vs HEAD, fail-open, span coordinate systems, resident-process resources, audit whitelist, JS layer, protocol compat): **verdict SOUND**, 0 critical/high/medium findings.
- No daemon ⇒ responses byte-identical to hardfp baseline (golden test `daemon_unavailable_is_byte_identical_to_hardfp_baseline`).
