### PR TITLE
feat(extension): first enterprise backend — local Vigils engine via Native Host

### DIFF
--- a/docs/book/src/getting-started/installation.md
+++ b/docs/book/src/getting-started/installation.md
@@ -77,7 +77,11 @@ block is recorded in a tamper-evident local ledger. Kick the tires with **`vigil
 Redacts secrets / PII before you paste or submit on AI sites. Install
 [**Vigils Browser Guard**](https://chromewebstore.google.com/detail/vigils-browser-guard/ffmgaglmcimapacgmoejaobfjdpmopch)
 from the Chrome Web Store — consumer mode works out of the box, no desktop app required.
-Optional: pairing with the desktop app's native host unlocks deep redaction. Dev builds:
+Optional deep redaction: install the Vigils CLI, register the native messaging host
+(`vigil-native-host install --extension-id <ID>`, ID shown in the extension's Options),
+then pick "Local Vigils engine" under enterprise mode in Options — checks route to the
+local engine (hard fingerprints + ML PII when the daemon runs); raw text never leaves
+the device. Dev builds:
 `chrome://extensions` → **Developer mode** → **Load unpacked** → pick `extensions/chrome-mv3/`.
 
 ---

--- a/extensions/chrome-mv3/README.md
+++ b/extensions/chrome-mv3/README.md
@@ -175,13 +175,20 @@ The extension has no frontend build step. It uses native MV3, HTML, CSS, and Jav
 
 ## Enterprise Provider Interface
 
-Everyday users do not need an enterprise provider. Enterprise mode can later integrate with:
+Everyday users do not need an enterprise provider. The first real backend is available now:
 
-- Native Host
-- localhost agent
-- Enterprise HTTPS API
-- Browser-side Wasm
-- Other managed providers
+- **Local Vigils engine (Native Host)** — implemented. In Options, switch to enterprise
+  mode and pick "Local Vigils engine". Requires the Vigils CLI/desktop install with the
+  native messaging host registered (see the user guide's Browser extension section; the
+  registration command needs the extension ID shown in Options). Checks are then routed
+  to the local `vigil-native-host` process: hard-fingerprint detection (13 credential
+  classes), plus semantic PII detection (email / person / phone / …) when the local ML
+  daemon is running. Raw text goes to the **local process only** and never leaves the
+  device (it stays in host memory and is dropped after classification). If the host is
+  enabled but unreachable, checks fail closed to block rather than silently downgrading.
+- localhost agent — planned
+- Enterprise HTTPS API — planned
+- Browser-side Wasm — planned
 
 The goal is to let organizations move scanning and policy decisions into a controlled environment while preserving the zero-setup consumer experience.
 
@@ -191,7 +198,7 @@ The goal is to let organizations move scanning and policy decisions into a contr
 - Improve deep input adapters for more AI websites
 - Add fuller E2E test coverage
 - Improve safety event explanations and risk education
-- Add enterprise provider examples
+- ~~Add the first enterprise provider (local Vigils engine via Native Host)~~ ✅ Done
 - ~~Package and publish to the Chrome Web Store~~ ✅ Done
 
 ## License

--- a/extensions/chrome-mv3/README.zh-CN.md
+++ b/extensions/chrome-mv3/README.zh-CN.md
@@ -171,15 +171,20 @@ node --test extensions/chrome-mv3/tests/*.test.mjs
 
 当前扩展没有前端构建步骤，使用原生 MV3、HTML、CSS 和 JavaScript。
 
-## 企业 Provider 预留
+## 企业 Provider
 
-普通用户不需要企业 provider。企业模式后续可以接入：
+普通用户不需要企业 provider。第一个真实后端现已可用：
 
-- Native Host
-- localhost agent
-- 企业 HTTPS API
-- 浏览器内 Wasm
-- 其他受管 provider
+- **本机 Vigils 引擎（Native Host）** —— 已实现。在选项页切到企业模式并选择「本机
+  Vigils 引擎」。前提：已安装 Vigils CLI/桌面版并注册 native messaging host（步骤见
+  用户文档「Browser extension」一节；注册命令需要选项页顶部的扩展 ID）。启用后检查
+  路由到本机 `vigil-native-host` 进程：硬指纹检测（13 类凭证），本机 ML daemon 运行
+  时叠加语义 PII 识别（邮箱 / 人名 / 电话等）。原文只送**本机进程**、不出设备（仅在
+  host 内存停留，分类完即丢弃）。已启用但 host 不可达时，检查 fail-closed 为阻断，
+  绝不静默降级。
+- localhost agent —— 规划中
+- 企业 HTTPS API —— 规划中
+- 浏览器内 Wasm —— 规划中
 
 设计目标是让企业用户可以把扫描和策略判断迁移到受控环境，同时保留普通用户的零配置体验。
 
@@ -189,7 +194,7 @@ node --test extensions/chrome-mv3/tests/*.test.mjs
 - 补充更多 AI 网站的深度输入框适配
 - 增加更完整的 E2E 测试
 - 改进安全事件说明和风险解释
-- 接入企业 provider 示例
+- ~~接入第一个企业 provider（本机 Vigils 引擎 / Native Host）~~ ✅ 已完成
 - ~~打包发布到 Chrome Web Store~~ ✅ 已完成
 
 ## 许可

--- a/extensions/chrome-mv3/background.js
+++ b/extensions/chrome-mv3/background.js
@@ -23,6 +23,7 @@
 import { normalizeCustomSiteInput } from "./custom-sites.js";
 import { checkWithScannerPipeline } from "./scanner-pipeline.js";
 import { normalizeCustomRiskRuleInput, normalizeCustomRiskRules } from "./redaction-rules.js";
+import { createNativeHostProvider } from "./providers/native-host-provider.js";
 
 const MAX_TEXT_CHARS = 32 * 1024 * 1024; // 32 MB 字符早退,避免超大文本拖垮 SW 消息处理
 const CUSTOM_SITES_STORAGE_KEY = "customProtectedSites";
@@ -31,9 +32,24 @@ const CUSTOM_CONTENT_SCRIPT_ID = "vigil-custom-protected-sites";
 const MODE_STORAGE_KEY = "vigilMode";
 const MODE_VALUES = Object.freeze(["consumer", "enterprise"]);
 const MODE_DEFAULT = "consumer";
+// 企业后端:none = 接口预留(enterprise_disabled,行为同普通保护);native_host = 本机
+// Vigils 引擎(vigil-native-host:硬指纹 + 可选 daemon ML;原文仅本机进程内存,不出设备)。
+const ENTERPRISE_BACKEND_STORAGE_KEY = "vigilEnterpriseBackend";
+const ENTERPRISE_BACKEND_VALUES = Object.freeze(["none", "native_host"]);
+const ENTERPRISE_BACKEND_DEFAULT = "none";
 const EXTENSION_ORIGIN = `chrome-extension://${chrome.runtime.id}`;
-/** @type {string} 当前模式,in-memory session 级 */
+/** @type {string} 当前模式,storage 持久(见 loadStoredMode)。 */
 let currentMode = MODE_DEFAULT;
+/** @type {string} 当前企业后端,storage 持久。 */
+let currentEnterpriseBackend = ENTERPRISE_BACKEND_DEFAULT;
+/** Native Host provider 单例(port 惰性建立,断连自愈;仅 backend=native_host 时被使用)。 */
+let nativeHostProvider = null;
+function getNativeHostProvider() {
+    if (nativeHostProvider === null) {
+        nativeHostProvider = createNativeHostProvider();
+    }
+    return nativeHostProvider;
+}
 
 // ───────────────────────── 自定义目标网站白名单 ─────────────────────────
 //
@@ -62,6 +78,30 @@ async function loadStoredMode() {
     const got = await storageGet({ [MODE_STORAGE_KEY]: MODE_DEFAULT });
     const mode = got[MODE_STORAGE_KEY];
     currentMode = MODE_VALUES.includes(mode) ? mode : MODE_DEFAULT;
+}
+
+async function loadStoredEnterpriseBackend() {
+    const got = await storageGet({
+        [ENTERPRISE_BACKEND_STORAGE_KEY]: ENTERPRISE_BACKEND_DEFAULT,
+    });
+    const backend = got[ENTERPRISE_BACKEND_STORAGE_KEY];
+    currentEnterpriseBackend = ENTERPRISE_BACKEND_VALUES.includes(backend)
+        ? backend
+        : ENTERPRISE_BACKEND_DEFAULT;
+}
+
+/**
+ * 本次检查的 enterprise 配置。backend=native_host → 注入本机引擎 provider;
+ * dataPolicy="raw_allowed" 在此语境 = 全文送**本机进程**(原文仅其内存,ADR 0009
+ * §I-9.1,不出设备)——远程端点后端未来引入时才用 local_only/metadata_only。
+ * nativeMessaging 权限被撤时 provider.check 抛 native_messaging_unavailable →
+ * pipeline 收敛 block(fail-closed,绝不静默降级为纯浏览器规则)。
+ */
+function enterpriseConfigForCheck() {
+    if (currentEnterpriseBackend === "native_host") {
+        return { provider: getNativeHostProvider(), dataPolicy: "raw_allowed" };
+    }
+    return { dataPolicy: "local_only" };
 }
 
 async function loadCustomSites() {
@@ -428,7 +468,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
                     {
                         mode: currentMode,
                         consumer: { customRiskRules },
-                        enterprise: { dataPolicy: "local_only" },
+                        enterprise: enterpriseConfigForCheck(),
                     },
                 ))
                     .then((resp) => {
@@ -540,6 +580,46 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         return false;
     }
 
+    if (msg.type === "vigil_get_enterprise_backend") {
+        sendResponse({
+            backend: currentEnterpriseBackend,
+            values: ENTERPRISE_BACKEND_VALUES.slice(),
+        });
+        return false;
+    }
+
+    if (msg.type === "vigil_set_enterprise_backend") {
+        const next = typeof msg.backend === "string" ? msg.backend : "";
+        if (!ENTERPRISE_BACKEND_VALUES.includes(next)) {
+            sendResponse({ ok: false, _error: "invalid_backend" });
+            return false;
+        }
+        currentEnterpriseBackend = next;
+        storageSet({ [ENTERPRISE_BACKEND_STORAGE_KEY]: next }).catch(() => {});
+        sendResponse({ ok: true, backend: currentEnterpriseBackend });
+        return false;
+    }
+
+    // options「启用本机引擎」流程的连接探测:向 native host 发一条真实形状的检查
+    // (白名单 origin + 无敏感样例文本),成功往返 = host 已注册可用。
+    if (msg.type === "vigil_probe_native_host") {
+        getNativeHostProvider()
+            .check({
+                request_id: crypto.randomUUID(),
+                origin: "https://chatgpt.com",
+                event_kind: "paste",
+                text: "vigils native host connection probe",
+            })
+            .then((result) => sendResponse({ ok: true, action: result.action }))
+            .catch((err) =>
+                sendResponse({
+                    ok: false,
+                    _error: String(err && err.message ? err.message : err),
+                }),
+            );
+        return true;
+    }
+
     return false; // 未识别消息:让其它可能的 listener 处理或自然 timeout
 });
 
@@ -550,6 +630,12 @@ chrome.storage.onChanged.addListener((changes, areaName) => {
     if (areaName === "local" && changes[MODE_STORAGE_KEY]) {
         const next = changes[MODE_STORAGE_KEY].newValue;
         currentMode = MODE_VALUES.includes(next) ? next : MODE_DEFAULT;
+    }
+    if (areaName === "local" && changes[ENTERPRISE_BACKEND_STORAGE_KEY]) {
+        const next = changes[ENTERPRISE_BACKEND_STORAGE_KEY].newValue;
+        currentEnterpriseBackend = ENTERPRISE_BACKEND_VALUES.includes(next)
+            ? next
+            : ENTERPRISE_BACKEND_DEFAULT;
     }
 });
 
@@ -564,6 +650,7 @@ if (chrome.permissions && chrome.permissions.onRemoved) {
 // ───────────────────────── service worker 生命周期 ─────────────────────────
 
 loadStoredMode().catch(() => {});
+loadStoredEnterpriseBackend().catch(() => {});
 syncCustomContentScripts().catch(() => {});
 
 self.addEventListener("install", () => {
@@ -579,6 +666,7 @@ self.addEventListener("activate", (event) => {
             Promise.all([
                 self.clients.claim(),
                 loadStoredMode(),
+                loadStoredEnterpriseBackend(),
                 syncCustomContentScripts(),
             ]).catch(() => {}),
         );

--- a/extensions/chrome-mv3/manifest.json
+++ b/extensions/chrome-mv3/manifest.json
@@ -16,6 +16,9 @@
     "storage",
     "scripting"
   ],
+  "optional_permissions": [
+    "nativeMessaging"
+  ],
   "optional_host_permissions": [
     "https://*/*"
   ],

--- a/extensions/chrome-mv3/options.html
+++ b/extensions/chrome-mv3/options.html
@@ -68,21 +68,29 @@
 
       <div id="enterprise-section" class="advanced-block">
         <h3>企业连接</h3>
-        <p class="desc">企业模式接口已预留，未配置 provider 时仍使用普通保护。</p>
-        <label for="enterprise-provider-type">Provider 类型</label>
-        <select id="enterprise-provider-type" disabled>
-          <option value="disabled">尚未配置</option>
-          <option value="native_host">Native Host</option>
-          <option value="localhost">Localhost Agent</option>
-          <option value="https_api">企业 HTTPS API</option>
-          <option value="wasm">浏览器内 Wasm</option>
+        <p class="desc">企业模式可将检查路由到更强的扫描后端；未配置时仍使用普通保护。</p>
+        <label for="enterprise-provider-type">扫描后端</label>
+        <select id="enterprise-provider-type">
+          <option value="none">尚未配置（普通保护）</option>
+          <option value="native_host">本机 Vigils 引擎</option>
+          <option value="localhost" disabled>Localhost Agent（规划中）</option>
+          <option value="https_api" disabled>企业 HTTPS API（规划中）</option>
+          <option value="wasm" disabled>浏览器内 Wasm（规划中）</option>
         </select>
+        <p id="enterprise-status" class="hint"></p>
+        <div id="enterprise-native-guide" class="hidden">
+          <p class="desc">启用本机引擎需要先安装 Vigils CLI（或桌面版）并完成本机引擎注册——
+            步骤见用户文档「Browser extension」一节；注册时会用到上方「扩展 ID」。完成后回到
+            此页重新选择「本机 Vigils 引擎」。</p>
+          <p class="desc">本机引擎：原文仅送本机进程内存、不出设备；含硬指纹检测，本机 ML
+            引擎运行时自动叠加语义识别（邮箱 / 人名 / 电话等）。</p>
+        </div>
 
         <label for="enterprise-data-policy">数据策略</label>
         <select id="enterprise-data-policy" disabled>
           <option value="local_only">local_only：不发送原文</option>
           <option value="metadata_only">metadata_only：只发送元数据</option>
-          <option value="raw_allowed">raw_allowed：允许发送原文</option>
+          <option value="raw_allowed">本机引擎：原文仅送本机进程（不出设备）</option>
         </select>
       </div>
 

--- a/extensions/chrome-mv3/options.js
+++ b/extensions/chrome-mv3/options.js
@@ -16,6 +16,10 @@ import { normalizeCustomRiskRuleInput } from "./redaction-rules.js";
     const modeInputs = Array.from(document.querySelectorAll("input[name='vigil-mode']"));
     const modeHint = document.getElementById("mode-hint");
     const enterpriseSection = document.getElementById("enterprise-section");
+    const enterpriseProviderSelect = document.getElementById("enterprise-provider-type");
+    const enterpriseDataPolicySelect = document.getElementById("enterprise-data-policy");
+    const enterpriseStatus = document.getElementById("enterprise-status");
+    const enterpriseNativeGuide = document.getElementById("enterprise-native-guide");
     const customRiskForm = document.getElementById("custom-risk-form");
     const customRiskName = document.getElementById("custom-risk-name");
     const customRiskPrefix = document.getElementById("custom-risk-prefix");
@@ -73,6 +77,60 @@ import { normalizeCustomRiskRuleInput } from "./redaction-rules.js";
         flashExtensionIdHint._t = setTimeout(() => {
             extensionIdHint.classList.add("fade");
         }, 1800);
+    }
+
+    function setEnterpriseStatus(text, tone) {
+        if (!enterpriseStatus) return;
+        enterpriseStatus.textContent = text || "";
+        enterpriseStatus.style.color = tone === "warn" ? "#b45309" : tone === "ok" ? "#15803d" : "";
+    }
+
+    function requestNativeMessagingPermission() {
+        return new Promise((resolve) => {
+            chrome.permissions.request({ permissions: ["nativeMessaging"] }, (granted) => {
+                void chrome.runtime.lastError;
+                resolve(Boolean(granted));
+            });
+        });
+    }
+
+    function removeNativeMessagingPermission() {
+        return new Promise((resolve) => {
+            chrome.permissions.remove({ permissions: ["nativeMessaging"] }, () => {
+                void chrome.runtime.lastError;
+                resolve();
+            });
+        });
+    }
+
+    /** 按当前后端同步企业区 UI(select 值 / 数据策略展示 / 状态行)。 */
+    function syncEnterpriseUi(backend) {
+        const active = backend === "native_host";
+        if (enterpriseProviderSelect) {
+            enterpriseProviderSelect.value = active ? "native_host" : "none";
+        }
+        if (enterpriseDataPolicySelect) {
+            enterpriseDataPolicySelect.value = active ? "raw_allowed" : "local_only";
+        }
+        if (!active && enterpriseNativeGuide) {
+            // 指引仅在启用失败时展开;成功/未配置态收起。
+            enterpriseNativeGuide.classList.add("hidden");
+        }
+        setEnterpriseStatus(
+            active
+                ? "已启用本机引擎：检查在本机完成，原文不出设备。"
+                : "未配置扫描后端：企业模式当前仍使用普通保护。",
+            active ? "ok" : "",
+        );
+    }
+
+    async function refreshEnterpriseBackend() {
+        const resp = await sendRuntimeMessage({ type: "vigil_get_enterprise_backend" });
+        syncEnterpriseUi(resp && resp.backend === "native_host" ? "native_host" : "none");
+    }
+
+    async function setEnterpriseBackend(backend) {
+        return sendRuntimeMessage({ type: "vigil_set_enterprise_backend", backend });
     }
 
     function setEnterpriseVisible(mode) {
@@ -308,6 +366,46 @@ import { normalizeCustomRiskRuleInput } from "./redaction-rules.js";
         });
     }
 
+    if (enterpriseProviderSelect) {
+        enterpriseProviderSelect.addEventListener("change", async () => {
+            const wanted = enterpriseProviderSelect.value;
+            if (wanted === "native_host") {
+                // 权限请求必须留在用户手势同步栈附近(change 事件内第一步)。
+                const granted = await requestNativeMessagingPermission();
+                if (!granted) {
+                    setEnterpriseStatus("未授予权限，已取消启用。", "warn");
+                    syncEnterpriseUi("none");
+                    return;
+                }
+                setEnterpriseStatus("正在探测本机引擎…");
+                const probe = await sendRuntimeMessage({ type: "vigil_probe_native_host" });
+                if (!probe || !probe.ok) {
+                    // 探测失败不保存(fail-closed 且不把用户锁进全阻断);展开指引。
+                    await setEnterpriseBackend("none");
+                    syncEnterpriseUi("none");
+                    if (enterpriseNativeGuide) enterpriseNativeGuide.classList.remove("hidden");
+                    setEnterpriseStatus(
+                        `未连接到本机引擎（${(probe && probe._error) || "未知错误"}）。请按下方指引完成安装与注册后重试。`,
+                        "warn",
+                    );
+                    return;
+                }
+                const resp = await setEnterpriseBackend("native_host");
+                if (resp && resp.ok) {
+                    syncEnterpriseUi("native_host");
+                } else {
+                    syncEnterpriseUi("none");
+                    setEnterpriseStatus(`启用失败：${(resp && resp._error) || "未知错误"}`, "warn");
+                }
+                return;
+            }
+            // 回落普通保护:清后端 + 主动撤回可选权限(最小权限)。
+            await setEnterpriseBackend("none");
+            await removeNativeMessagingPermission();
+            syncEnterpriseUi("none");
+        });
+    }
+
     customSiteForm.addEventListener("submit", async (ev) => {
         ev.preventDefault();
         const input = customSiteInput.value;
@@ -403,6 +501,7 @@ import { normalizeCustomRiskRuleInput } from "./redaction-rules.js";
     }
 
     refreshMode();
+    refreshEnterpriseBackend();
     refreshCustomSites();
     refreshCustomRiskRules();
 })();

--- a/extensions/chrome-mv3/providers/native-host-provider.js
+++ b/extensions/chrome-mv3/providers/native-host-provider.js
@@ -1,0 +1,167 @@
+// Native Host enterprise provider —— 把检查路由到本机 Vigils 引擎
+// (`vigil-native-host`:硬指纹分类 + 可选 daemon ML 语义 PII 增强,见 ADR 0009/0024)。
+//
+// 数据边界:原文经 Chrome Native Messaging 送**本机进程**,仅在其内存停留(ADR 0009
+// §I-9.1,分类完立即丢弃,绝不落盘)——不出设备。与远程企业端点不同,本 provider
+// 需要全文才能分类;pipeline 的 dataPolicy 应配 "raw_allowed",UI 呈现为「本机引擎」。
+//
+// fail-closed:host 未注册 / 断连 / 超时 / 协议错 → check() reject,由
+// scanner-pipeline 的 catch 收敛为 block(enterprise_provider_failed)。
+
+export const NATIVE_HOST_NAME = "com.vigil.host";
+const REQUEST_TTL_MS = 10_000;
+const MAX_FINDING_KIND_CHARS = 64;
+
+/**
+ * 创建 Native Host provider。`options.chromeApi` 供 node 测试注入 mock;
+ * `options.hostName` / `options.ttlMs` 同理。
+ */
+export function createNativeHostProvider(options = {}) {
+    const hostName = typeof options.hostName === "string" ? options.hostName : NATIVE_HOST_NAME;
+    const ttlMs = typeof options.ttlMs === "number" && options.ttlMs > 0 ? options.ttlMs : REQUEST_TTL_MS;
+    const chromeApi = options.chromeApi || globalThis.chrome;
+
+    /** 单例 port;断连置 null,下次 check 重连(host 崩溃后可自愈)。 */
+    let port = null;
+    /** pending 请求表:request_id → { deliver, fail }(均已含 TTL timer 清理)。 */
+    const pending = new Map();
+
+    function failAll(reason) {
+        for (const [, slot] of pending) {
+            slot.fail(new Error(reason));
+        }
+        pending.clear();
+    }
+
+    function onHostMessage(msg) {
+        if (!msg || typeof msg !== "object") return;
+        // ErrorFrame 优先分流(协议错误无论 request_id 是否存在都必须 fail-closed;
+        // 语义对齐既有 host 协议:无 request_id 的流级错误 → 全 pending 连坐)。
+        if (typeof msg.error === "string") {
+            const reqId = typeof msg.request_id === "string" ? msg.request_id : null;
+            if (reqId !== null) {
+                const slot = pending.get(reqId);
+                if (slot) {
+                    pending.delete(reqId);
+                    slot.fail(new Error(`host_error:${msg.error}`));
+                }
+                return;
+            }
+            failAll(`host_protocol_error:${msg.error}`);
+            return;
+        }
+        const reqId = msg.request_id;
+        if (typeof reqId !== "string") return;
+        const slot = pending.get(reqId);
+        if (!slot) return; // 孤儿响应(已超时清理)
+        pending.delete(reqId);
+        slot.deliver(msg);
+    }
+
+    function onHostDisconnect() {
+        const reason =
+            (chromeApi.runtime.lastError && chromeApi.runtime.lastError.message) ||
+            "host_disconnected";
+        failAll(reason);
+        port = null;
+    }
+
+    function getPort() {
+        if (port !== null) return port;
+        port = chromeApi.runtime.connectNative(hostName);
+        port.onMessage.addListener(onHostMessage);
+        port.onDisconnect.addListener(onHostDisconnect);
+        return port;
+    }
+
+    /** host BrowserCheckResponse → pipeline provider result(findings 统一 {kind} 形状)。 */
+    function toProviderResult(requestId, resp) {
+        const findings = [];
+        const pushKind = (value, source) => {
+            if (typeof value !== "string" || value.length === 0) return;
+            findings.push({ kind: value.slice(0, MAX_FINDING_KIND_CHARS), source });
+        };
+        for (const kind of Array.isArray(resp.findings) ? resp.findings : []) {
+            pushKind(kind, "native_host");
+        }
+        // daemon ML 语义 PII 标签(host 侧已 sanitize 闭集)并入 findings 供展示/审计。
+        for (const label of Array.isArray(resp.ml_labels) ? resp.ml_labels : []) {
+            pushKind(label, "native_host_ml");
+        }
+        // action 白名单;未知值 fail-closed 收敛 block。"redact" 由 pipeline
+        // normalizeAction 归一为 confirm_redact(保留用户确认交互)。
+        const action =
+            resp.action === "allow" || resp.action === "redact" || resp.action === "block"
+                ? resp.action
+                : "block";
+        const result = {
+            request_id: requestId,
+            action,
+            findings,
+            source: "native_host",
+        };
+        if (typeof resp.redacted_text === "string") {
+            result.redacted_text = resp.redacted_text;
+        }
+        return result;
+    }
+
+    return {
+        name: "native_host",
+        async check(request) {
+            const requestId =
+                request && typeof request.request_id === "string" && request.request_id
+                    ? request.request_id
+                    : crypto.randomUUID();
+            const text = request && typeof request.text === "string" ? request.text : "";
+            if (
+                !chromeApi ||
+                !chromeApi.runtime ||
+                typeof chromeApi.runtime.connectNative !== "function"
+            ) {
+                // nativeMessaging 权限缺失 / 非扩展环境 → reject(pipeline 收敛 block)。
+                throw new Error("native_messaging_unavailable");
+            }
+            return new Promise((resolve, reject) => {
+                let activePort;
+                try {
+                    activePort = getPort();
+                } catch (err) {
+                    reject(new Error(`connect_failed:${String(err && err.message ? err.message : err)}`));
+                    return;
+                }
+                const timer = setTimeout(() => {
+                    if (pending.has(requestId)) {
+                        pending.delete(requestId);
+                        reject(new Error("host_timeout"));
+                    }
+                }, ttlMs);
+                pending.set(requestId, {
+                    deliver: (resp) => {
+                        clearTimeout(timer);
+                        resolve(toProviderResult(requestId, resp));
+                    },
+                    fail: (err) => {
+                        clearTimeout(timer);
+                        reject(err);
+                    },
+                });
+                try {
+                    activePort.postMessage({
+                        request_id: requestId,
+                        origin: request && typeof request.origin === "string" ? request.origin : "",
+                        event_kind:
+                            request && typeof request.event_kind === "string"
+                                ? request.event_kind
+                                : "paste",
+                        text,
+                    });
+                } catch (err) {
+                    clearTimeout(timer);
+                    pending.delete(requestId);
+                    reject(new Error(`post_failed:${String(err && err.message ? err.message : err)}`));
+                }
+            });
+        },
+    };
+}

--- a/extensions/chrome-mv3/tests/native-host-provider.test.mjs
+++ b/extensions/chrome-mv3/tests/native-host-provider.test.mjs
@@ -1,0 +1,149 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNativeHostProvider, NATIVE_HOST_NAME } from "../providers/native-host-provider.js";
+
+function fakeChrome() {
+    const state = {
+        posted: [],
+        connectCalls: 0,
+        messageListeners: [],
+        disconnectListeners: [],
+        lastError: null,
+    };
+    const port = {
+        onMessage: { addListener: (fn) => state.messageListeners.push(fn) },
+        onDisconnect: { addListener: (fn) => state.disconnectListeners.push(fn) },
+        postMessage: (msg) => state.posted.push(msg),
+    };
+    const chromeApi = {
+        runtime: {
+            get lastError() {
+                return state.lastError;
+            },
+            connectNative: (name) => {
+                state.connectCalls += 1;
+                state.connectedName = name;
+                return port;
+            },
+        },
+    };
+    return {
+        chromeApi,
+        state,
+        emit: (msg) => state.messageListeners.forEach((fn) => fn(msg)),
+        disconnect: () => state.disconnectListeners.forEach((fn) => fn()),
+    };
+}
+
+function request(text) {
+    return {
+        request_id: "33333333-3333-4333-8333-333333333333",
+        origin: "https://chatgpt.com",
+        event_kind: "paste",
+        text,
+    };
+}
+
+test("round trip maps host response into pipeline provider shape", async () => {
+    const fake = fakeChrome();
+    const provider = createNativeHostProvider({ chromeApi: fake.chromeApi });
+    const checking = provider.check(request("token ghp_x alice@example.com"));
+
+    assert.equal(fake.state.connectedName, NATIVE_HOST_NAME);
+    assert.equal(fake.state.posted.length, 1);
+    assert.equal(fake.state.posted[0].request_id, "33333333-3333-4333-8333-333333333333");
+    assert.equal(fake.state.posted[0].event_kind, "paste");
+
+    fake.emit({
+        request_id: "33333333-3333-4333-8333-333333333333",
+        action: "redact",
+        findings: ["github_token"],
+        ml_labels: ["private_email"],
+        redacted_text: "token [REDACTED github_token] [REDACTED private_email]",
+    });
+    const result = await checking;
+    assert.equal(result.action, "redact");
+    assert.equal(result.source, "native_host");
+    assert.deepEqual(result.findings, [
+        { kind: "github_token", source: "native_host" },
+        { kind: "private_email", source: "native_host_ml" },
+    ]);
+    assert.match(result.redacted_text, /\[REDACTED github_token\]/);
+});
+
+test("unknown host action fails closed to block", async () => {
+    const fake = fakeChrome();
+    const provider = createNativeHostProvider({ chromeApi: fake.chromeApi });
+    const checking = provider.check(request("hello"));
+    fake.emit({
+        request_id: "33333333-3333-4333-8333-333333333333",
+        action: "totally_new_action",
+        findings: [],
+    });
+    const result = await checking;
+    assert.equal(result.action, "block");
+});
+
+test("host error frame with request_id rejects that request", async () => {
+    const fake = fakeChrome();
+    const provider = createNativeHostProvider({ chromeApi: fake.chromeApi });
+    const checking = provider.check(request("hello"));
+    fake.emit({ error: "too_large", request_id: "33333333-3333-4333-8333-333333333333" });
+    await assert.rejects(checking, /host_error:too_large/);
+});
+
+test("host error frame without request_id fails all pending", async () => {
+    const fake = fakeChrome();
+    const provider = createNativeHostProvider({ chromeApi: fake.chromeApi });
+    const checking = provider.check(request("hello"));
+    fake.emit({ error: "bad_json" });
+    await assert.rejects(checking, /host_protocol_error:bad_json/);
+});
+
+test("disconnect rejects pending and next check reconnects", async () => {
+    const fake = fakeChrome();
+    const provider = createNativeHostProvider({ chromeApi: fake.chromeApi });
+    const checking = provider.check(request("hello"));
+    fake.disconnect();
+    await assert.rejects(checking, /host_disconnected/);
+
+    const again = provider.check(request("hello again"));
+    assert.equal(fake.state.connectCalls, 2, "断连后下次 check 应重连(自愈)");
+    fake.emit({
+        request_id: "33333333-3333-4333-8333-333333333333",
+        action: "allow",
+        findings: [],
+    });
+    const result = await again;
+    assert.equal(result.action, "allow");
+});
+
+test("timeout rejects when host never answers", async () => {
+    const fake = fakeChrome();
+    const provider = createNativeHostProvider({ chromeApi: fake.chromeApi, ttlMs: 20 });
+    await assert.rejects(provider.check(request("hello")), /host_timeout/);
+});
+
+test("missing nativeMessaging capability rejects unavailable", async () => {
+    const provider = createNativeHostProvider({ chromeApi: { runtime: {} } });
+    await assert.rejects(provider.check(request("hello")), /native_messaging_unavailable/);
+});
+
+test("malformed finding entries are dropped and kinds are length-capped", async () => {
+    const fake = fakeChrome();
+    const provider = createNativeHostProvider({ chromeApi: fake.chromeApi });
+    const checking = provider.check(request("hello"));
+    fake.emit({
+        request_id: "33333333-3333-4333-8333-333333333333",
+        action: "redact",
+        findings: ["github_token", 42, null, ""],
+        ml_labels: ["x".repeat(200)],
+        redacted_text: "[REDACTED github_token]",
+    });
+    const result = await checking;
+    assert.deepEqual(
+        result.findings.map((f) => f.kind),
+        ["github_token", "x".repeat(64)],
+        "非字符串/空条目丢弃;超长 kind 截断",
+    );
+});

--- a/extensions/chrome-mv3/tests/scanner-pipeline.test.mjs
+++ b/extensions/chrome-mv3/tests/scanner-pipeline.test.mjs
@@ -181,3 +181,87 @@ test("configured but unavailable enterprise provider fails closed", async () => 
     assert.equal(result.action, "block");
     assert.equal(result.error, "enterprise_provider_failed");
 });
+
+// ── native host 后端(raw_allowed = 本机进程,原文不出设备)集成 ──
+
+function nativeHostLikeProvider(overrides = {}) {
+    return {
+        name: "native_host",
+        seen: [],
+        async check(request) {
+            this.seen.push(request);
+            if (overrides.throwError) throw new Error("host_disconnected");
+            return {
+                request_id: request.request_id,
+                action: overrides.action || "redact",
+                findings: overrides.findings || [
+                    { kind: "github_token", source: "native_host" },
+                    { kind: "private_email", source: "native_host_ml" },
+                ],
+                redacted_text: overrides.redacted_text,
+                source: "native_host",
+            };
+        },
+    };
+}
+
+test("enterprise raw_allowed passes full text to the local native host backend", async () => {
+    const provider = nativeHostLikeProvider({ action: "allow", findings: [] });
+    await checkWithScannerPipeline(request("plain text with alice@example.com"), {
+        mode: "enterprise",
+        enterprise: { provider, dataPolicy: "raw_allowed" },
+    });
+    assert.equal(provider.seen.length, 1);
+    assert.equal(
+        provider.seen[0].text,
+        "plain text with alice@example.com",
+        "raw_allowed(本机 native host)必须收到全文才能分类",
+    );
+});
+
+test("enterprise native host block wins over consumer confirm_redact", async () => {
+    const provider = nativeHostLikeProvider({
+        action: "block",
+        findings: [{ kind: "pem_private_key", source: "native_host" }],
+    });
+    const result = await checkWithScannerPipeline(
+        request("token ghp_abcdefghijklmnopqrstuvwxyz1234567890ABCD"),
+        { mode: "enterprise", enterprise: { provider, dataPolicy: "raw_allowed" } },
+    );
+    assert.equal(result.action, "block", "后端 block 必须胜过本地 confirm_redact(取最严)");
+    const kinds = result.findings.map((f) => f.kind);
+    assert.ok(kinds.includes("github_token"), "本地 findings 保留");
+    assert.ok(kinds.includes("pem_private_key"), "后端 findings 并入");
+});
+
+test("enterprise native host redaction (hardfp+ML) overrides consumer redaction on tie", async () => {
+    const provider = nativeHostLikeProvider({
+        action: "redact",
+        redacted_text: "token [REDACTED github_token] mail [REDACTED private_email]",
+    });
+    const result = await checkWithScannerPipeline(
+        request("token ghp_abcdefghijklmnopqrstuvwxyz1234567890ABCD mail alice@example.com"),
+        { mode: "enterprise", enterprise: { provider, dataPolicy: "raw_allowed" } },
+    );
+    assert.equal(result.action, "confirm_redact", "host 的 redact 归一为 confirm_redact");
+    assert.match(
+        result.redacted_text,
+        /\[REDACTED private_email\]/,
+        "同级最严时后端(hardfp+ML 更全)的 redacted_text 胜出",
+    );
+    assert.ok(
+        result.findings.some((f) => f.kind === "private_email"),
+        "ML 语义标签并入 findings",
+    );
+});
+
+test("enterprise native host failure fails closed to block with local findings kept", async () => {
+    const provider = nativeHostLikeProvider({ throwError: true });
+    const result = await checkWithScannerPipeline(
+        request("token ghp_abcdefghijklmnopqrstuvwxyz1234567890ABCD"),
+        { mode: "enterprise", enterprise: { provider, dataPolicy: "raw_allowed" } },
+    );
+    assert.equal(result.action, "block", "已启用的后端不可达必须 fail-closed(不静默降级)");
+    assert.equal(result.error, "enterprise_provider_failed");
+    assert.ok(result.findings.some((f) => f.kind === "github_token"), "本地 findings 保留");
+});


### PR DESCRIPTION
## What

Wires the enterprise-provider seam introduced in #32 to its **first real backend**: the local Vigils engine (`vigil-native-host`), which since #57 runs hard-fingerprint detection plus daemon-ML semantic PII (email / person / phone / …) when the local ML daemon is up.

Consumer mode is untouched and stays the zero-setup default. Enterprise mode gains a working "Local Vigils engine" option that routes checks to the local process — raw text goes to the **local process only**, stays in its memory, and never leaves the device (ADR 0009 §I-9.1).

This also makes the docs line "pairing with the desktop app's native host unlocks deep redaction" true — until now 0.2.0 had no code path behind it; the docs now describe the real steps.

## How it works

- **`providers/native-host-provider.js`** — `connectNative("com.vigil.host")` client: single lazy port with reconnect-after-disconnect, pending map + 10s TTL, ErrorFrame fan-out (protocol errors without a request_id fail all pending), host `findings` + `ml_labels` mapped into the pipeline `{kind, source}` shape, unknown actions fail closed to `block`. Host `redact` is normalized by the pipeline to `confirm_redact`, so the existing confirmation UX is preserved.
- **background** — new persisted state `vigilEnterpriseBackend` (`none` | `native_host`). With `native_host`, the pipeline gets `{ provider, dataPolicy: "raw_allowed" }`; in this backend `raw_allowed` means *full text to the local process* (it needs the text to classify), not "raw to a remote endpoint" — remote backends (localhost agent / HTTPS API) will use `local_only` / `metadata_only` when they arrive. If the backend is enabled but unreachable (host unregistered, permission revoked), checks **fail closed to block** via the pipeline's existing catch — never a silent downgrade to browser-only rules.
- **options** — activates the previously-reserved backend selector: `nativeMessaging` permission requested inside the user gesture → connection probe → only then saved (probe failure shows a guide pane and does **not** save, so users are never locked into all-block before the host exists). Switching back removes the optional permission (least privilege).
- **manifest** — `optional_permissions: ["nativeMessaging"]`. The consumer default is unchanged; the existing test asserting `permissions` must not contain `nativeMessaging` still passes.
- **Copy discipline respected** — no install-command copy in the default UI (existing `ui-copy-source` assertions untouched); registration steps live in the user guide, and the Options guide pane points there plus surfaces the extension ID it needs.

## Tests

`node --test extensions/chrome-mv3/tests/*.test.mjs` → **56/56 green** (+13 new: provider unit ×9 — round-trip mapping, ErrorFrame with/without id, disconnect + reconnect self-heal, timeout, unavailable API, malformed finding entries; pipeline integration ×4 — raw text reaches the local backend, backend block wins the merge, backend redaction overrides on tie with ML labels merged, backend failure fails closed with local findings kept). All pre-existing consumer-mode / security / ui-copy assertions pass unmodified.

## Not in this PR

- No store release: manifest `version` stays 0.2.0 — bump + Chrome Web Store upload is the maintainer's call (the new permission is optional, so existing installs are not re-prompted).
- No content-script/popup changes (provider results flow through the existing pipeline shapes).
- Posture-file → extension-tier propagation (Phase 2 of the engine-link plan) is separate work.
