### PR TITLE
feat(cli): setup --status gains a browser-guard line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5977,6 +5977,7 @@ dependencies = [
  "vigil-http-transport",
  "vigil-lease",
  "vigil-mcp",
+ "vigil-native-host",
  "vigil-policy",
  "vigil-redaction",
  "vigil-runner",

--- a/apps/native-host/src/install.rs
+++ b/apps/native-host/src/install.rs
@@ -287,6 +287,15 @@ pub struct StatusReport {
     pub registry_present: Option<bool>,
 }
 
+impl StatusReport {
+    /// 综合注册判定:manifest 在位且(Windows 上)HKCU 注册表键在位;
+    /// 非 Windows 无注册表概念(`registry_present = None`)→ 仅看 manifest。
+    /// 供 CLI `setup --status` 与桌面 Protection Overview 卡共用,防各自重实现漂移。
+    pub fn is_registered(&self) -> bool {
+        self.manifest_exists && self.registry_present.unwrap_or(true)
+    }
+}
+
 // ─────────────────────────── 内部辅助:跨平台分流 ─────────────────────────────────────
 
 /// 计算 manifest 文件绝对路径(不负责写;全平台共用)。
@@ -619,5 +628,29 @@ mod tests {
         assert!(msg.contains("/tmp/xyz"), "保留目标路径");
         assert!(!msg.contains("Permission denied"), "不透传 io 原文");
         assert!(!msg.contains("os error"), "不透传 os error");
+    }
+
+    #[test]
+    fn status_report_is_registered_matrix() {
+        use std::path::PathBuf;
+        let mk = |manifest_exists, registry_present| super::StatusReport {
+            manifest_path: PathBuf::from("/x/com.vigil.host.json"),
+            manifest_exists,
+            registry_present,
+        };
+        assert!(
+            mk(true, Some(true)).is_registered(),
+            "manifest + 注册表在位"
+        );
+        assert!(
+            mk(true, None).is_registered(),
+            "非 Windows(无注册表概念)仅看 manifest"
+        );
+        assert!(
+            !mk(true, Some(false)).is_registered(),
+            "Windows 注册表键缺失"
+        );
+        assert!(!mk(false, Some(true)).is_registered(), "manifest 缺失");
+        assert!(!mk(false, None).is_registered());
     }
 }

--- a/apps/vigil-hub-cli/Cargo.toml
+++ b/apps/vigil-hub-cli/Cargo.toml
@@ -72,6 +72,8 @@ vigil-ui-protocol = { path = "../../crates/vigil-ui-protocol" }
 # 契约)已抽至 vigil-daemon-ipc(供 hook 与 vigil-native-host 共用);本 crate 保留服务端
 # (`daemon::server` accept 循环需 interprocess Listener 类型,与 ipc crate 同版本 "2" 同源解析)。
 vigil-daemon-ipc = { path = "../../crates/vigil-daemon-ipc" }
+# setup --status 浏览器防线行:直调 native host 注册状态(install::status,只读)。
+vigil-native-host = { path = "../native-host" }
 interprocess = "2"
 
 # CLI/帮助文本国际化(i18n):按系统语言(Windows 用户默认 UI 语言 / Unix LANG 等)选择

--- a/apps/vigil-hub-cli/src/main.rs
+++ b/apps/vigil-hub-cli/src/main.rs
@@ -2502,6 +2502,25 @@ fn print_setup_report(
                 tr(lang, "no servers wrapped", "尚未防护任何服务器").to_string()
             }
         );
+        // 浏览器防线(可选层):native host 注册态。直调 install::status(纯文件/注册表
+        // 只读,与桌面 Protection Overview 卡同源判定 is_registered,防重实现漂移)。
+        println!(
+            "  {}{}",
+            tr(lang, "Browser guard: ", "浏览器防线:  "),
+            match vigil_native_host::install::status(None) {
+                Ok(s) if s.is_registered() => tr(
+                    lang,
+                    "native host registered (pick it in the extension's enterprise settings)",
+                    "native host 已注册(在扩展企业设置选择本机引擎后生效)",
+                ),
+                Ok(_) => tr(
+                    lang,
+                    "not registered (optional; see the Browser extension docs)",
+                    "未注册(可选;见浏览器扩展文档)",
+                ),
+                Err(_) => tr(lang, "status unknown", "状态未知"),
+            }
+        );
         if hook_active {
             println!(
                 "  {}{}",


### PR DESCRIPTION
## What

`vigil-hub setup --status` now reports the browser protection line alongside hook and MCP gateway — completing the turnkey status story for all three protection surfaces (#57/#58/#59/#60 built the line; this makes the CLI aware of it).

- `StatusReport::is_registered` lands on the native-host lib (manifest present && Windows HKCU key present; non-Windows is manifest-only) with a 5-state matrix test — one shared judgment for this CLI line and the desktop Protection Overview card (#60), so they can't drift.
- Output states: registered (points the user at the extension's enterprise settings to activate) / not registered (explicitly marked **optional**, pointing at the Browser extension docs) / status unknown. Bilingual en/zh, aligned with the existing status column style.

## Verification

Remote gates: `cargo fmt --check` / `clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace` → **1257 passed, 0 failed** (win64; +1 matrix test over #60 baseline).