### PR TITLE
feat(observability): browser guard events first-class in Activity Feed + popup backend label

### DIFF
--- a/apps/desktop/ui/src/pages/ActivityFeed.vue
+++ b/apps/desktop/ui/src/pages/ActivityFeed.vue
@@ -78,6 +78,10 @@ const EVENT_TYPE_OPTIONS: SelectOption[] = [
   { label: "server.command_drifted", value: "server.command_drifted" },
   { label: "server.command_re_approved", value: "server.command_re_approved" },
   { label: "server.command_drift_rejected", value: "server.command_drift_rejected" },
+  // 浏览器扩展守门(native host 写入共享账本;payload.action = allow|redact|block)
+  { label: "browser.paste_checked", value: "browser.paste_checked" },
+  { label: "browser.input_checked", value: "browser.input_checked" },
+  { label: "browser.submit_checked", value: "browser.submit_checked" },
 ];
 
 const decisionOptions: SelectOption[] = [
@@ -101,6 +105,10 @@ function fmtTime(ts: number): string {
 }
 
 function displayType(eventType: string): string {
+  // browser.<kind>_checked → browser.<kind>(保留动作语义,只剥状态后缀)。
+  if (eventType.startsWith("browser.")) {
+    return eventType.replace(/_checked$/, "");
+  }
   // Strip the canonical suffix so the table reads like the prototype.
   return eventType.replace(
     /\.(opened|decided|executed|execute_failed|abandoned|recorded|created|resolved|note|minted|revoked|first_approved|re_approved|drift_rejected|command_drifted|command_re_approved|command_drift_rejected)$/,
@@ -146,6 +154,16 @@ function decisionKeyFromPayload(payload: unknown): DecisionKey | null {
       block: "deny",
     };
     return map[p.decision.toLowerCase()] ?? null;
+  }
+  if (typeof p.action === "string") {
+    // browser.*_checked 审计 payload:action = allow | redact | block。
+    // redact(已自动脱敏放行)标 approve 色 —— 传达「有干预处理」,区别于原样放行与阻断。
+    const map: Record<string, DecisionKey> = {
+      allow: "allow",
+      redact: "approve",
+      block: "deny",
+    };
+    return map[p.action.toLowerCase()] ?? null;
   }
   return null;
 }

--- a/extensions/chrome-mv3/popup.js
+++ b/extensions/chrome-mv3/popup.js
@@ -196,7 +196,14 @@ import { normalizeCustomSiteInput } from "./custom-sites.js";
         const resp = await sendRuntimeMessage({ type: "vigil_get_mode" });
         const mode = resp && resp.mode === "enterprise" ? "enterprise" : "consumer";
         if (mode === "enterprise") {
-            if (statusText) statusText.textContent = "企业保护";
+            // 企业模式:标出实际扫描后端(本机引擎 = 检查在本机 Vigils 进程完成)。
+            const backendResp = await sendRuntimeMessage({ type: "vigil_get_enterprise_backend" });
+            const backend =
+                backendResp && backendResp.backend === "native_host" ? "native_host" : "none";
+            if (statusText) {
+                statusText.textContent =
+                    backend === "native_host" ? "企业保护 · 本机引擎" : "企业保护";
+            }
             setHeaderStatus("ok");
         }
     }


### PR DESCRIPTION
## What

Closes the last visibility gap from the engine-link line (#57, #58): browser guard audit events (`browser.paste_checked` / `input_checked` / `submit_checked`) have been landing in the shared ledger ever since the native host wrote there — but the desktop Activity Feed never listed them in its event-type filter and had no tone mapping for them, so the protection was invisible ('protected but can't see it').

- **Activity Feed**: the three browser events join the filter options; display strips only the `_checked` suffix (keeps the action, e.g. `browser.paste`); row tone derives from the audit payload's `action` field — `allow` → allow, `redact` → approve (reads as 'intervened'), `block` → deny.
- **Extension popup**: the enterprise status line now names the actual scanning backend — `企业保护 · 本机引擎` when the local Vigils engine (#58) is active, so users can tell at a glance which engine is guarding the page.

## Verification

- Extension tests: 56/56 green (`node --test extensions/chrome-mv3/tests/*.test.mjs`).
- Desktop UI: `vue-tsc --noEmit` + `vite build` green locally.
- No Rust changes; the feed already renders arbitrary ledger events — this only promotes them to first-class filter/tone citizens.