### PR TITLE
feat(hook): Command Guard file-write persistence detection

### DIFF
--- a/apps/vigil-hub-cli/src/command_guard.rs
+++ b/apps/vigil-hub-cli/src/command_guard.rs
@@ -80,6 +80,67 @@ pub fn classify(command: &str, project_root: Option<&str>) -> Option<CommandRisk
     classify_depth(command, project_root, 0)
 }
 
+/// 文件写入 / 编辑工具的**目标路径**是否命中持久化落点 → [`GuardTier::Dangerous`]。
+///
+/// 这是 [`classify`] 的对称面:hook 只扫 shell command 字符串([`classify`] 走 `command` 字段),
+/// 但**文件写入**(`Write` 的 `{file_path, content}`,无 command 字段)会从旁边绕过。往
+/// shell rc / SSH authorized_keys / cron / systemd / launchd / git-hook 写**任何**内容都是
+/// 可疑持久化(与 shell 侧 `echo >> ~/.bashrc` 判 Dangerous 对称;只看落点不看内容,落点即风险)。
+/// 普通项目文件 → `None`,不误伤日常写码。
+///
+/// # 覆盖边界(external contract,2026-07-06 核实官方文档)
+/// **Claude** `Write`/`Edit` 与 **Gemini** `write_file`/`replace` 均用 `file_path` 字段且触发
+/// PreToolUse —— 本函数覆盖。**Codex** `apply_patch` 当前不可靠触发 PreToolUse(平台限制:
+/// "PreToolUse only supports Bash tool interception")、**Cursor** 只有 shell/MCP hook 无文件
+/// 写入事件 —— 那两家的文件写入防护由 MCP 网关([`vigil_firewall`] `FsWrite`)承担,不在 hook 范围。
+pub fn classify_file_write(file_path: &str) -> Option<CommandRisk> {
+    if is_persistence_write_target(strip_quotes(file_path.trim())) {
+        return Some(CommandRisk {
+            tier: GuardTier::Dangerous,
+            category: GuardCategory::Persistence,
+            detail: "writes to a shell startup file, SSH authorized_keys, a cron/systemd/launchd unit, or a git hook — a persistence foothold that runs code automatically",
+        });
+    }
+    None
+}
+
+/// 写入目标路径是否为持久化落点。**路径锚定**(区别于 shell 侧 [`SENSITIVE_PERSIST_FILE`] 的
+/// 命令子串):rc / 登录 dotfile 按 **basename 精确**匹配 —— 否则 `webpack.profile.json` 这类
+/// 普通文件会被 `.profile` 子串误伤(而 file_path 每次写入都触发,误报面远大于 shell 命令);
+/// 敏感目录 / 文件按足够特异的**路径段**匹配。反斜杠归一为正斜杠 + 小写,兼顾 Windows 与大小写。
+/// 词表与 [`SENSITIVE_PERSIST_FILE`] 对齐(语义不同:那里判「命令里出现」,这里判「路径即写入目标」)。
+fn is_persistence_write_target(path: &str) -> bool {
+    if path.is_empty() {
+        return false;
+    }
+    let norm = path.replace('\\', "/").to_ascii_lowercase();
+    let base = norm.rsplit('/').next().unwrap_or(norm.as_str());
+    const RC_FILES: &[&str] = &[
+        ".bashrc",
+        ".bash_profile",
+        ".bash_login",
+        ".zshrc",
+        ".zprofile",
+        ".zshenv",
+        ".profile",
+    ];
+    if RC_FILES.contains(&base) {
+        return true;
+    }
+    const SENSITIVE_PATHS: &[&str] = &[
+        "/.ssh/authorized_keys",
+        "/etc/cron",
+        "/var/spool/cron",
+        "/etc/systemd/system",
+        "/.config/systemd/user",
+        "/library/launchagents",
+        "/library/launchdaemons",
+        "/.git/hooks/",
+        "start menu/programs/startup",
+    ];
+    SENSITIVE_PATHS.iter().any(|s| norm.contains(s))
+}
+
 /// 嵌套 shell(`bash -c "<script>"`)递归深度上限 —— 防病态深嵌套无界递归。
 const MAX_NEST_DEPTH: u8 = 4;
 
@@ -574,7 +635,7 @@ static WRITE_INDICATOR: Lazy<Regex> =
 
 static SENSITIVE_PERSIST_FILE: Lazy<Regex> = Lazy::new(|| {
     re(
-        r"(?i)(\.bashrc|\.bash_profile|\.bash_login|\.zshrc|\.zprofile|\.zshenv|\.profile|/\.ssh/authorized_keys|/etc/cron|/var/spool/cron|/etc/systemd/system|/\.config/systemd/user|/library/launchagents|/library/launchdaemons|start menu\\programs\\startup)",
+        r"(?i)(\.bashrc|\.bash_profile|\.bash_login|\.zshrc|\.zprofile|\.zshenv|\.profile|/\.ssh/authorized_keys|/etc/cron|/var/spool/cron|/etc/systemd/system|/\.config/systemd/user|/library/launchagents|/library/launchdaemons|\.git/hooks/|start menu\\programs\\startup)",
     )
 });
 
@@ -702,6 +763,54 @@ mod tests {
         assert!(classify("cat ~/.bashrc", Some("/proj")).is_none());
         // crontab -l 是列出(读),不拦。
         assert!(classify("crontab -l", Some("/proj")).is_none());
+    }
+
+    #[test]
+    fn file_write_to_persistence_path_is_dangerous() {
+        // 文件写入工具(Write/write_file)的 file_path 命中持久化落点须判 Dangerous ——
+        // 与 shell 侧 `echo >> ~/.bashrc` 对称(hook 只扫 command 字符串会漏掉文件写入形态)。
+        for p in [
+            "/home/user/.bashrc",
+            "~/.zshrc",
+            "/home/user/.ssh/authorized_keys",
+            "/etc/systemd/system/evil.service",
+            "/Users/x/Library/LaunchAgents/eviltask.plist",
+            "/proj/.git/hooks/pre-commit",
+        ] {
+            let r = classify_file_write(p).unwrap_or_else(|| panic!("expected a hit for `{p}`"));
+            assert_eq!(r.tier, GuardTier::Dangerous, "`{p}` 应判高危");
+            assert_eq!(r.category, GuardCategory::Persistence, "`{p}`");
+        }
+    }
+
+    #[test]
+    fn file_write_to_ordinary_project_path_is_allowed() {
+        // 日常写码 = 普通项目文件,绝不拦(否则每次 Write/Edit 都误报)。
+        for p in [
+            "/proj/src/main.rs",
+            "./README.md",
+            "/proj/config.toml",
+            "notes.txt",
+            "/home/user/project/index.js",
+            "",
+            // `.profile` 作为 infix 的普通文件:basename 锚定后不再误伤(hostile 复审 FP-2)。
+            "/proj/webpack.profile.json",
+            "/proj/report.profile",
+            "/proj/build.profile.js",
+        ] {
+            assert!(classify_file_write(p).is_none(), "`{p}` 不应命中");
+        }
+    }
+
+    #[test]
+    fn shell_write_to_git_hook_is_dangerous() {
+        // `.git/hooks/` 进 SENSITIVE_PERSIST_FILE 后,shell 侧写 git hook 也算持久化。
+        let r = cat(
+            "echo 'export EVIL=1' >> .git/hooks/pre-commit",
+            Some("/proj"),
+        );
+        assert_eq!(r.category, GuardCategory::Persistence);
+        assert_eq!(r.tier, GuardTier::Dangerous);
     }
 
     #[test]

--- a/apps/vigil-hub-cli/src/hook.rs
+++ b/apps/vigil-hub-cli/src/hook.rs
@@ -154,6 +154,13 @@ const CO_APPROVAL_WAIT_SECS_CODEX: u64 = 86_000;
 /// shell 命令执行工具(`Bash`=Claude/Codex;`shell`=Cursor 合成名,为未来扩展预留)。
 const EXECUTION_BOUNDARY_TOOLS: &[&str] = &["Bash", "shell"];
 
+/// 文件写入 / 编辑工具名(归一化后的原始 `tool_name`):其 `file_path` 是**写入目标**,交
+/// [`command_guard::classify_file_write`] 做持久化落点检测。**必须门禁到写工具** —— `Read` 也用
+/// `file_path`、`Grep`/`Glob` 用 `path`,那是**读**操作(读 shell rc 是合法调试),绝不能当持久化
+/// 写拦截(hostile 复审 FP-1)。Claude `Write`/`Edit`/`MultiEdit`、Gemini `write_file`/`replace`
+/// 在此列;Codex `apply_patch` / Cursor 文件编辑不触发 PreToolUse(平台限制,走 MCP 网关)。
+const FILE_WRITE_TOOLS: &[&str] = &["Write", "Edit", "MultiEdit", "write_file", "replace"];
+
 /// 注入 lease 绑定的合成 server id(原生工具无 MCP server 概念)。lease 三元组绑定
 /// (session + server + tool)中此维固定,与 mint/resolve 同值即匹配(本进程即用即弃)。
 const HOOK_INJECT_SERVER_ID: &str = "hook-native";
@@ -615,63 +622,30 @@ pub fn run<R: Read>(args: &HookArgs, stdin: &mut R) -> HookOutcome {
         ));
     }
 
-    // Command Guard(危险命令防线):对**原生** shell/Bash 工具的 command 字段分类破坏性/
-    // 持久化/RCE 动作。这是 hook 侧唯一防线 —— 用户开「允许所有命令」时,agent 因意图漂移/
-    // 注入/参数事故跑出的 `rm -rf ~`、`curl … | sh`、写 crontab 等无 secret 无占位符的命令
-    // 会直接放行。MCP 工具不在此评估(is_mcp 排除:走网关自有 destructive 检测,避免双评估)。
-    // 灾难级恒 Deny(硬地板);高危按姿态 Ask/Deny(见 posture 决策表)。
+    // Command Guard(危险命令防线):对**原生**工具分类破坏性/持久化/RCE 动作。hook 侧唯一防线 ——
+    // 用户开「允许所有命令」时,agent 因意图漂移/注入/参数事故跑出的 `rm -rf ~`、`curl … | sh`、
+    // 写 crontab、或**文件写入 `~/.bashrc`/`authorized_keys`/systemd/git-hook** 等无 secret 无
+    // 占位符的动作会直接放行。两条提取路径(shell 命令优先、文件写入兜底):shell 工具走 `command`
+    // 字段([`command_guard::classify`],项目根 = 事件 cwd 用于「项目外删除」判别);**写/编辑工具**
+    // (`FILE_WRITE_TOOLS` 门禁,排除 `Read`/`Grep` 等读工具 —— 读 shell rc 是合法调试,不是持久化写)
+    // 走 `file_path`([`command_guard::classify_file_write`],持久化落点检测,补 shell-only 的旁路)。
+    // 命中后共用 [`decide_command_risk`] 映射到姿态决策(灾难级恒 Deny 硬地板;高危 Ask/Deny)。
+    // MCP 工具排除(is_mcp:走网关自有 destructive 检测,避免双评估)。
     if !is_mcp {
-        if let Some(cmd) = shell_command_of(&input) {
-            // 项目根 = 事件 cwd(用于「项目外删除」判别;缺失则退化为「命中家目录/系统路径」)。
-            let root = input.cwd.as_deref();
-            if let Some(risk) = command_guard::classify(&cmd, root) {
-                let (rc, kind_label) = match risk.tier {
-                    command_guard::GuardTier::Catastrophic => {
-                        (RiskClass::DestructiveCatastrophic, "catastrophic_command")
-                    }
-                    command_guard::GuardTier::Dangerous => {
-                        (RiskClass::DangerousCommand, "dangerous_command")
-                    }
-                };
-                // 灾难级 posture 无关(恒 Deny);高危才需算有效档(base + session risk 升档)。
-                let profile = match risk.tier {
-                    command_guard::GuardTier::Catastrophic => posture::PostureProfile::Low,
-                    command_guard::GuardTier::Dangerous => {
-                        load_effective_posture(args, input.session_id.as_deref())
-                    }
-                };
-                match posture::decide(profile, rc) {
-                    // 两类在决策表里都不产生 Allow;真出现(未来表变动)保守放行不 brick。
-                    PostureAction::Allow => {}
-                    PostureAction::Deny => {
-                        audit_deny(
-                            args,
-                            &input,
-                            kind_label,
-                            Some(risk.category.audit_tag()),
-                            &serialized,
-                        );
-                        return HookOutcome::Deny(format!(
-                            "Vigil blocked tool `{tool}`: {detail}. This is a FINAL security decision \
-                             (posture: {p}) — retrying, rephrasing, or switching tools will be blocked \
-                             the same way. If this action is genuinely intended, the user can run it \
-                             themselves outside the agent, or lower Vigil's command-guard posture.",
-                            tool = tool_display,
-                            detail = risk.detail,
-                            p = profile.as_str(),
-                        ));
-                    }
-                    PostureAction::Ask => {
-                        return co_approve_command(
-                            args,
-                            &input,
-                            &tool_display,
-                            &serialized,
-                            profile,
-                            risk.detail,
-                        );
-                    }
+        let risk = shell_command_of(&input)
+            .and_then(|cmd| command_guard::classify(&cmd, input.cwd.as_deref()))
+            .or_else(|| {
+                if FILE_WRITE_TOOLS.contains(&input.tool_name.as_str()) {
+                    file_path_of(&input).and_then(|fp| command_guard::classify_file_write(&fp))
+                } else {
+                    None
                 }
+            });
+        if let Some(risk) = risk {
+            if let Some(outcome) =
+                decide_command_risk(risk, args, &input, &tool_display, &serialized)
+            {
+                return outcome;
             }
         }
     }
@@ -789,6 +763,73 @@ fn shell_command_of(input: &NormalizedEvent) -> Option<String> {
         }
     }
     None
+}
+
+/// 文件写入/编辑工具的**目标路径**(Command Guard 文件写入侧翼)。Claude `Write`/`Edit`/`MultiEdit`、
+/// Gemini `write_file`/`replace` 均用 `file_path`。**只读 `file_path`,不兜底 `path`** —— `path` 是
+/// `Grep`/`Glob` 等**读**工具的字段,读取合法不应触发持久化写检测(调用方已用 [`FILE_WRITE_TOOLS`]
+/// 门禁,此处双保险)。MCP 工具由调用方 `is_mcp` 排除。见 [`command_guard::classify_file_write`]。
+fn file_path_of(input: &NormalizedEvent) -> Option<String> {
+    input
+        .tool_input
+        .get("file_path")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+/// Command Guard 命中 → 姿态决策 + 审计 + 拦截。shell 命令与文件写入两路共用(DRY)。
+/// `Some(outcome)` = 终态(Deny/Ask);`None` = 决策表放行(灾难/高危两类实际不产生 Allow,
+/// 防御性 fall-through 不 brick)。deny 说明只带固定 `detail`(非命令/路径原文,不回显不可信输入)。
+fn decide_command_risk(
+    risk: command_guard::CommandRisk,
+    args: &HookArgs,
+    input: &NormalizedEvent,
+    tool_display: &str,
+    serialized: &str,
+) -> Option<HookOutcome> {
+    let (rc, kind_label) = match risk.tier {
+        command_guard::GuardTier::Catastrophic => {
+            (RiskClass::DestructiveCatastrophic, "catastrophic_command")
+        }
+        command_guard::GuardTier::Dangerous => (RiskClass::DangerousCommand, "dangerous_command"),
+    };
+    // 灾难级 posture 无关(恒 Deny);高危才需算有效档(base + session risk 升档)。
+    let profile = match risk.tier {
+        command_guard::GuardTier::Catastrophic => posture::PostureProfile::Low,
+        command_guard::GuardTier::Dangerous => {
+            load_effective_posture(args, input.session_id.as_deref())
+        }
+    };
+    match posture::decide(profile, rc) {
+        PostureAction::Allow => None,
+        PostureAction::Deny => {
+            audit_deny(
+                args,
+                input,
+                kind_label,
+                Some(risk.category.audit_tag()),
+                serialized,
+            );
+            Some(HookOutcome::Deny(format!(
+                "Vigil blocked tool `{tool}`: {detail}. This is a FINAL security decision \
+                 (posture: {p}) — retrying, rephrasing, or switching tools will be blocked \
+                 the same way. If this action is genuinely intended, the user can run it \
+                 themselves outside the agent, or lower Vigil's command-guard posture.",
+                tool = tool_display,
+                detail = risk.detail,
+                p = profile.as_str(),
+            )))
+        }
+        PostureAction::Ask => Some(co_approve_command(
+            args,
+            input,
+            tool_display,
+            serialized,
+            profile,
+            risk.detail,
+        )),
+    }
 }
 
 /// 算有效姿态档(磁盘 base 档 + session risk 升档;读失败 fail-closed 维持 base)。
@@ -2827,6 +2868,92 @@ mod tests {
             "tool_input": { "command": "rm -rf ~" }
         }));
         assert_eq!(out, HookOutcome::Allow, "MCP 工具 hook 侧不评估命令守卫");
+    }
+
+    #[test]
+    fn command_guard_file_write_to_bashrc_denied_at_high() {
+        // 文件写入旁路(补 shell-only):Write 到 ~/.bashrc(持久化落点)= Dangerous;High 档 Deny。
+        // content 无 secret,证明拦截来自 file_path 持久化判定(非 secret 扫描)。
+        let out = run_json_posture(
+            json!({
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Write",
+                "tool_input": { "file_path": "/home/user/.bashrc", "content": "export PATH=/x\n" }
+            }),
+            CliKind::Claude,
+            Some(PostureProfile::High),
+        );
+        assert!(
+            matches!(out, HookOutcome::Deny(_)),
+            "写 ~/.bashrc High 档应 Deny"
+        );
+    }
+
+    #[test]
+    fn command_guard_file_write_to_authkeys_asks_at_default() {
+        // 默认 Low + 无 ledger:文件写入持久化落点走 Ask(「允许所有」下的 backstop)。
+        let out = run_json(json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Write",
+            "tool_input": {
+                "file_path": "/home/user/.ssh/authorized_keys",
+                "content": "ssh-ed25519 AAAA\n"
+            }
+        }));
+        assert!(
+            matches!(out, HookOutcome::Ask(_)),
+            "写 authorized_keys 默认档应 Ask"
+        );
+    }
+
+    #[test]
+    fn command_guard_gemini_write_file_to_systemd_denied_at_high() {
+        // 跨 agent:Gemini `write_file`(同 `file_path` 字段)到 systemd unit → 同样命中。
+        let out = run_json_posture(
+            json!({
+                "hook_event_name": "PreToolUse",
+                "tool_name": "write_file",
+                "tool_input": {
+                    "file_path": "/etc/systemd/system/evil.service",
+                    "content": "[Service]\n"
+                }
+            }),
+            CliKind::Gemini,
+            Some(PostureProfile::High),
+        );
+        assert!(
+            matches!(out, HookOutcome::Deny(_)),
+            "Gemini write_file 写 systemd 应 Deny"
+        );
+    }
+
+    #[test]
+    fn command_guard_ordinary_file_write_allowed() {
+        // 日常写码 = 普通项目文件,绝不拦(否则每次 Write/Edit 都误报)。
+        let out = run_json(json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Write",
+            "tool_input": { "file_path": "/proj/src/main.rs", "content": "fn main() {}" }
+        }));
+        assert_eq!(out, HookOutcome::Allow, "普通项目文件写入应放行");
+    }
+
+    #[test]
+    fn command_guard_read_of_sensitive_path_not_flagged() {
+        // hostile 复审 FP-1:`Read`(也用 file_path)/`Grep`(用 path)读 shell rc 是合法调试,
+        // 绝不能当持久化写拦截 —— FILE_WRITE_TOOLS 门禁 + file_path_of 只读 file_path 双保险。
+        let read = run_json(json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Read",
+            "tool_input": { "file_path": "/home/user/.bashrc" }
+        }));
+        assert_eq!(read, HookOutcome::Allow, "Read ~/.bashrc 是读操作,不该拦");
+        let grep = run_json(json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Grep",
+            "tool_input": { "path": "/home/user/.zshrc", "pattern": "alias" }
+        }));
+        assert_eq!(grep, HookOutcome::Allow, "Grep ~/.zshrc 是读操作,不该拦");
     }
 
     #[test]


### PR DESCRIPTION
## What

Extends Command Guard beyond shell command strings to close the **file-write persistence bypass**: a write/edit tool whose target path lands on a persistence foothold (shell rc, SSH `authorized_keys`, cron/systemd/launchd unit, git hook) is now classified **Dangerous** — symmetric with the shell-side `echo >> ~/.bashrc`.

Previously the hook only inspected shell `command` strings, so writing to `~/.bashrc` via the agent's `Write` tool (no `command` field) sailed straight through. This is exactly the weak-LLM / allow-all threat model the guard targets, reachable via an equally-available path.

## How

- **command_guard.rs**: `classify_file_write(file_path)` with **basename-anchored** matching (avoids `.profile` infix false positives on ordinary files like `webpack.profile.json`); `.git/hooks/` also added to the shell-side regex.
- **hook.rs**: extracted `decide_command_risk` shared by the shell and file-write paths (**zero behavioral drift** — verified line-by-line); `FILE_WRITE_TOOLS` gate + `file_path_of` reads only `file_path`.

## Coverage (verified against official docs)

Claude `Write`/`Edit`/`MultiEdit` + Gemini `write_file`/`replace` (both use `file_path`, both fire PreToolUse). Codex `apply_patch` / Cursor file edits **do not fire a hook** (platform limitation) — those go through the MCP gateway (`FsWrite`).

## Hardening (hostile review)

An adversarial review caught and fixed two real defects before this PR:
- **FP-1**: no tool-name gate → `Read` (also uses `file_path`) / `Grep`/`Glob` (use `path`) reading shell rc were mis-flagged as persistence **writes** (Ask on Claude, hard **Deny** on Gemini/Codex, with a wrong message). Fixed with `FILE_WRITE_TOOLS` gate + dropping the `path` fallback.
- **FP-2**: unanchored `.profile` substring over-matched ordinary files. Fixed with basename anchoring (without touching the shared command regex).

## Tests

6 new tests including FP-1 and FP-2 regressions. Full workspace `test` + `clippy --all-targets -D warnings` + `fmt --check` green on the internal build host (identical code); public-repo rustfmt verified against this repo's `rustfmt.toml`.