### PR TITLE
feat(desktop): browser guard line on Protection Overview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5862,6 +5862,7 @@ dependencies = [
  "vigil-firewall",
  "vigil-lease",
  "vigil-mcp",
+ "vigil-native-host",
  "vigil-policy",
  "vigil-runner",
  "vigil-types",

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -58,6 +58,8 @@ gui = [
 vigil-types = { path = "../../crates/vigil-types" }
 vigil-ui-protocol = { path = "../../crates/vigil-ui-protocol" }
 vigil-audit = { path = "../../crates/vigil-audit" }
+# 浏览器防线卡(Protection Overview):直调 native host 注册状态(install::status,只读)。
+vigil-native-host = { path = "../native-host" }
 vigil-runner = { path = "../../crates/vigil-runner", default-features = false }
 # v0.5 P1 ADR 0014 α1:GUI bin embed Hub 骨架(默认关闭;features = ["gui"] 拉)。
 # `vigil-firewall.default-features = false`:防默认拉 ort feature(ISS-008 P2 模型路径,

--- a/apps/desktop/capabilities/default.json
+++ b/apps/desktop/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2/capability",
   "identifier": "default",
-  "description": "I08b-β1 capability 白名单 —— 系统能力(core:default)+ 应用层 28 条 invoke command 显式 allow(ISS-017 加 list_privacy_findings, ISS-018 加 export_session_replay,ADR 0024 加 daemon_status/start/stop + model_status/install)。permission identifier 无前缀 = APP_ACL_KEY(应用自身命令);命令名 underscore 由 tauri-build 在构建期 slugify 为 hyphen(例:`list_sessions` → `allow-list-sessions`)。SSOT 是 `apps/desktop/src/commands.rs::INVOKE_COMMANDS`;新增/删除 handler 必须三处同步:commands.rs + src/bin/vigils.rs 的 generate_handler! + 本文件。参见 https://v2.tauri.app/security/permissions/",
+  "description": "I08b-β1 capability 白名单 —— 系统能力(core:default)+ 应用层 30 条 invoke command 显式 allow(ISS-017 加 list_privacy_findings, ISS-018 加 export_session_replay,ADR 0024 加 daemon_status/start/stop + model_status/install)。permission identifier 无前缀 = APP_ACL_KEY(应用自身命令);命令名 underscore 由 tauri-build 在构建期 slugify 为 hyphen(例:`list_sessions` → `allow-list-sessions`)。SSOT 是 `apps/desktop/src/commands.rs::INVOKE_COMMANDS`;新增/删除 handler 必须三处同步:commands.rs + src/bin/vigils.rs 的 generate_handler! + 本文件。参见 https://v2.tauri.app/security/permissions/",
   "windows": ["main"],
   "permissions": [
     "core:default",
@@ -32,6 +32,7 @@
     "allow-export-session-replay",
     "allow-protection-summary",
     "allow-anchor-checkpoint",
+    "allow-browser-guard-status",
     "allow-daemon-status",
     "allow-daemon-start",
     "allow-daemon-stop",

--- a/apps/desktop/src/bin/vigils.rs
+++ b/apps/desktop/src/bin/vigils.rs
@@ -640,6 +640,13 @@ async fn verify_chain(state: State<'_, AppState>) -> Result<ChainVerifyReport, S
 // `vigil_desktop::ml_control`)。这些 handler 取 `AppHandle`(Tauri 自动注入)以经 resource_dir /
 // 稳定启动器 / PATH 解析引擎二进制;不触 Ledger / Hub。引擎缺失时只读 handler 优雅回默认值不报错。
 
+/// `invoke('browser_guard_status')` → 只读浏览器防线(native host)注册态。
+#[tauri::command]
+async fn browser_guard_status() -> Result<vigil_desktop::browser_guard::BrowserGuardStatus, String>
+{
+    vigil_desktop::browser_guard::browser_guard_status()
+}
+
 /// `invoke('daemon_status')` → 只读 daemon 运行态(running / pii_loaded / engine_present)。
 #[tauri::command]
 async fn daemon_status(
@@ -798,6 +805,8 @@ fn main() {
             model_install,
             // ML 引擎变体安装(端到端 ML 最后一公里)
             download_ml_engine,
+            // 浏览器防线卡(Protection Overview —— 1 read)
+            browser_guard_status,
         ])
         .setup(move |app| {
             let _main_window = app.get_webview_window("main");

--- a/apps/desktop/src/browser_guard.rs
+++ b/apps/desktop/src/browser_guard.rs
@@ -1,0 +1,45 @@
+//! 浏览器防线状态(Protection Overview 卡):本机 native messaging host 的注册态。
+//!
+//! 直调 `vigil_native_host::install::status`(结构化返回,免 shell-out 文本解析;
+//! 只读,不触任何注册表/manifest 写入)。ML daemon 运行态由既有 `daemon_status`
+//! command 提供,前端合并展示(已注册 + ML 运行中 → 深度脱敏全开)。
+
+use serde::Serialize;
+
+/// 浏览器防线(native host)注册状态 DTO。
+#[derive(Debug, Clone, Serialize)]
+pub struct BrowserGuardStatus {
+    /// 综合判定:manifest 在位且(Windows 上)HKCU 注册表键在位。
+    pub registered: bool,
+    /// host manifest JSON 是否存在。
+    pub manifest_exists: bool,
+    /// Windows HKCU 注册表键是否在位;非 Windows 平台恒 `null`。
+    pub registry_present: Option<bool>,
+}
+
+/// 读取本机 native host 注册状态(只读)。
+pub fn browser_guard_status() -> Result<BrowserGuardStatus, String> {
+    let report = vigil_native_host::install::status(None).map_err(|e| e.to_string())?;
+    // 非 Windows 无注册表概念(`registry_present = None`)→ 仅看 manifest。
+    let registered = report.manifest_exists && report.registry_present.unwrap_or(true);
+    Ok(BrowserGuardStatus {
+        registered,
+        manifest_exists: report.manifest_exists,
+        registry_present: report.registry_present,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::browser_guard_status;
+
+    /// 只读冒烟:真实环境下(不管是否注册)必须返回 Ok 且字段自洽 ——
+    /// `registered` 蕴含 `manifest_exists`(综合判定不得凭空为真)。
+    #[test]
+    fn status_is_readonly_and_consistent() {
+        let s = browser_guard_status().expect("status query must not fail");
+        if s.registered {
+            assert!(s.manifest_exists, "registered 蕴含 manifest_exists");
+        }
+    }
+}

--- a/apps/desktop/src/commands.rs
+++ b/apps/desktop/src/commands.rs
@@ -66,6 +66,8 @@ pub const INVOKE_COMMANDS: &[&str] = &[
     "model_install",
     // ML 引擎变体安装(让 GUI 用户的 ML 真正可用)
     "download_ml_engine",
+    // 浏览器防线卡(Protection Overview —— native host 注册态,1 read)
+    "browser_guard_status",
 ];
 
 #[cfg(test)]
@@ -81,7 +83,7 @@ mod tests {
     fn invoke_commands_count_in_sync() {
         assert_eq!(
             INVOKE_COMMANDS.len(),
-            29,
+            30,
             "INVOKE_COMMANDS 漂移 —— 新增/删除 handler 时必须同步:\n\
              1) 本文件 `apps/desktop/src/commands.rs`\n\
              2) `apps/desktop/src/bin/vigils.rs` 的 `tauri::generate_handler!` 列表\n\

--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -13,6 +13,8 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
 
+/// 浏览器防线卡(Protection Overview):native host 注册态(只读,详见模块内注释)。
+pub mod browser_guard;
 /// I08b-β1 Tauri `#[tauri::command]` 真白名单 SSOT(与 build.rs 通过 `include!` 共用)。
 ///
 /// 详见 `commands.rs` 顶部注释(因 include! 约束采用 `//` 而非 `//!`)。

--- a/apps/desktop/ui/src/api/ipc.ts
+++ b/apps/desktop/ui/src/api/ipc.ts
@@ -652,6 +652,17 @@ export async function daemonStatus(): Promise<DaemonStatus> {
   return await invoke<DaemonStatus>("daemon_status");
 }
 
+/** 对应 Rust `vigil_desktop::browser_guard::BrowserGuardStatus`(native host 注册态,只读)。 */
+export interface BrowserGuardStatus {
+  registered: boolean;
+  manifest_exists: boolean;
+  registry_present: boolean | null;
+}
+
+export async function browserGuardStatus(): Promise<BrowserGuardStatus> {
+  return await invoke<BrowserGuardStatus>("browser_guard_status");
+}
+
 /** 写：detached 启动常驻 daemon（暖载 ML 供 hook 主路径）。回最新状态。 */
 export async function daemonStart(): Promise<DaemonStatus> {
   return await invoke<DaemonStatus>("daemon_start");

--- a/apps/desktop/ui/src/i18n/locales/en-US.json
+++ b/apps/desktop/ui/src/i18n/locales/en-US.json
@@ -79,7 +79,11 @@
     "decision_monitor": "MONITOR",
     "rules_active": "Policy rules active: {count}",
     "servers_registered": "Servers registered: {count}",
-    "privacy_findings_count": "Privacy findings: {count}"
+    "privacy_findings_count": "Privacy findings: {count}",
+    "browser_guard_ml": "Browser guard: local engine registered · ML running",
+    "browser_guard_hardfp": "Browser guard: local engine registered (hard fingerprints)",
+    "browser_guard_off": "Browser guard: local engine not registered",
+    "browser_guard_unknown": "Browser guard: status unknown"
   },
   "approval": {
     "page_title": "Approval Queue",

--- a/apps/desktop/ui/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/ui/src/i18n/locales/zh-CN.json
@@ -79,7 +79,11 @@
     "decision_monitor": "监控",
     "rules_active": "策略规则活跃: {count}",
     "servers_registered": "已注册服务器: {count}",
-    "privacy_findings_count": "隐私发现: {count}"
+    "privacy_findings_count": "隐私发现: {count}",
+    "browser_guard_ml": "浏览器防线：本机引擎已注册 · ML 运行中",
+    "browser_guard_hardfp": "浏览器防线：本机引擎已注册（硬指纹）",
+    "browser_guard_off": "浏览器防线：未注册本机引擎",
+    "browser_guard_unknown": "浏览器防线：状态未知"
   },
   "approval": {
     "page_title": "审批队列",

--- a/apps/desktop/ui/src/pages/ProtectionOverview.vue
+++ b/apps/desktop/ui/src/pages/ProtectionOverview.vue
@@ -24,10 +24,13 @@ import {
   listPrivacyFindings,
   listRecentEvents,
   protectionSummary,
+  browserGuardStatus,
+  daemonStatus,
   verifyChain,
   type ChainVerifyReport,
   type EventSummary,
   type PrivacyFindingDto,
+  type BrowserGuardStatus,
   type ProtectionSummary,
   type SessionView,
 } from "@/api/ipc";
@@ -46,6 +49,8 @@ const serversStore = useServersStore();
 
 // ─────────────────────────── State ───────────────────────────
 const summary = ref<ProtectionSummary | null>(null);
+const browserGuard = ref<BrowserGuardStatus | null>(null);
+const browserGuardMl = ref<boolean>(false);
 const summaryLoading = ref(false);
 const recentEvents = ref<EventSummary[]>([]);
 const recentEventsLoading = ref(false);
@@ -81,6 +86,22 @@ async function loadRecentEvents(): Promise<void> {
   }
 }
 
+async function loadBrowserGuard(): Promise<void> {
+  try {
+    browserGuard.value = await browserGuardStatus();
+  } catch (e) {
+    // non-fatal: the line shows "unknown"
+    console.error("browserGuardStatus failed", e);
+    browserGuard.value = null;
+  }
+  try {
+    const d = await daemonStatus();
+    browserGuardMl.value = Boolean(d && d.running);
+  } catch {
+    browserGuardMl.value = false;
+  }
+}
+
 async function loadPrivacyFindings(): Promise<void> {
   privacyLoading.value = true;
   try {
@@ -102,6 +123,7 @@ async function loadAll(): Promise<void> {
     serversStore.refresh(),
     loadRecentEvents(),
     loadPrivacyFindings(),
+    loadBrowserGuard(),
   ]);
   // Treat the moment we first load as the last verification timestamp
   lastVerifiedAt.value = Date.now();
@@ -112,6 +134,14 @@ onMounted(() => loadAll());
 
 // ─────────────────────────── Derived metrics ───────────────────────────
 const blockedAttempts = computed(() => summary.value?.raw_secrets_blocked ?? 0);
+const browserGuardLine = computed(() => {
+  const g = browserGuard.value;
+  if (!g) return t("protection.browser_guard_unknown");
+  if (!g.registered) return t("protection.browser_guard_off");
+  return browserGuardMl.value
+    ? t("protection.browser_guard_ml")
+    : t("protection.browser_guard_hardfp");
+});
 const chainIntact = computed(() => chainReport.value?.ok ?? summary.value?.chain_intact ?? true);
 
 const activeSessions = computed(
@@ -357,6 +387,9 @@ async function exportSession(sessionId: string): Promise<void> {
             </div>
             <div class="flex justify-between">
               <span class="text-vigils-text-secondary">{{ t("protection.privacy_findings_count", { count: privacyFindingTotal }) }}</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-vigils-text-secondary">{{ browserGuardLine }}</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What

Adds a browser-guard status line to the Protection Overview status card, so the browser protection line (#57 engine link, #58 enterprise backend, #59 feed events) is visible where users check their overall posture.

- **Rust**: new `vigil_desktop::browser_guard` — read-only registration status via a direct `vigil_native_host::install::status` call (structured report, no shell-out text parsing). `registered` = host manifest present && (on Windows) HKCU key present.
- **UI**: one line, four states — `本机引擎已注册 · ML 运行中` / `已注册（硬指纹）` / `未注册本机引擎` / `状态未知` (en equivalents). ML state reuses the existing `daemon_status` command; failures are fail-soft to 'unknown'.
- **Sync discipline**: INVOKE_COMMANDS (+count guard 29→30), `generate_handler!`, `capabilities/default.json`, `ipc.ts` — all four sync points updated; the count test enforces it.

## Verification

- Remote gates: `cargo fmt --check` / `clippy --workspace --all-targets -D warnings` / `cargo test --workspace` → **1256 passed, 0 failed** (win64) — includes a new read-only smoke test asserting status coherence (registered ⇒ manifest_exists).
- `vue-tsc --noEmit` + `vite build` green; locale diffs are +4 keys each (no reformat).