### PR TITLE
feat(browser): posture propagation + browser-guard 24h stats (Phase 2 port)

### DIFF
--- a/apps/desktop/src/bin/vigils.rs
+++ b/apps/desktop/src/bin/vigils.rs
@@ -640,11 +640,12 @@ async fn verify_chain(state: State<'_, AppState>) -> Result<ChainVerifyReport, S
 // `vigil_desktop::ml_control`)。这些 handler 取 `AppHandle`(Tauri 自动注入)以经 resource_dir /
 // 稳定启动器 / PATH 解析引擎二进制;不触 Ledger / Hub。引擎缺失时只读 handler 优雅回默认值不报错。
 
-/// `invoke('browser_guard_status')` → 只读浏览器防线(native host)注册态。
+/// `invoke('browser_guard_status')` → 只读浏览器防线(native host)注册态 + 24h 守门统计。
 #[tauri::command]
-async fn browser_guard_status() -> Result<vigil_desktop::browser_guard::BrowserGuardStatus, String>
-{
-    vigil_desktop::browser_guard::browser_guard_status()
+async fn browser_guard_status(
+    state: State<'_, AppState>,
+) -> Result<vigil_desktop::browser_guard::BrowserGuardStatus, String> {
+    vigil_desktop::browser_guard::browser_guard_status(state.ledger.as_ref())
 }
 
 /// `invoke('daemon_status')` → 只读 daemon 运行态(running / pii_loaded / engine_present)。

--- a/apps/desktop/src/browser_guard.rs
+++ b/apps/desktop/src/browser_guard.rs
@@ -6,7 +6,7 @@
 
 use serde::Serialize;
 
-/// 浏览器防线(native host)注册状态 DTO。
+/// 浏览器防线(native host)注册状态 + 最近 24h 守门统计 DTO。
 #[derive(Debug, Clone, Serialize)]
 pub struct BrowserGuardStatus {
     /// 综合判定:manifest 在位且(Windows 上)HKCU 注册表键在位。
@@ -15,17 +15,40 @@ pub struct BrowserGuardStatus {
     pub manifest_exists: bool,
     /// Windows HKCU 注册表键是否在位;非 Windows 平台恒 `null`。
     pub registry_present: Option<bool>,
+    /// 最近 24h 浏览器检查总数(paste/input/submit)。
+    pub checks_24h: u64,
+    /// 其中拦截(block)。
+    pub blocked_24h: u64,
+    /// 其中脱敏放行(redact)。
+    pub redacted_24h: u64,
 }
 
-/// 读取本机 native host 注册状态(只读)。
-pub fn browser_guard_status() -> Result<BrowserGuardStatus, String> {
-    let report = vigil_native_host::install::status(None).map_err(|e| e.to_string())?;
+/// 读取本机 native host 注册状态 + 24h 守门统计(均只读)。
+///
+/// 注册态查询失败(home 不可得等)按未注册处理:状态卡宁可保守提示,不报错阻塞整页;
+/// 统计走 ledger 纯读([`vigil_audit::Ledger::browser_guard_counts`],窗口 = now-24h)。
+pub fn browser_guard_status(ledger: &vigil_audit::Ledger) -> Result<BrowserGuardStatus, String> {
+    let (manifest_exists, registry_present) = match vigil_native_host::install::status(None) {
+        Ok(report) => (report.manifest_exists, report.registry_present),
+        Err(_) => (false, None),
+    };
     // 非 Windows 无注册表概念(`registry_present = None`)→ 仅看 manifest。
-    let registered = report.manifest_exists && report.registry_present.unwrap_or(true);
+    let registered = manifest_exists && registry_present.unwrap_or(true);
+    let since = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+        .saturating_sub(24 * 3600);
+    let counts = ledger
+        .browser_guard_counts(since)
+        .map_err(|e| e.to_string())?;
     Ok(BrowserGuardStatus {
         registered,
-        manifest_exists: report.manifest_exists,
-        registry_present: report.registry_present,
+        manifest_exists,
+        registry_present,
+        checks_24h: counts.checks,
+        blocked_24h: counts.blocked,
+        redacted_24h: counts.redacted,
     })
 }
 
@@ -37,9 +60,11 @@ mod tests {
     /// `registered` 蕴含 `manifest_exists`(综合判定不得凭空为真)。
     #[test]
     fn status_is_readonly_and_consistent() {
-        let s = browser_guard_status().expect("status query must not fail");
+        let ledger = vigil_audit::Ledger::open_in_memory().expect("in-memory ledger");
+        let s = browser_guard_status(&ledger).expect("status query must not fail");
         if s.registered {
             assert!(s.manifest_exists, "registered 蕴含 manifest_exists");
         }
+        assert_eq!((s.checks_24h, s.blocked_24h, s.redacted_24h), (0, 0, 0));
     }
 }

--- a/apps/desktop/ui/src/api/ipc.ts
+++ b/apps/desktop/ui/src/api/ipc.ts
@@ -657,6 +657,12 @@ export interface BrowserGuardStatus {
   registered: boolean;
   manifest_exists: boolean;
   registry_present: boolean | null;
+  /** 最近 24h 浏览器检查总数(paste/input/submit) */
+  checks_24h: number;
+  /** 其中拦截(block) */
+  blocked_24h: number;
+  /** 其中脱敏放行(redact) */
+  redacted_24h: number;
 }
 
 export async function browserGuardStatus(): Promise<BrowserGuardStatus> {

--- a/apps/desktop/ui/src/i18n/locales/en-US.json
+++ b/apps/desktop/ui/src/i18n/locales/en-US.json
@@ -83,7 +83,8 @@
     "browser_guard_ml": "Browser guard: local engine registered · ML running",
     "browser_guard_hardfp": "Browser guard: local engine registered (hard fingerprints)",
     "browser_guard_off": "Browser guard: local engine not registered",
-    "browser_guard_unknown": "Browser guard: status unknown"
+    "browser_guard_unknown": "Browser guard: status unknown",
+    "browser_guard_stats": "Last 24h: {checks} checks · {blocked} blocked · {redacted} redacted"
   },
   "approval": {
     "page_title": "Approval Queue",

--- a/apps/desktop/ui/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/ui/src/i18n/locales/zh-CN.json
@@ -83,7 +83,8 @@
     "browser_guard_ml": "浏览器防线：本机引擎已注册 · ML 运行中",
     "browser_guard_hardfp": "浏览器防线：本机引擎已注册（硬指纹）",
     "browser_guard_off": "浏览器防线：未注册本机引擎",
-    "browser_guard_unknown": "浏览器防线：状态未知"
+    "browser_guard_unknown": "浏览器防线：状态未知",
+    "browser_guard_stats": "近 24h：检查 {checks} · 拦截 {blocked} · 脱敏 {redacted}"
   },
   "approval": {
     "page_title": "审批队列",

--- a/apps/desktop/ui/src/pages/ProtectionOverview.vue
+++ b/apps/desktop/ui/src/pages/ProtectionOverview.vue
@@ -134,6 +134,15 @@ onMounted(() => loadAll());
 
 // ─────────────────────────── Derived metrics ───────────────────────────
 const blockedAttempts = computed(() => summary.value?.raw_secrets_blocked ?? 0);
+const browserGuardStats = computed(() => {
+  const g = browserGuard.value;
+  if (!g || !g.registered || g.checks_24h === 0) return null;
+  return t("protection.browser_guard_stats", {
+    checks: g.checks_24h,
+    blocked: g.blocked_24h,
+    redacted: g.redacted_24h,
+  });
+});
 const browserGuardLine = computed(() => {
   const g = browserGuard.value;
   if (!g) return t("protection.browser_guard_unknown");
@@ -390,6 +399,9 @@ async function exportSession(sessionId: string): Promise<void> {
             </div>
             <div class="flex justify-between">
               <span class="text-vigils-text-secondary">{{ browserGuardLine }}</span>
+            </div>
+            <div v-if="browserGuardStats" class="flex justify-between">
+              <span class="text-vigils-text-secondary">{{ browserGuardStats }}</span>
             </div>
           </div>
         </div>

--- a/apps/native-host/src/lib.rs
+++ b/apps/native-host/src/lib.rs
@@ -147,6 +147,59 @@ pub fn engine_allows_ml(raw: Option<&str>) -> bool {
     )
 }
 
+/// posture.json(`{"version":1,"posture":"low"|"medium"|"high"}`,SSOT 见 vigil-hub-cli
+/// `posture.rs`)内容 → 扩展建议 tier 的**纯函数**映射(Phase 2「策略+观测」;`raw` = 文件
+/// 内容,`None` = 文件缺失):
+///
+/// - 缺失 → `"balanced"`(未配置 = Low 默认档语义,与 `load_posture` 的唯一"更松"分支一致);
+/// - `"low"` → `"balanced"`、`"medium"` / `"high"` → `"strict"`(扩展 tier 闭集只有
+///   strict/balanced/recall-first,medium 的"交确认"在浏览器 paste 路径无 Ask 通道,
+///   收敛到更严的 strict —— 只收紧方向);
+/// - 损坏 / 版本不识别 / 未知档位 → `"strict"`(镜像 `load_posture` fail-closed 收敛 High;
+///   本层解析独立于 SSOT 实现,字段漂移时最多退化为更严,绝不更松)。
+pub fn posture_to_tier(raw: Option<&str>) -> &'static str {
+    let Some(raw) = raw else {
+        return "balanced"; // 文件缺失 = 未配置 → Low 默认
+    };
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(raw) else {
+        return "strict"; // 损坏 → 收敛最严
+    };
+    if v.get("version").and_then(serde_json::Value::as_u64) != Some(1) {
+        return "strict"; // 版本不识别 → 不按旧语义猜
+    }
+    match v.get("posture").and_then(serde_json::Value::as_str) {
+        Some("low") => "balanced",
+        Some("medium") | Some("high") => "strict",
+        _ => "strict", // 未知档位 → 收敛最严
+    }
+}
+
+/// 姿态源(DI 边界,production-logic-testable):`tier` 返 `None` = 无法定位配置目录
+/// (响应省略 `posture_tier` 字段,扩展 fall 到内建默认),`Some(tier)` = 建议 tier。
+pub trait PostureSource {
+    /// 读取当前系统姿态并映射为扩展建议 tier(`"balanced"` / `"strict"`)。
+    fn tier(&self) -> Option<&'static str>;
+}
+
+/// 生产实现:每请求现读 `<data_local>/Vigil/posture.json`(host 为 Chrome 长驻进程,
+/// 现读避免配置陈旧 —— 与 [`DaemonProbe`] 现读 engine.json 同纪律;文件极小,paste 为
+/// 人手频率,成本可忽略)。
+#[derive(Debug, Default)]
+pub struct FilePostureSource;
+
+impl PostureSource for FilePostureSource {
+    fn tier(&self) -> Option<&'static str> {
+        let path = dirs::data_local_dir().map(|d| d.join("Vigil").join("posture.json"))?;
+        Some(match std::fs::read_to_string(path) {
+            Ok(raw) => posture_to_tier(Some(&raw)),
+            // 缺失 = 未配置 → Low 默认;读失败(权限/是目录等)= 状态不明 → 镜像
+            // load_posture fail-closed 收敛最严。
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => posture_to_tier(None),
+            Err(_) => "strict",
+        })
+    }
+}
+
 /// ML 探针(DI 边界,production-logic-testable):`scan` 返 `None` = 本次不可用
 /// (daemon 缺席/超时/协议错/被禁用/冷却中),`Some(findings)` = 扫描成功(可为空 = 无命中)。
 pub trait MlProbe {
@@ -287,11 +340,12 @@ pub fn run<R: Read, W: Write>(
     ledger: &Ledger,
     session_id: &str,
     ml: &dyn MlProbe,
+    posture: &dyn PostureSource,
 ) -> Result<(), std::io::Error> {
     loop {
         match read_frame(stdin) {
             Ok(Some(payload)) => {
-                handle_one(&payload, stdout, ledger, session_id, ml)?;
+                handle_one(&payload, stdout, ledger, session_id, ml, posture)?;
             }
             Ok(None) => return Ok(()), // 扩展断开
             Err(code) => {
@@ -311,6 +365,7 @@ fn handle_one<W: Write>(
     ledger: &Ledger,
     session_id: &str,
     ml: &dyn MlProbe,
+    posture: &dyn PostureSource,
 ) -> Result<(), std::io::Error> {
     // 解析请求
     let req: BrowserCheckRequest = match serde_json::from_slice(payload) {
@@ -328,6 +383,10 @@ fn handle_one<W: Write>(
         ClassifyOutcome::Response(mut resp) => {
             // daemon ML 增强(fail-closed 纯加性;daemon 缺席时本行为恒等于现状)。
             let engine = ml_augment(&req.text, &mut resp, ml);
+            // Phase 2「策略+观测」:响应附着引擎标识(popup 徽标)+ 姿态建议 tier
+            // (扩展「跟随系统」)。均为仅展示/策略提示的可选字段,不改 action 语义。
+            resp.engine = Some(engine.to_string());
+            resp.posture_tier = posture.tier().map(str::to_string);
             // 审计(metadata only)—— 用 `BrowserAuditMeta` 接口边界编码"不得含 raw text"
             let meta = BrowserAuditMeta {
                 origin: &req.origin,
@@ -690,6 +749,105 @@ mod ml_augment_tests {
         assert!(
             !cd.in_cooldown(t0 + Duration::from_secs(61)),
             "窗口过后自动恢复(daemon 复活可自愈)"
+        );
+    }
+}
+
+#[cfg(test)]
+mod posture_tier_tests {
+    use super::posture_to_tier;
+
+    /// 三档映射 + 缺失默认(Phase 2「策略+观测」):low→balanced;medium/high→strict;
+    /// 缺失 = 未配置 → Low 默认 balanced(load_posture 唯一"更松"分支的镜像)。
+    #[test]
+    fn posture_mapping_matrix() {
+        assert_eq!(posture_to_tier(None), "balanced");
+        assert_eq!(
+            posture_to_tier(Some(r#"{"version":1,"posture":"low"}"#)),
+            "balanced"
+        );
+        assert_eq!(
+            posture_to_tier(Some(r#"{"version":1,"posture":"medium"}"#)),
+            "strict"
+        );
+        assert_eq!(
+            posture_to_tier(Some(r#"{"version":1,"posture":"high"}"#)),
+            "strict"
+        );
+    }
+
+    /// fail-closed 收敛(镜像 hub-cli `load_posture`):损坏 / 版本不识别 / 未知档位 /
+    /// 缺字段 → 一律 strict(宁严不松;SSOT 字段漂移时最多退化为更严)。
+    #[test]
+    fn malformed_and_unknown_fail_closed_to_strict() {
+        assert_eq!(posture_to_tier(Some("not json")), "strict");
+        assert_eq!(
+            posture_to_tier(Some(r#"{"version":2,"posture":"low"}"#)),
+            "strict"
+        );
+        assert_eq!(
+            posture_to_tier(Some(r#"{"version":1,"posture":"paranoid"}"#)),
+            "strict"
+        );
+        assert_eq!(posture_to_tier(Some(r#"{"version":1}"#)), "strict");
+        assert_eq!(posture_to_tier(Some(r#"{"posture":"low"}"#)), "strict");
+        assert_eq!(
+            posture_to_tier(Some(r#"{"version":1,"posture":7}"#)),
+            "strict"
+        );
+    }
+
+    /// 输出闭集守门:本函数只允许产出扩展 tier 闭集的成员(strict/balanced)——
+    /// 扩展侧按闭集校验,任何漂移值会被忽略;此测试保证 host 永不发出会被忽略的值。
+    #[test]
+    fn output_is_within_extension_tier_closed_set() {
+        for raw in [
+            None,
+            Some(r#"{"version":1,"posture":"low"}"#),
+            Some(r#"{"version":1,"posture":"medium"}"#),
+            Some(r#"{"version":1,"posture":"high"}"#),
+            Some("garbage"),
+        ] {
+            let t = posture_to_tier(raw);
+            assert!(
+                t == "balanced" || t == "strict",
+                "posture_to_tier 产出 {t},不在扩展 tier 闭集"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod browser_event_ssot_tests {
+    //! SSOT 漂移守门(feedback「SSOT drift guard」):GUI 的 24h 拦截统计
+    //! (`vigil_audit::Ledger::browser_guard_counts`)按 `BROWSER_GUARD_EVENT_TYPES`
+    //! 常量过滤事件;真实写入点是本 crate `handle_one` 经 `event_type_for` 产出的
+    //! 字面量。两个集合必须**精确相等**(双向,非子集/count),否则新增浏览器事件类型
+    //! 会在统计侧静默丢失(或统计声称覆盖不存在的类型)。
+
+    #[test]
+    fn browser_guard_event_types_exactly_match_event_type_for() {
+        use std::collections::BTreeSet;
+        use vigil_browser::{event_type_for, BrowserEventKind};
+
+        // 写入侧:event_type_for 对全部 BrowserEventKind 变体的产出(新增变体时
+        // 此数组由穷举 match 强制更新)。
+        let emitted: BTreeSet<&str> = [
+            BrowserEventKind::Paste,
+            BrowserEventKind::Input,
+            BrowserEventKind::Submit,
+        ]
+        .into_iter()
+        .map(event_type_for)
+        .collect();
+        // 统计侧:vigil-audit 的过滤常量。
+        let counted: BTreeSet<&str> = vigil_audit::BROWSER_GUARD_EVENT_TYPES
+            .iter()
+            .copied()
+            .collect();
+        assert_eq!(
+            emitted, counted,
+            "browser 事件字面量与 vigil-audit BROWSER_GUARD_EVENT_TYPES 漂移:两侧必须精确相等"
         );
     }
 }

--- a/apps/native-host/src/main.rs
+++ b/apps/native-host/src/main.rs
@@ -146,7 +146,10 @@ fn run_stdio_loop() -> ExitCode {
 
     // daemon ML 探针:engine.json 门控 + 失败冷却;daemon 缺席 → 行为恒等纯硬指纹(fail-closed)。
     let ml = vigil_native_host::DaemonProbe::new();
-    match vigil_native_host::run(&mut stdin, &mut stdout, &ledger, &session_id, &ml) {
+    // 姿态源(Phase 2「策略+观测」):每请求现读 posture.json → 响应附着建议 tier,
+    // 扩展「跟随系统」据此取档;读不到配置目录 → 字段省略,扩展 fall 到内建默认。
+    let posture = vigil_native_host::FilePostureSource;
+    match vigil_native_host::run(&mut stdin, &mut stdout, &ledger, &session_id, &ml, &posture) {
         Ok(()) => ExitCode::SUCCESS,
         Err(_) => ExitCode::from(1),
     }

--- a/apps/native-host/tests/acceptance.rs
+++ b/apps/native-host/tests/acceptance.rs
@@ -18,6 +18,16 @@ use vigil_browser::{
     FindingKind,
 };
 
+/// 固定姿态源(Phase 2):`None` = 配置目录不可得(响应省略 posture_tier),
+/// `Some(tier)` = 固定建议 tier。集成测试不触真实文件系统。
+struct FixedPosture(Option<&'static str>);
+
+impl vigil_native_host::PostureSource for FixedPosture {
+    fn tier(&self) -> Option<&'static str> {
+        self.0
+    }
+}
+
 /// 编码一条 request frame。
 fn encode_request(req: &BrowserCheckRequest) -> Vec<u8> {
     let body = serde_json::to_vec(req).unwrap();
@@ -56,6 +66,7 @@ fn run_once(req: &BrowserCheckRequest) -> (Ledger, String, serde_json::Value) {
         &ledger,
         &sid,
         &vigil_native_host::DisabledMlProbe,
+        &FixedPosture(None),
     )
     .unwrap();
     let frames = decode_responses(&stdout);
@@ -206,6 +217,7 @@ fn oversized_length_prefix_returns_too_large() {
         &ledger,
         &sid,
         &vigil_native_host::DisabledMlProbe,
+        &FixedPosture(None),
     )
     .unwrap();
     let frames = decode_responses(&stdout);
@@ -231,6 +243,7 @@ fn bad_json_payload_returns_bad_json() {
         &ledger,
         &sid,
         &vigil_native_host::DisabledMlProbe,
+        &FixedPosture(None),
     )
     .unwrap();
     let frames = decode_responses(&stdout);
@@ -265,6 +278,7 @@ fn multi_frame_sequence_roundtrip() {
         &ledger,
         &sid,
         &vigil_native_host::DisabledMlProbe,
+        &FixedPosture(None),
     )
     .unwrap();
     let frames = decode_responses(&stdout);
@@ -275,4 +289,37 @@ fn multi_frame_sequence_roundtrip() {
     assert_eq!(r1.action, BrowserAction::Allow);
     assert_eq!(r2.action, BrowserAction::Redact);
     assert_eq!(r3.action, BrowserAction::Block);
+}
+
+/// Phase 2「策略+观测」:响应附着 `engine` + `posture_tier`(姿态源可得时);
+/// 姿态源不可得(None)→ `posture_tier` 字段**整个省略**(skip_serializing_if,
+/// 旧扩展/JS undefined-tolerant),`engine` 恒在(DisabledMlProbe → "hardfp")。
+#[test]
+fn response_carries_engine_and_posture_tier_when_available() {
+    let ledger = Ledger::open_in_memory().unwrap();
+    let sid = ledger.start_session("h", None).unwrap();
+    let req = make_req("hello plain text", "https://chatgpt.com");
+    let mut stdin = Cursor::new(encode_request(&req));
+    let mut stdout: Vec<u8> = Vec::new();
+    vigil_native_host::run(
+        &mut stdin,
+        &mut stdout,
+        &ledger,
+        &sid,
+        &vigil_native_host::DisabledMlProbe,
+        &FixedPosture(Some("strict")),
+    )
+    .unwrap();
+    let frames = decode_responses(&stdout);
+    assert_eq!(frames.len(), 1);
+    assert_eq!(frames[0]["engine"], "hardfp");
+    assert_eq!(frames[0]["posture_tier"], "strict");
+
+    // 姿态源 None → 字段省略(不是 null)。
+    let (_l, _sid, v) = run_once(&req);
+    assert_eq!(v["engine"], "hardfp");
+    assert!(
+        v.get("posture_tier").is_none(),
+        "posture 源不可得时 posture_tier 应整体省略:{v}"
+    );
 }

--- a/crates/vigil-audit/src/ledger.rs
+++ b/crates/vigil-audit/src/ledger.rs
@@ -178,6 +178,30 @@ pub struct ProtectionSummary {
     pub recent: Vec<EventHit>,
 }
 
+/// 浏览器防线(native host)写入的审计事件类型全集(Phase 2「策略+观测」)。
+///
+/// 真实写入点 = `vigil-native-host` `handle_one` 经 `vigil_browser::event_type_for` 产出;
+/// 两侧集合由 native-host 的 `browser_guard_event_types_exactly_match_event_type_for`
+/// 测试做**精确相等**守门(vigil-audit 不依赖 vigil-browser,字面量在此复制;新增
+/// `BrowserEventKind` 变体时该测试强制同步本常量)。
+pub const BROWSER_GUARD_EVENT_TYPES: &[&str] = &[
+    "browser.paste_checked",
+    "browser.input_checked",
+    "browser.submit_checked",
+];
+
+/// [`Ledger::browser_guard_counts`] 的窗口统计(桌面 Protection Overview 浏览器防线卡)。
+/// 纯整数计数,不携带任何事件内容。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct BrowserGuardCounts {
+    /// 窗口内检查总数(三类 browser.* 事件行数)。
+    pub checks: u64,
+    /// 其中 action=block(阻断)。
+    pub blocked: u64,
+    /// 其中 action=redact(脱敏放行)。
+    pub redacted: u64,
+}
+
 /// I08 `list_sessions` 返回的 session 摘要投影。
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SessionSummaryRow {
@@ -986,6 +1010,49 @@ impl Ledger {
             chain_intact,
             recent,
         })
+    }
+
+    /// 浏览器防线(native host)审计事件的窗口统计 → [`BrowserGuardCounts`]
+    /// (Phase 2「策略+观测」:桌面 Protection Overview 浏览器防线卡)。
+    ///
+    /// 过滤 [`BROWSER_GUARD_EVENT_TYPES`] 三类事件且 `created_at >= since_epoch_secs`,
+    /// 逐行解析 payload 的 `action` 归类(block / redact / 其它=放行)。**纯读**;payload
+    /// 本身是 metadata-only(vigil-browser §I-9.1/9.2 白名单,不含原文),解析失败的行
+    /// 只计入 `checks` 不计入动作(不 Err —— 统计卡不因单行畸形而整体失败)。
+    /// 事件量 = 人手 paste 频率 × 窗口(默认 24h),全取到内存逐行解析成本可忽略。
+    pub fn browser_guard_counts(&self, since_epoch_secs: i64) -> Result<BrowserGuardCounts> {
+        let guard = self.conn.lock().map_err(|_| AuditError::LockPoisoned)?;
+        let mut stmt = guard.prepare(
+            "SELECT payload_json FROM events WHERE event_type IN (?1, ?2, ?3) AND created_at >= ?4",
+        )?;
+        let rows = stmt.query_map(
+            rusqlite::params![
+                BROWSER_GUARD_EVENT_TYPES[0],
+                BROWSER_GUARD_EVENT_TYPES[1],
+                BROWSER_GUARD_EVENT_TYPES[2],
+                since_epoch_secs
+            ],
+            |r| r.get::<_, String>(0),
+        )?;
+        let mut counts = BrowserGuardCounts {
+            checks: 0,
+            blocked: 0,
+            redacted: 0,
+        };
+        for payload in rows {
+            let payload = payload?;
+            counts.checks += 1;
+            match serde_json::from_str::<serde_json::Value>(&payload)
+                .ok()
+                .and_then(|v| v.get("action").and_then(|a| a.as_str().map(String::from)))
+                .as_deref()
+            {
+                Some("block") => counts.blocked += 1,
+                Some("redact") => counts.redacted += 1,
+                _ => {}
+            }
+        }
+        Ok(counts)
     }
 
     /// 主动触发 WAL checkpoint(TRUNCATE 模式:尽量缩短 WAL 文件)。

--- a/crates/vigil-audit/src/lib.rs
+++ b/crates/vigil-audit/src/lib.rs
@@ -28,10 +28,11 @@ pub use error::{AuditError, Result};
 #[allow(deprecated)]
 pub use ledger::RESERVED_EVENT_PREFIX;
 pub use ledger::{
-    AppendedEvent, EventDetailRow, EventHit, Ledger, NewRedactionFinding, NewRedactionScan,
-    ProtectionSummary, RedactionFindingRow, RedactionScanRow, ReplayEvent, SessionSummaryRow,
-    ALLOWED_REDACTION_LABELS, EVENT_TYPE_RAW_SECRET_BLOCKED, EVENT_TYPE_SECRET_ALIAS_UNRESOLVED,
-    EVENT_TYPE_TOOL_RESULT_LEAK, RESERVED_EVENT_PREFIXES,
+    AppendedEvent, BrowserGuardCounts, EventDetailRow, EventHit, Ledger, NewRedactionFinding,
+    NewRedactionScan, ProtectionSummary, RedactionFindingRow, RedactionScanRow, ReplayEvent,
+    SessionSummaryRow, ALLOWED_REDACTION_LABELS, BROWSER_GUARD_EVENT_TYPES,
+    EVENT_TYPE_RAW_SECRET_BLOCKED, EVENT_TYPE_SECRET_ALIAS_UNRESOLVED, EVENT_TYPE_TOOL_RESULT_LEAK,
+    RESERVED_EVENT_PREFIXES,
 };
 pub use outbox::{OutboxItem, OutboxKind, OutboxStatus};
 pub use registry::{

--- a/crates/vigil-audit/tests/browser_guard_counts.rs
+++ b/crates/vigil-audit/tests/browser_guard_counts.rs
@@ -1,0 +1,93 @@
+//! `Ledger::browser_guard_counts` 的数据层测试(Phase 2「策略+观测」:桌面
+//! Protection Overview 浏览器防线卡的 24h 窗口统计)。
+//!
+//! 覆盖:三类 browser.* 事件按 payload `action` 归类计数 + 非浏览器噪声不入统计 +
+//! 畸形 payload 只计 checks 不计动作 + 窗口过滤(未来 cutoff → 全零)+ 空账本全零。
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use serde_json::json;
+use vigil_audit::{Ledger, BROWSER_GUARD_EVENT_TYPES};
+
+#[test]
+fn browser_guard_counts_by_action_and_window() {
+    let l = Ledger::open_in_memory().unwrap();
+    let sid = l.start_session("browser_host", None).unwrap();
+
+    // 2 block + 3 redact + 1 allow,分布在三类事件类型上(与 native-host 真实写入同形:
+    // metadata-only payload,action 字段承载动作)。
+    l.append_event(
+        &sid,
+        "browser.paste_checked",
+        &json!({"action":"block","origin":"https://x.com"}),
+        Some("browser.paste_checked origin:https://x.com action:\"block\""),
+    )
+    .unwrap();
+    l.append_event(
+        &sid,
+        "browser.submit_checked",
+        &json!({"action":"block","origin":"https://y.com"}),
+        None,
+    )
+    .unwrap();
+    for _ in 0..3 {
+        l.append_event(
+            &sid,
+            "browser.input_checked",
+            &json!({"action":"redact","origin":"https://z.com"}),
+            None,
+        )
+        .unwrap();
+    }
+    l.append_event(
+        &sid,
+        "browser.paste_checked",
+        &json!({"action":"allow","origin":"https://ok.com"}),
+        None,
+    )
+    .unwrap();
+    // 噪声:非浏览器事件绝不入统计。
+    l.append_event(&sid, "hello.world", &json!({"action":"block"}), None)
+        .unwrap();
+
+    let c = l.browser_guard_counts(0).unwrap();
+    assert_eq!(c.checks, 6, "三类 browser.* 全计,噪声不计");
+    assert_eq!(c.blocked, 2);
+    assert_eq!(c.redacted, 3);
+
+    // 窗口过滤:cutoff 在未来 → 全零(created_at 为写入时刻)。
+    let far_future = 4_102_444_800; // 2100-01-01
+    let none = l.browser_guard_counts(far_future).unwrap();
+    assert_eq!((none.checks, none.blocked, none.redacted), (0, 0, 0));
+}
+
+#[test]
+fn malformed_payload_counts_check_but_no_action() {
+    let l = Ledger::open_in_memory().unwrap();
+    let sid = l.start_session("browser_host", None).unwrap();
+    // payload 无 action 字段 / action 非字符串:计 checks,不计 blocked/redacted,不 Err。
+    l.append_event(&sid, "browser.paste_checked", &json!({"x":1}), None)
+        .unwrap();
+    l.append_event(&sid, "browser.input_checked", &json!({"action":7}), None)
+        .unwrap();
+    let c = l.browser_guard_counts(0).unwrap();
+    assert_eq!((c.checks, c.blocked, c.redacted), (2, 0, 0));
+}
+
+#[test]
+fn empty_ledger_is_all_zero() {
+    let l = Ledger::open_in_memory().unwrap();
+    let c = l.browser_guard_counts(0).unwrap();
+    assert_eq!((c.checks, c.blocked, c.redacted), (0, 0, 0));
+}
+
+/// 常量本身的最小卫生守门:恰 3 类、全 `browser.` 前缀(与写入端的精确集合相等性
+/// 由 native-host 侧 `browser_guard_event_types_exactly_match_event_type_for` 守门,
+/// 那里能同时看到 vigil-browser 与本 crate)。
+#[test]
+fn event_types_const_shape() {
+    assert_eq!(BROWSER_GUARD_EVENT_TYPES.len(), 3);
+    assert!(BROWSER_GUARD_EVENT_TYPES
+        .iter()
+        .all(|t| t.starts_with("browser.")));
+}

--- a/crates/vigil-browser/src/audit.rs
+++ b/crates/vigil-browser/src/audit.rs
@@ -114,6 +114,8 @@ mod tests {
                 _ => None,
             },
             ml_labels: Vec::new(),
+            engine: None,
+            posture_tier: None,
         }
     }
 
@@ -194,6 +196,8 @@ mod tests {
             findings: vec![FindingKind::GithubToken],
             redacted_text: Some("[REDACTED github_token]".into()),
             ml_labels: vec!["private_email".into()],
+            engine: Some("hardfp+ml".into()),
+            posture_tier: Some("balanced".into()),
         };
         let p = build_audit_payload(&meta, &resp);
         let s = serde_json::to_string(&p).unwrap();

--- a/crates/vigil-browser/src/classifier.rs
+++ b/crates/vigil-browser/src/classifier.rs
@@ -96,6 +96,9 @@ pub fn classify(request: &BrowserCheckRequest) -> ClassifyOutcome {
         redacted_text,
         // classify 是纯硬指纹层;ML 标签由 host 层(native-host ml_augment)按 daemon 可用性追加。
         ml_labels: Vec::new(),
+        // engine / posture_tier 同为 host 层(handle_one)按运行时状态附着;分类器不感知。
+        engine: None,
+        posture_tier: None,
     })
 }
 

--- a/crates/vigil-browser/src/protocol.rs
+++ b/crates/vigil-browser/src/protocol.rs
@@ -137,6 +137,18 @@ pub struct BrowserCheckResponse {
     /// 空(`default`,向后兼容 hardfp-only host 的响应)。
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub ml_labels: Vec<String>,
+    /// 参与本次决策的引擎标识(`"hardfp"` / `"hardfp+ml"`,与审计 payload 的 `engine` 同源;
+    /// Phase 2「策略+观测」)。**仅展示层**:popup 引擎态徽标用,不进 tier / action 决策。
+    /// 可选字段只增不改(协议不 bump):旧扩展忽略未知字段;旧 host 缺省 → `None`。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub engine: Option<String>,
+    /// 系统安全姿态(posture.json)映射出的**建议 tier**(`"balanced"` / `"strict"`;
+    /// Phase 2「策略+观测」)。映射(low→balanced、medium/high→strict、损坏→strict)在
+    /// host 侧完成 —— posture 词汇闭集与穷举 match 留在 Rust,扩展只见 tier 值。
+    /// 扩展在「跟随系统」模式(无会话级覆盖)下按此取 tier;值非 tier 闭集成员时扩展
+    /// 忽略(fail 到内建默认)。旧 host 缺省 → `None` = 扩展行为等于现状。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub posture_tier: Option<String>,
 }
 
 /// Core 层错误码(Host 在 framing 层也会用相同 error schema 返扩展)。

--- a/docs/adr/0009-browser-extension-mvp.md
+++ b/docs/adr/0009-browser-extension-mvp.md
@@ -398,3 +398,42 @@ pub enum FindingKind {
 - 后续:Phase 2(posture→tier 统一 + GUI 观测)、Phase 3(setup 编排 + 文档一致性)。
   Chrome Web Store 消费版扩展(0.2.0,纯 JS consumer 模式)已独立上架;本轮 native host
   ML 能力对应其 enterprise 模式的 provider 接缝,接线属 Phase 2+ 产品决策。
+
+## Revised 2026-07-07(Phase 2「策略+观测」移植:posture 下发 + 浏览器防线统计)
+
+自内部实现轮移植(方案承接上一 Revised 段所引 PR 描述的三阶段计划)。
+
+### P2-1. 决策
+
+1. **posture→tier 下发通道 = Response 可选字段**(否决「新增 host 消息」:会新开协议
+   request 形态、且启动时拉取会陈旧):host 每请求现读 `posture.json`(与 engine.json
+   现读同纪律)→ `BrowserCheckResponse.posture_tier`("balanced"|"strict")。逐次新鲜
+   —— 桌面/CLI 切姿态,下一次 paste 即生效;映射闭集与穷举 match 留在 Rust
+   (`posture_to_tier` 纯函数)。
+2. **映射**:缺失→balanced(Low 默认,`load_posture` 唯一"更松"分支的镜像);
+   low→balanced;medium/high→strict(浏览器 paste 路径无 Ask 通道,medium 收敛更严);
+   损坏/坏版本/未知档位→strict(镜像 SSOT fail-closed 收敛 High;漂移只会更严不会更松)。
+3. **扩展消费(0.2.x consumer/enterprise 形态)**:consumer 模式采用固定推荐策略、
+   无用户档位,不消费 `posture_tier`;该字段的消费点是 enterprise 后端策略层
+   (「本机 Vigils 引擎」启用后按系统姿态收紧,后续接线)。原内部 0.1.x 形态的
+   三档跟随语义随 2026-07-06 内外扩展收敛(公开形态为唯一权威)退役。
+4. **观测面**:Response 增 `engine`(与审计 payload 同源;供扩展未来展示实际引擎)+
+   GUI Protection Overview 浏览器防线卡增最近 24h 守门统计
+   (`vigil_audit::Ledger::browser_guard_counts`,payload 仅 metadata,整数计数;
+   注册态判定沿用 `StatusReport::is_registered` 收口)。
+
+### P2-2. 新增守门
+
+- `BROWSER_GUARD_EVENT_TYPES`(vigil-audit,统计侧字面量)与 `event_type_for` 全变体
+  产出(写入侧)**精确集合相等**,由 native-host `browser_event_ssot_tests` 双向守门
+  (vigil-audit 不依赖 vigil-browser,防字面量漂移静默丢统计)。
+- `posture_to_tier` 输出闭集守门(只允许产出扩展 tier 闭集成员)。
+- 协议只加可选字段不 bump:旧扩展×新 host(忽略未知字段)/新扩展×旧 host
+  (字段缺省 → 行为=现状)双向兼容。
+
+### P2-3. 验证
+
+- 远端 `fmt --all --check` / `clippy --workspace --all-targets -- -D warnings` /
+  `test --workspace` 全绿:**1266 passed / 0 failed**(基线 1257,+9:posture_to_tier 3
+  + SSOT 集合守门 1 + browser_guard_counts 4 + acceptance 响应字段 1);
+  前端 vue-tsc + vite build 绿。

--- a/docs/adr/STATUS.md
+++ b/docs/adr/STATUS.md
@@ -666,6 +666,13 @@ ADR 0012 §3.2-§3.7 全实施(commit `b5419b5`):
 - **审查**:hostile sub-agent SOUND(A-G 全 OK,0 Crit/High/Med;3 LOW 非阻断,其一 JS 限长已当场加固);远端 fmt/clippy(-D warnings)/test 全绿 **1270/0**(+10)
 - **评估依据**:见引入 PR 描述(四断裂分析 + 能力增量矩阵 + 三阶段方案);Phase 2/3 后续推进
 
+### ADR 0009 Phase 2「策略+观测」移植(2026-07-07)
+
+- **交付**:posture 下发(host 每请求现读 posture.json → `posture_to_tier` 闭集映射 → `BrowserCheckResponse.posture_tier` 可选字段;`PostureSource` DI trait 镜像 `MlProbe` 惯例)+ Response `engine` 可选字段(与审计 payload 同源)+ Protection Overview 浏览器防线卡增 24h 守门统计(`Ledger::browser_guard_counts`;注册态沿用 `is_registered` 收口)
+- **扩展消费边界**:0.2.x consumer 形态不消费 posture_tier(固定推荐策略);字段留给 enterprise 后端策略层(后续接线)
+- **新守门**:`BROWSER_GUARD_EVENT_TYPES` ↔ `event_type_for` 双向 SSOT 集合相等;posture_to_tier 输出闭集;协议只加可选字段不 bump(双向兼容)
+- **验证**:远端 fmt/clippy(-D warnings)/test 全绿 **1266/0**(基线 1257,+9);vue-tsc+vite build 绿
+
 ## 维护约定
 
 - **每轮迭代 ACCEPT 后**:作者在表格相应行填 "最终状态 / Codex 审查轮次 / 交付测试数",并在"Codex review 关键修复摘要"追加段落


### PR DESCRIPTION
## What

Ports the internal Phase 2 「策略+观测」 line: the native host now propagates the system posture and its engine identity as optional response fields, and the desktop browser-guard card gains real 24h numbers.

- **vigil-browser**: `BrowserCheckResponse.posture_tier` + `engine` optional fields (protocol not bumped; both directions old×new compatible).
- **native-host**: `posture_to_tier` pure mapping — missing→balanced (mirror of the posture SSOT's only lenient branch), low→balanced, medium/high→strict (the paste path has no Ask channel), corrupt/unknown→strict (drift can only tighten); per-request fresh read of posture.json, same discipline as engine.json; `BROWSER_GUARD_EVENT_TYPES` ↔ `event_type_for` bidirectional SSOT set-equality tests.
- **vigil-audit**: `Ledger::browser_guard_counts` windowed stats (metadata-only integer counts, +4 tests).
- **desktop**: the #60 browser-guard line now also shows `Last 24h: N checks · N blocked · N redacted` when the host is registered and active — fed from the existing AppState ledger.

## Extension consumption boundary (deliberate)

The store extension's consumer mode uses the fixed recommended policy and does **not** consume `posture_tier`; the field's consumer is the enterprise backend's policy layer (follow-up wiring on the #58 seam). The internal 0.1.x three-tier 'follow the system' semantics were retired by the 2026-07-06 convergence decision (public 0.2.x shape is the single authority).

## Verification

Remote gates: fmt --check / clippy --workspace --all-targets -D warnings / test --workspace → **1266 passed, 0 failed** (baseline 1257, +9 exactly matching the internal increment); vue-tsc + vite build green.