### PR TITLE
feat(extension): intervention chain fixes + posture-aware pipeline + branded UX (parity port)

### DIFF
--- a/extensions/chrome-mv3/background.js
+++ b/extensions/chrome-mv3/background.js
@@ -44,6 +44,22 @@ let currentMode = MODE_DEFAULT;
 let currentEnterpriseBackend = ENTERPRISE_BACKEND_DEFAULT;
 /** Native Host provider 单例(port 惰性建立,断连自愈;仅 backend=native_host 时被使用)。 */
 let nativeHostProvider = null;
+// Phase 2「策略+观测」观测缓存:最近一次本机引擎回报的姿态档 / 引擎标识(闭集校验后
+// 缓存;仅展示用 —— options 企业状态行 / popup 企业标注,不参与任何决策路径,决策端
+// 的姿态升级在 scanner-pipeline 逐次用响应自带值完成)。
+/** @type {string|null} */
+let lastPostureTier = null;
+/** @type {string|null} */
+let lastEngine = null;
+function cacheHostObservability(result) {
+    if (!result || typeof result !== "object") return;
+    if (result.posture_tier === "balanced" || result.posture_tier === "strict") {
+        lastPostureTier = result.posture_tier;
+    }
+    if (result.engine === "hardfp" || result.engine === "hardfp+ml") {
+        lastEngine = result.engine;
+    }
+}
 function getNativeHostProvider() {
     if (nativeHostProvider === null) {
         nativeHostProvider = createNativeHostProvider();
@@ -472,15 +488,23 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
                     },
                 ))
                     .then((resp) => {
-                        recordFinding({
-                            ts: Date.now(),
-                            origin: msg.origin || "?",
-                            event_kind: msg.event_kind || "?",
-                            action: resp.action,
-                            findings: (resp.findings || []).map((finding) =>
-                                typeof finding === "string" ? finding : finding.label || finding.kind,
-                            ),
-                        });
+                        cacheHostObservability(resp);
+                        // 只把**风险**事件(命中脱敏 / 阻断)记入事件列表。allow(未见风险)
+                        // 不入列 —— 否则简单文本的正常放行会被 popup 显示成「检测到风险内容」
+                        // (用户报告的误报:即使输入简单文本事件中心也报风险)。
+                        if (resp.action !== "allow") {
+                            recordFinding({
+                                ts: Date.now(),
+                                origin: msg.origin || "?",
+                                event_kind: msg.event_kind || "?",
+                                action: resp.action,
+                                findings: (resp.findings || []).map((finding) =>
+                                    typeof finding === "string"
+                                        ? finding
+                                        : finding.label || finding.kind,
+                                ),
+                            });
+                        }
                         sendResponse(resp);
                     });
             })
@@ -584,6 +608,9 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         sendResponse({
             backend: currentEnterpriseBackend,
             values: ENTERPRISE_BACKEND_VALUES.slice(),
+            // 观测缓存(null = 尚无本机引擎回报):options 状态行 / popup 标注用。
+            posture_tier: lastPostureTier,
+            engine: lastEngine,
         });
         return false;
     }
@@ -610,7 +637,17 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
                 event_kind: "paste",
                 text: "vigils native host connection probe",
             })
-            .then((result) => sendResponse({ ok: true, action: result.action }))
+            .then((result) => {
+                // 探测成功即缓存姿态/引擎 —— 启用瞬间 options 就能显示当前姿态档,
+                // 不必等首次真实检查。
+                cacheHostObservability(result);
+                sendResponse({
+                    ok: true,
+                    action: result.action,
+                    posture_tier: lastPostureTier,
+                    engine: lastEngine,
+                });
+            })
             .catch((err) =>
                 sendResponse({
                     ok: false,

--- a/extensions/chrome-mv3/content-script.js
+++ b/extensions/chrome-mv3/content-script.js
@@ -41,8 +41,24 @@
     globalThis.__vigilBrowserGuardLoaded = true;
     globalThis.__vigilBrowserGuardDisabled = false;
 
+    // 构建标记(纯版本字符串,无任何用户数据)——写到页面根元素的 data 属性,供在
+    // Console 用 `document.documentElement.dataset.vigilBuild` 一眼确认「装的是不是最新版」。
+    // 排查用户报告时区分「代码 bug」与「装的是旧版」的关键锚点。改动内联守门逻辑时递增。
+    const VIGIL_BUILD = "2026-07-07-inline-ux-3";
+    try {
+        document.documentElement.setAttribute("data-vigil-build", VIGIL_BUILD);
+    } catch (_) {
+        /* documentElement 尚不可用时忽略(document_start 极早期);不影响守门 */
+    }
+
     const ORIGIN = location.origin;
     const INPUT_DEBOUNCE_MS = 700;
+    // 防抖最长等待:真实富文本框架(ProseMirror / Lexical / React 受控组件)在用户输入后
+    // 会**持续派发 input 事件**(重渲染心跳 / 协作光标 / IME),间隔可能 < 防抖窗口,把
+    // 700ms 防抖 timer 无限 reset → 永不 fire → 手动输入永不被检查(用户报告的「检测到
+    // 却不提醒」的真根因:input 根本没查,事件列表的记录来自粘贴路径)。maxWait 保证:自
+    // 首次未决检查起超过此上限,不再推迟,让已排定的检查 fire。
+    const INPUT_MAX_WAIT_MS = 1200;
 
     function isGuardDisabled() {
         return globalThis.__vigilBrowserGuardDisabled === true;
@@ -178,11 +194,6 @@
         return labels[kind] || String(kind || "未知风险");
     }
 
-    function primaryFindingLabel(findings) {
-        const first = findings && findings.length > 0 ? findings[0] : null;
-        return findingLabel(first || "风险内容");
-    }
-
     function clampNumber(value, min, max) {
         return Math.max(min, Math.min(value, max));
     }
@@ -271,31 +282,95 @@
         }
     }
 
-    function mountPromptBase(title, findings, anchor) {
+    // ── 内联品牌图标(SVG 用 createElementNS 构建,不用 innerHTML;content script 隔离
+    //    世界不受页面 CSP 影响)。Aegis 神盾是 Vigil 的品牌符号。──
+    const SVG_NS = "http://www.w3.org/2000/svg";
+    function svgEl(tag, attrs) {
+        const el = document.createElementNS(SVG_NS, tag);
+        for (const k in attrs) el.setAttribute(k, attrs[k]);
+        return el;
+    }
+    function promptAccent(tone) {
+        return tone === "block" ? "#ef4444" : "#f59e0b";
+    }
+    function shieldIcon(color, kind /* "warn" | "block" */) {
+        const svg = svgEl("svg", { width: "18", height: "18", viewBox: "0 0 24 24", fill: "none" });
+        svg.style.flex = "0 0 auto";
+        svg.appendChild(
+            svgEl("path", {
+                d: "M12 2.5l6.4 2.8v5.3c0 4.2-2.7 7.9-6.4 9.4-3.7-1.5-6.4-5.2-6.4-9.4V5.3L12 2.5z",
+                fill: color,
+                "fill-opacity": "0.16",
+                stroke: color,
+                "stroke-width": "1.5",
+                "stroke-linejoin": "round",
+            }),
+        );
+        if (kind === "block") {
+            svg.appendChild(
+                svgEl("path", { d: "M9.6 9.6l4.8 4.8M14.4 9.6l-4.8 4.8", stroke: color, "stroke-width": "1.8", "stroke-linecap": "round" }),
+            );
+        } else {
+            svg.appendChild(svgEl("path", { d: "M12 8v4.3", stroke: color, "stroke-width": "1.8", "stroke-linecap": "round" }));
+            svg.appendChild(svgEl("circle", { cx: "12", cy: "15.4", r: "0.95", fill: color }));
+        }
+        return svg;
+    }
+    function lockIcon() {
+        const svg = svgEl("svg", { width: "12", height: "12", viewBox: "0 0 24 24", fill: "none" });
+        svg.style.flex = "0 0 auto";
+        svg.style.opacity = "0.85";
+        svg.appendChild(svgEl("rect", { x: "5", y: "10.5", width: "14", height: "9.5", rx: "2", fill: "currentColor", "fill-opacity": "0.14", stroke: "currentColor", "stroke-width": "1.6" }));
+        svg.appendChild(svgEl("path", { d: "M8 10.5V7.8a4 4 0 018 0v2.7", stroke: "currentColor", "stroke-width": "1.6", "stroke-linecap": "round" }));
+        return svg;
+    }
+    function findingChip(label, tone /* "risk" | "block" */) {
+        const chip = document.createElement("span");
+        chip.textContent = label;
+        const isBlock = tone === "block";
+        Object.assign(chip.style, {
+            display: "inline-block",
+            padding: "2px 9px",
+            borderRadius: "999px",
+            fontSize: "11px",
+            fontWeight: "650",
+            lineHeight: "1.6",
+            background: isBlock ? "var(--vigil-chip-block-bg)" : "var(--vigil-chip-bg)",
+            color: isBlock ? "var(--vigil-chip-block-fg)" : "var(--vigil-chip-fg)",
+            border: "1px solid " + (isBlock ? "var(--vigil-chip-block-border)" : "var(--vigil-chip-border)"),
+            whiteSpace: "nowrap",
+        });
+        return chip;
+    }
+
+    function mountPromptBase(title, subtitle, findings, anchor, tone /* "risk" | "block" */) {
         closeSafePrompt();
         closeRiskPrompt();
         const parent = document.body || document.documentElement;
         if (!parent) return null;
+        const accent = promptAccent(tone);
 
         const box = document.createElement("div");
         box.setAttribute("data-vigil-risk-prompt", "");
+        box.setAttribute("data-vigil-tone", tone || "risk");
         box.setAttribute("role", "dialog");
         box.setAttribute("aria-live", "polite");
         Object.assign(box.style, {
             position: "fixed",
             zIndex: "2147483647",
-            width: "min(300px, calc(100vw - 32px))",
-            padding: "14px",
-            borderRadius: "14px",
+            width: "min(320px, calc(100vw - 32px))",
+            padding: "15px 16px 14px",
+            borderRadius: "16px",
+            borderTop: `2.5px solid ${accent}`,
             background: "var(--vigil-prompt-bg)",
             color: "var(--vigil-prompt-fg)",
             boxShadow: "var(--vigil-prompt-shadow)",
-            fontFamily: "system-ui, -apple-system, sans-serif",
+            fontFamily: "system-ui, -apple-system, 'Segoe UI', sans-serif",
             fontSize: "13px",
-            lineHeight: "1.45",
+            lineHeight: "1.5",
             border: "1px solid var(--vigil-prompt-border)",
             boxSizing: "border-box",
-            animation: "vigil-prompt-in 0.25s cubic-bezier(0.4, 0, 0.2, 1) forwards, vigil-prompt-pulse 1.8s ease-in-out 0.3s 1",
+            animation: "vigil-prompt-in 0.28s cubic-bezier(0.34, 1.4, 0.5, 1) forwards",
             transition: "opacity 0.2s ease, transform 0.2s ease",
         });
 
@@ -310,30 +385,53 @@
         });
         box.appendChild(arrow);
 
-        const heading = document.createElement("div");
-        heading.style.fontWeight = "750";
-        heading.style.marginBottom = "6px";
-        heading.style.fontSize = "13px";
-        heading.textContent = title;
-        box.appendChild(heading);
+        // 标题行:盾图标 + 标题
+        const head = document.createElement("div");
+        Object.assign(head.style, { display: "flex", alignItems: "center", gap: "8px" });
+        head.appendChild(shieldIcon(accent, tone === "block" ? "block" : "warn"));
+        const titleEl = document.createElement("div");
+        titleEl.style.fontWeight = "750";
+        titleEl.style.fontSize = "13.5px";
+        titleEl.textContent = title;
+        head.appendChild(titleEl);
+        box.appendChild(head);
 
+        // finding chips(去重、最多 4 个;类别名,无原文)
+        const kinds = Array.isArray(findings) ? findings : [];
+        if (kinds.length > 0) {
+            const chipRow = document.createElement("div");
+            Object.assign(chipRow.style, { display: "flex", flexWrap: "wrap", gap: "5px", marginTop: "9px" });
+            const labels = [...new Set(kinds.map((f) => findingLabel(f)))].slice(0, 4);
+            for (const l of labels) chipRow.appendChild(findingChip(l, tone));
+            box.appendChild(chipRow);
+        }
+
+        // 副文案
         const body = document.createElement("div");
         body.style.color = "var(--vigil-prompt-muted)";
-        body.textContent = "建议先脱敏再发送。";
+        body.style.marginTop = "10px";
+        body.textContent = subtitle;
         box.appendChild(body);
 
+        // 隐私保证:锁图标 + 文案
         const privacy = document.createElement("div");
-        privacy.style.marginTop = "6px";
-        privacy.style.color = "var(--vigil-prompt-muted)";
-        privacy.style.opacity = "0.7";
-        privacy.textContent = "原文未离开你的浏览器。";
+        Object.assign(privacy.style, {
+            display: "flex",
+            alignItems: "center",
+            gap: "5px",
+            marginTop: "8px",
+            color: "var(--vigil-prompt-muted)",
+            opacity: "0.9",
+            fontSize: "12px",
+        });
+        privacy.appendChild(lockIcon());
+        const privacyText = document.createElement("span");
+        privacyText.textContent = "原文从未离开你的浏览器";
+        privacy.appendChild(privacyText);
         box.appendChild(privacy);
 
         const actions = document.createElement("div");
-        actions.style.display = "flex";
-        actions.style.gap = "8px";
-        actions.style.marginTop = "14px";
-        actions.style.justifyContent = "flex-end";
+        Object.assign(actions.style, { display: "flex", gap: "8px", marginTop: "14px", justifyContent: "flex-end" });
         box.appendChild(actions);
 
         parent.appendChild(box);
@@ -350,11 +448,12 @@
         btn.textContent = label;
         Object.assign(btn.style, {
             border: "1px solid transparent",
-            borderRadius: "8px",
-            padding: "7px 12px",
+            borderRadius: "9px",
+            padding: "8px 14px",
             cursor: "pointer",
             fontWeight: "700",
-            fontSize: "12px",
+            fontSize: "12.5px",
+            letterSpacing: "0.2px",
             transition: "background 0.15s ease, border-color 0.15s ease, transform 0.1s ease, box-shadow 0.15s ease, filter 0.15s ease",
         });
         if (tone === "primary") {
@@ -393,23 +492,35 @@
 
     function showRiskPrompt(response, anchor, onRedact) {
         const findings = response.findings || [];
-        const actions = mountPromptBase(`检测到 ${primaryFindingLabel(findings)}`, findings, anchor);
+        const actions = mountPromptBase(
+            "检测到敏感内容",
+            "脱敏后即可安全发送，密钥会替换为占位符。",
+            findings,
+            anchor,
+            "risk",
+        );
         if (!actions) return;
         const redactBtn = promptButton("脱敏后继续", "primary");
         redactBtn.addEventListener("click", () => {
             closeRiskPrompt();
             onRedact(response.redacted_text || "");
         });
-        const blockBtn = promptButton("阻断", "secondary");
+        const blockBtn = promptButton("取消", "secondary");
         blockBtn.addEventListener("click", closeRiskPrompt);
         actions.append(redactBtn, blockBtn);
     }
 
     function showBlockPrompt(response, anchor) {
         const findings = response.findings || [];
-        const actions = mountPromptBase(`已阻断 ${primaryFindingLabel(findings)}`, findings, anchor);
+        const actions = mountPromptBase(
+            "已拦截高危内容",
+            "此内容无法安全脱敏，已为你阻止发送。",
+            findings,
+            anchor,
+            "block",
+        );
         if (!actions) return;
-        const closeBtn = promptButton("关闭", "secondary");
+        const closeBtn = promptButton("知道了", "secondary");
         closeBtn.addEventListener("click", closeRiskPrompt);
         actions.appendChild(closeBtn);
     }
@@ -519,15 +630,10 @@
             "  from { opacity: 1; transform: translateX(0) translateY(0); }",
             "  to   { opacity: 0; transform: translateX(-12px) translateY(4px); }",
             "}",
-            /* prompt slide-in */
+            /* prompt spring-in(轻微回弹,配合 cubic-bezier(0.34,1.4,0.5,1)) */
             "@keyframes vigil-prompt-in {",
-            "  from { opacity: 0; transform: translateY(10px) scale(0.97); }",
+            "  from { opacity: 0; transform: translateY(12px) scale(0.94); }",
             "  to   { opacity: 1; transform: translateY(0) scale(1); }",
-            "}",
-            /* prompt arrow pulse for attention */
-            "@keyframes vigil-prompt-pulse {",
-            "  0%, 100% { box-shadow: 0 0 0 0 rgba(245, 158, 11, 0.35); }",
-            "  50%  { box-shadow: 0 0 0 6px rgba(245, 158, 11, 0); }",
             "}",
             /* shared CSS variables */
             ":root {",
@@ -546,6 +652,12 @@
             "  --vigil-btn-secondary-fg: " + (isDark ? "#e2e8f0" : "#44403c") + ";",
             "  --vigil-btn-secondary-border: " + (isDark ? "rgba(255,255,255,0.12)" : "#d6d3d1") + ";",
             "  --vigil-safe-bg: " + (isDark ? "rgba(245, 158, 11, 0.10)" : "rgba(255, 251, 235, 0.92)") + ";",
+            "  --vigil-chip-bg: " + (isDark ? "rgba(245, 158, 11, 0.18)" : "rgba(245, 158, 11, 0.12)") + ";",
+            "  --vigil-chip-fg: " + (isDark ? "#fcd34d" : "#b45309") + ";",
+            "  --vigil-chip-border: " + (isDark ? "rgba(245, 158, 11, 0.40)" : "rgba(245, 158, 11, 0.32)") + ";",
+            "  --vigil-chip-block-bg: " + (isDark ? "rgba(239, 68, 68, 0.18)" : "rgba(239, 68, 68, 0.12)") + ";",
+            "  --vigil-chip-block-fg: " + (isDark ? "#fca5a5" : "#b91c1c") + ";",
+            "  --vigil-chip-block-border: " + (isDark ? "rgba(239, 68, 68, 0.40)" : "rgba(239, 68, 68, 0.32)") + ";",
             "}",
         ].join("\n");
         parent.appendChild(vigilStyleEl);
@@ -1300,11 +1412,18 @@
             timer: 0,
             lastText: "",
             lastWritten: null,
+            firstAt: 0,
         };
         // Codex review NEEDS-FIX:仅当全文 === 扩展上次写入的**确切值**才跳过(防循环)。
         // **不**用包含式 redaction 标记匹配 —— 否则用户在普通文本里手打 `[REDACTED ...]`
         // 即可诱导跳过分类,绕过守门。绝不信任用户控制的文本内容。
         if (text === prev.lastWritten) return;
+
+        // maxWait:自首次未决检查起超过上限,不再 reset,让已排定的 timer fire(防框架
+        // 持续派发 input 把防抖饿死)。用 Date.now() 仅作 UI 节流基线,不涉安全 replay。
+        const now = Date.now();
+        const firstAt = prev.firstAt || now;
+        if (prev.timer && now - firstAt >= INPUT_MAX_WAIT_MS) return;
 
         if (prev.timer) clearTimeout(prev.timer);
         const next = {
@@ -1312,23 +1431,34 @@
             timer: 0,
             lastText: text,
             lastWritten: prev.lastWritten,
+            firstAt,
         };
         next.timer = setTimeout(async () => {
             if (isGuardDisabled()) return;
             const current = inputChecks.get(target);
             if (!current || current.seq !== next.seq) return;
+            // 本轮检查启动 —— 重置 maxWait 基线(下一轮从下次输入重新计)。
+            current.firstAt = 0;
             const ad = adaptTarget(target);
             if (!ad) return;
+            // 富文本框架(ProseMirror 类,ChatGPT/DeepSeek 等站点编辑器)会在 input 后异步
+            // normalize 文本(零宽字符/占位节点/重排)。若此处要求「与事件时刻文本严格一致」,
+            // 真实站点的手动输入检查会被恒静默吞掉(用户可见症状:粘贴弹卡、手动输入不弹)。
+            // 停顿窗口内的**用户后续输入**已由 seq+clearTimeout 取消本次 fire —— 能走到这里
+            // 即用户已停顿;以 fire 时刻的**当前文本**为检查基准,框架 normalize 不取消检查。
+            // 自写跳过(防 redact 写回→input→再检查循环)仍按精确匹配守住,安全红线不动。
             const latest = ad.getText();
-            if (!latest || latest !== next.lastText) return;
+            if (!latest) return;
+            if (latest === current.lastWritten) return;
 
             const resp = await callBackground("input", latest);
-            const after = inputChecks.get(target);
-            if (!after || after.seq !== next.seq) return;
-            const latestAdapter = adaptTarget(target);
-            if (!latestAdapter) return;
-            const latestAgain = latestAdapter.getText();
-            if (latestAgain !== latest) return;
+            // 弹卡**无条件**基于 SW 判定 —— 真实站点数据(ChatGPT ProseMirror)证实:富文本
+            // 框架在检查往返期间会 re-render 并**派发额外 input 事件**,使排程序号递增 /
+            // normalize 文本。旧实现在此比较「往返后序号 vs 送检时序号」(以及更早的按
+            // 文本严格相等)→ 往返期间任何框架活动都会让弹卡被静默放弃(用户报告的「守护环
+            // 在、检测到、却不弹卡」)。SW 已判定有风险,弹卡是纯提示,必须呈现。用户若真在
+            // 往返期间续写,新排程会另弹一次(showRiskPrompt 幂等替换旧卡);真正的 TOCTOU
+            // 只在**写回**时收口(recheck 当前文本)。
 
             if (resp.action === "allow") {
                 if (target instanceof HTMLElement) setInputVigilState(target, "guarded");
@@ -1338,21 +1468,40 @@
                 resp.action === "confirm_redact" &&
                 typeof resp.redacted_text === "string"
             ) {
-                const safeText = toDisplayRedactedText(resp.redacted_text);
-                showRiskPrompt(resp, target, () => {
+                showRiskPrompt(resp, target, async () => {
+                    // 写回前对**当前**输入框文本重新脱敏 —— 写回的永远是当前内容的脱敏版,
+                    // 消除 TOCTOU(框架 normalize / 用户在弹卡期间续写都安全:不会用过时的
+                    // 脱敏版覆盖新内容,也不会因框架微调而拒绝写回)。
                     const currentAdapter = adaptTarget(target);
                     if (!currentAdapter) return;
-                    if (currentAdapter.getText() !== latestAgain) {
-                        showToast("Vigils: 输入内容已变化,请重新触发安全检查。", "warn");
-                        return;
+                    const currentText = currentAdapter.getText();
+                    if (!currentText) return;
+                    const recheck = await callBackground("input", currentText);
+                    if (
+                        recheck.action === "confirm_redact" &&
+                        typeof recheck.redacted_text === "string"
+                    ) {
+                        writeFieldByExtension(
+                            target,
+                            currentAdapter,
+                            toDisplayRedactedText(recheck.redacted_text),
+                        );
+                        if (target instanceof HTMLElement) setInputVigilState(target, "guarded");
+                        showToast("Vigils: 已脱敏后写入", "info");
+                    } else if (recheck.action === "allow") {
+                        if (target instanceof HTMLElement) setInputVigilState(target, "guarded");
+                        showToast("Vigils: 当前内容已安全", "info");
+                    } else {
+                        writeFieldByExtension(target, currentAdapter, "");
+                        if (target instanceof HTMLElement) setInputVigilState(target, "block");
+                        showToast("Vigils: 含高危密钥,已清除", "warn");
                     }
-                    writeFieldByExtension(target, currentAdapter, safeText);
-                    showToast("Vigils: 已脱敏后写入", "info");
                 });
                 return;
             }
 
-            writeFieldByExtension(target, latestAdapter, "");
+            const blockAdapter = adaptTarget(target);
+            if (blockAdapter) writeFieldByExtension(target, blockAdapter, "");
             if (target instanceof HTMLElement) setInputVigilState(target, "block");
             showBlockPrompt(resp, target);
         }, INPUT_DEBOUNCE_MS);
@@ -1447,18 +1596,19 @@
                 typeof resp.redacted_text === "string"
             ) {
                 showRiskPrompt(resp, target, (redactedText) => {
+                    // 写回脱敏后的**粘贴文本**(不含敏感)到当前光标处。**不**再要求「框内容 ===
+                    // 粘贴时刻快照」—— 富文本框架在弹卡期间 normalize 会让精确相等失败,导致
+                    // 脱敏版被拒绝写入(用户报告:多次粘贴不叠加、后续粘贴无结果)。脱敏文本插到
+                    // 任何位置都安全,故容忍框架微调,只在当前选区插入(保留框内既有内容 → 叠加)。
                     const currentAdapter = adaptTarget(target);
                     if (!currentAdapter) return;
-                    if (pasteSnapshot && currentAdapter.getText() !== pasteSnapshot.text) {
-                        showToast("Vigils: 输入内容已变化,请重新粘贴安全版本。", "warn");
-                        return;
+                    const safe = toDisplayRedactedText(redactedText);
+                    if (typeof currentAdapter.insertText === "function") {
+                        currentAdapter.insertText(safe);
+                    } else {
+                        insertAtPasteSnapshot(target, currentAdapter, safe, pasteSnapshot);
                     }
-                    insertAtPasteSnapshot(
-                        target,
-                        currentAdapter,
-                        toDisplayRedactedText(redactedText),
-                        pasteSnapshot,
-                    );
+                    if (target instanceof HTMLElement) setInputVigilState(target, "guarded");
                     showToast("Vigils: 已脱敏后写入", "info");
                 });
                 return;
@@ -1577,28 +1727,34 @@
                 typeof resp.redacted_text === "string"
             ) {
                 if (primaryInput) {
-                    const ad = adaptTarget(primaryInput);
-                    const originalText = ad ? ad.getText() : "";
-                    showRiskPrompt(resp, primaryInput, (redactedText) => {
-                        if (primaryInput) {
-                            const currentAdapter = adaptTarget(primaryInput);
-                            if (!currentAdapter) return;
-                            if (currentAdapter.getText() !== originalText) {
-                                showToast(
-                                    "Vigils: 提交内容已变化,请重新触发安全检查。",
-                                    "warn",
-                                );
-                                return;
-                            }
+                    showRiskPrompt(resp, primaryInput, async () => {
+                        // 写回前对**当前**输入框文本重新送检 —— 写回/续发的永远是当前内容
+                        // 的最新裁决(框架 normalize / 用户弹卡期间续写都安全:不用过时脱敏版
+                        // 覆盖新内容,新增的高危也绝不自动续发)。旧实现按「与提交时刻文本
+                        // 严格相等」守门,富文本框架异步 normalize 会让写回恒被拒绝。
+                        const currentAdapter = adaptTarget(primaryInput);
+                        if (!currentAdapter) return;
+                        const currentText = currentAdapter.getText();
+                        if (!currentText) return;
+                        const recheck = await callBackground("submit", currentText);
+                        if (
+                            recheck.action === "confirm_redact" &&
+                            typeof recheck.redacted_text === "string"
+                        ) {
                             writeFieldByExtension(
                                 primaryInput,
                                 currentAdapter,
-                                toDisplayRedactedText(redactedText),
+                                toDisplayRedactedText(recheck.redacted_text),
                             );
                             continueSubmit(form, submitter);
                             showToast("Vigils: 已脱敏后写入", "info");
+                        } else if (recheck.action === "allow") {
+                            continueSubmit(form, submitter);
                         } else {
-                            showToast("Vigils: 无法定位输入框，已阻断", "error");
+                            if (primaryInput instanceof HTMLElement) {
+                                setInputVigilState(primaryInput, "block");
+                            }
+                            showBlockPrompt(recheck, primaryInput);
                         }
                     });
                     return;
@@ -1638,24 +1794,36 @@
                 resp.action === "confirm_redact" &&
                 typeof resp.redacted_text === "string"
             ) {
-                const ad = adaptTarget(target);
-                const originalText = ad ? ad.getText() : "";
-                showRiskPrompt(resp, target, (redactedText) => {
+                showRiskPrompt(resp, target, async () => {
+                    // 同 form 提交路径:写回前对当前文本重查,消除「框架 normalize 导致
+                    // 严格相等失败 → 写回被拒」;新增高危绝不放行。
                     const currentAdapter = adaptTarget(target);
                     if (!currentAdapter) return;
-                    if (currentAdapter.getText() !== originalText) {
-                        showToast("Vigils: 提交内容已变化,请重新触发安全检查。", "warn");
-                        return;
+                    const currentText = currentAdapter.getText();
+                    if (!currentText) return;
+                    const recheck = await callBackground("submit", currentText);
+                    if (
+                        recheck.action === "confirm_redact" &&
+                        typeof recheck.redacted_text === "string"
+                    ) {
+                        writeFieldByExtension(
+                            target,
+                            currentAdapter,
+                            toDisplayRedactedText(recheck.redacted_text),
+                        );
+                        continueContenteditableSubmit(
+                            target,
+                            "Vigils: 已脱敏后写入，请确认内容后手动再次发送。",
+                        );
+                    } else if (recheck.action === "allow") {
+                        continueContenteditableSubmit(
+                            target,
+                            "Vigils: 已允许本次内容，请确认内容后手动再次发送。",
+                        );
+                    } else {
+                        setInputVigilState(target, "block");
+                        showBlockPrompt(recheck, target);
                     }
-                    writeFieldByExtension(
-                        target,
-                        currentAdapter,
-                        toDisplayRedactedText(redactedText),
-                    );
-                    continueContenteditableSubmit(
-                        target,
-                        "Vigils: 已脱敏后写入，请确认内容后手动再次发送。",
-                    );
                 });
                 return;
             }

--- a/extensions/chrome-mv3/manifest.json
+++ b/extensions/chrome-mv3/manifest.json
@@ -69,7 +69,7 @@
         "https://spark.xfyun.cn/*"
       ],
       "js": ["content-script.js"],
-      "run_at": "document_idle",
+      "run_at": "document_start",
       "all_frames": true
     }
   ],

--- a/extensions/chrome-mv3/options.css
+++ b/extensions/chrome-mv3/options.css
@@ -388,3 +388,176 @@
   white-space: nowrap;
   border: 0;
 }
+
+/* ── 企业引导(高级版):价值卡 + 状态徽章 + 三步引导 ── */
+.enterprise-guide {
+  display: grid;
+  gap: 12px;
+}
+
+.ent-value {
+  padding: 12px;
+  border: 1px solid var(--accent-soft);
+  border-radius: 10px;
+  background: var(--accent-soft);
+}
+.ent-value-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+.ent-shield {
+  flex: 0 0 auto;
+  margin-top: 1px;
+  color: var(--accent-strong);
+}
+.ent-value-head strong {
+  display: block;
+  color: var(--fg);
+  font-size: 13px;
+}
+.ent-value-head p {
+  margin: 3px 0 0;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.4;
+}
+.ent-benefits {
+  list-style: none;
+  margin: 11px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 7px;
+}
+.ent-benefits li {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  color: var(--fg);
+  font-size: 12px;
+  line-height: 1.4;
+}
+.ent-benefit-ic {
+  flex: 0 0 auto;
+  font-size: 13px;
+  line-height: 1.3;
+}
+
+.ent-badge {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  font-size: 12px;
+  font-weight: 700;
+}
+.ent-badge-dot {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--muted);
+  transition: background 0.2s, box-shadow 0.2s;
+}
+.ent-badge-idle .ent-badge-text {
+  color: var(--muted);
+}
+.ent-badge-ok {
+  border-color: var(--success-border);
+  background: var(--success-bg);
+}
+.ent-badge-ok .ent-badge-dot {
+  background: var(--success);
+  box-shadow: 0 0 0 3px var(--success-bg);
+}
+.ent-badge-ok .ent-badge-text {
+  color: var(--success);
+}
+.ent-badge-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-left: auto;
+}
+.ent-chip {
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--panel);
+  border: 1px solid var(--success-border);
+  color: var(--success);
+  font-size: 10px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.ent-steps {
+  list-style: none;
+  margin: 0;
+  padding: 12px;
+  display: grid;
+  gap: 13px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--panel);
+  transition: border-color 0.2s, box-shadow 0.2s, opacity 0.2s;
+}
+.ent-steps.attention {
+  border-color: var(--warn);
+  box-shadow: 0 0 0 3px var(--warn-bg);
+}
+.ent-connected .ent-steps {
+  opacity: 0.7;
+}
+.ent-step {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+.ent-step-n {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+}
+.ent-step-body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.ent-step-body > strong {
+  display: block;
+  color: var(--fg);
+  font-size: 12px;
+}
+.ent-step-body > p {
+  margin: 3px 0 7px;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.4;
+}
+.ent-step-body label {
+  display: block;
+  margin: 7px 0 4px;
+  color: var(--muted);
+  font-size: 11px;
+}
+.ent-step-body select {
+  width: 100%;
+  padding: 7px 10px;
+  color: var(--fg);
+  background: var(--panel);
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+}
+.ent-step-body .id-value {
+  font-size: 11px;
+}

--- a/extensions/chrome-mv3/options.html
+++ b/extensions/chrome-mv3/options.html
@@ -56,42 +56,72 @@
     <details id="advanced-settings" class="advanced-settings">
       <summary>高级设置</summary>
 
-      <div class="advanced-block">
-        <h3>扩展 ID</h3>
-        <p class="desc">用于排查问题或后续企业 provider 对接时识别当前扩展实例。</p>
-        <div class="id-row">
-          <code id="extension-id" class="id-value">—</code>
-          <button id="copy-id-btn" type="button">复制</button>
-        </div>
-        <p id="extension-id-hint" class="hint"></p>
-      </div>
+      <div id="enterprise-section" class="advanced-block enterprise-guide">
+        <h3>企业连接 · 本机引擎</h3>
 
-      <div id="enterprise-section" class="advanced-block">
-        <h3>企业连接</h3>
-        <p class="desc">企业模式可将检查路由到更强的扫描后端；未配置时仍使用普通保护。</p>
-        <label for="enterprise-provider-type">扫描后端</label>
-        <select id="enterprise-provider-type">
-          <option value="none">尚未配置（普通保护）</option>
-          <option value="native_host">本机 Vigils 引擎</option>
-          <option value="localhost" disabled>Localhost Agent（规划中）</option>
-          <option value="https_api" disabled>企业 HTTPS API（规划中）</option>
-          <option value="wasm" disabled>浏览器内 Wasm（规划中）</option>
-        </select>
-        <p id="enterprise-status" class="hint"></p>
-        <div id="enterprise-native-guide" class="hidden">
-          <p class="desc">启用本机引擎需要先安装 Vigils CLI（或桌面版）并完成本机引擎注册——
-            步骤见用户文档「Browser extension」一节；注册时会用到上方「扩展 ID」。完成后回到
-            此页重新选择「本机 Vigils 引擎」。</p>
-          <p class="desc">本机引擎：原文仅送本机进程内存、不出设备；含硬指纹检测，本机 ML
-            引擎运行时自动叠加语义识别（邮箱 / 人名 / 电话等）。</p>
+        <div class="ent-value">
+          <div class="ent-value-head">
+            <svg class="ent-shield" width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path d="M12 2.5l6.4 2.8v5.3c0 4.2-2.7 7.9-6.4 9.4-3.7-1.5-6.4-5.2-6.4-9.4V5.3L12 2.5z"
+                fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" />
+              <path d="M9 12.2l2.1 2.1L15 10.4" stroke="currentColor" stroke-width="1.7"
+                stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+            <div>
+              <strong>把检查升级到本机 Vigils 引擎</strong>
+              <p>企业模式下，更强的扫描后端在你本机运行；普通用户无需配置。</p>
+            </div>
+          </div>
+          <ul class="ent-benefits">
+            <li><span class="ent-benefit-ic" aria-hidden="true">🔒</span><span>原文仅在本机进程内存处理，<strong>不出设备</strong></span></li>
+            <li><span class="ent-benefit-ic" aria-hidden="true">🎯</span><span>硬指纹检测 + 本机 ML 语义识别（邮箱 / 人名 / 电话）</span></li>
+            <li><span class="ent-benefit-ic" aria-hidden="true">⚙️</span><span>跟随系统安全姿态，strict 命中<strong>即阻断</strong></span></li>
+          </ul>
         </div>
 
-        <label for="enterprise-data-policy">数据策略</label>
-        <select id="enterprise-data-policy" disabled>
-          <option value="local_only">local_only：不发送原文</option>
-          <option value="metadata_only">metadata_only：只发送元数据</option>
-          <option value="raw_allowed">本机引擎：原文仅送本机进程（不出设备）</option>
-        </select>
+        <div id="enterprise-badge" class="ent-badge ent-badge-idle">
+          <span class="ent-badge-dot" aria-hidden="true"></span>
+          <span id="enterprise-badge-text" class="ent-badge-text">未连接本机引擎</span>
+          <span id="enterprise-badge-chips" class="ent-badge-chips"></span>
+        </div>
+
+        <ol id="enterprise-native-guide" class="ent-steps">
+          <li class="ent-step">
+            <span class="ent-step-n" aria-hidden="true">1</span>
+            <div class="ent-step-body">
+              <strong>安装 Vigils CLI 或桌面版</strong>
+              <p>参见用户文档「Browser extension」一节；已安装可跳过此步。</p>
+            </div>
+          </li>
+          <li class="ent-step">
+            <span class="ent-step-n" aria-hidden="true">2</span>
+            <div class="ent-step-body">
+              <strong>用扩展 ID 注册本机引擎</strong>
+              <p>注册时需要下面这串扩展 ID，用于识别当前扩展实例。</p>
+              <div class="id-row">
+                <code id="extension-id" class="id-value">—</code>
+                <button id="copy-id-btn" type="button">复制 ID</button>
+              </div>
+              <p id="extension-id-hint" class="hint"></p>
+            </div>
+          </li>
+          <li class="ent-step">
+            <span class="ent-step-n" aria-hidden="true">3</span>
+            <div class="ent-step-body">
+              <strong>开启「本机 Vigils 引擎」</strong>
+              <p>安装并注册完成后在此选择本机引擎；扩展会先探测连通再启用。</p>
+              <label for="enterprise-provider-type">扫描后端</label>
+              <select id="enterprise-provider-type">
+                <option value="none">尚未配置（普通保护）</option>
+                <option value="native_host">本机 Vigils 引擎</option>
+                <option value="localhost" disabled>Localhost Agent（规划中）</option>
+                <option value="https_api" disabled>企业 HTTPS API（规划中）</option>
+                <option value="wasm" disabled>浏览器内 Wasm（规划中）</option>
+              </select>
+              <p id="enterprise-status" class="hint"></p>
+            </div>
+          </li>
+        </ol>
       </div>
 
       <div class="advanced-block">

--- a/extensions/chrome-mv3/options.js
+++ b/extensions/chrome-mv3/options.js
@@ -17,9 +17,11 @@ import { normalizeCustomRiskRuleInput } from "./redaction-rules.js";
     const modeHint = document.getElementById("mode-hint");
     const enterpriseSection = document.getElementById("enterprise-section");
     const enterpriseProviderSelect = document.getElementById("enterprise-provider-type");
-    const enterpriseDataPolicySelect = document.getElementById("enterprise-data-policy");
     const enterpriseStatus = document.getElementById("enterprise-status");
     const enterpriseNativeGuide = document.getElementById("enterprise-native-guide");
+    const enterpriseBadge = document.getElementById("enterprise-badge");
+    const enterpriseBadgeText = document.getElementById("enterprise-badge-text");
+    const enterpriseBadgeChips = document.getElementById("enterprise-badge-chips");
     const customRiskForm = document.getElementById("custom-risk-form");
     const customRiskName = document.getElementById("custom-risk-name");
     const customRiskPrefix = document.getElementById("custom-risk-prefix");
@@ -103,22 +105,55 @@ import { normalizeCustomRiskRuleInput } from "./redaction-rules.js";
         });
     }
 
-    /** 按当前后端同步企业区 UI(select 值 / 数据策略展示 / 状态行)。 */
-    function syncEnterpriseUi(backend) {
+    /** 姿态档 → 状态行后缀(tier 字面量 + 效果说明;非闭集值不显示)。 */
+    function postureSuffix(postureTier) {
+        if (postureTier === "strict") return "跟随系统姿态：strict（命中即阻断）。";
+        if (postureTier === "balanced") return "跟随系统姿态：balanced（脱敏后确认）。";
+        return "";
+    }
+
+    /** 状态徽章:未连接(灰)/已连接(绿)+ 能力 chip(引擎档 + 姿态档,均来自本机引擎回报)。 */
+    function renderEnterpriseBadge(active, info) {
+        if (enterpriseBadge) {
+            enterpriseBadge.classList.toggle("ent-badge-ok", active);
+            enterpriseBadge.classList.toggle("ent-badge-idle", !active);
+        }
+        if (enterpriseBadgeText) {
+            enterpriseBadgeText.textContent = active ? "已连接本机引擎" : "未连接本机引擎";
+        }
+        if (!enterpriseBadgeChips) return;
+        enterpriseBadgeChips.replaceChildren();
+        if (!active) return;
+        const chips = [info && info.engine === "hardfp+ml" ? "ML 语义增强" : "硬指纹检测"];
+        if (info && info.posture_tier === "strict") chips.push("严格姿态");
+        else if (info && info.posture_tier === "balanced") chips.push("均衡姿态");
+        for (const label of chips) {
+            const chip = document.createElement("span");
+            chip.className = "ent-chip";
+            chip.textContent = label;
+            enterpriseBadgeChips.appendChild(chip);
+        }
+    }
+
+    /** 按当前后端同步企业区 UI(select 值 / 徽章 / 状态行;info 可带姿态与引擎观测)。 */
+    function syncEnterpriseUi(backend, info) {
         const active = backend === "native_host";
         if (enterpriseProviderSelect) {
             enterpriseProviderSelect.value = active ? "native_host" : "none";
         }
-        if (enterpriseDataPolicySelect) {
-            enterpriseDataPolicySelect.value = active ? "raw_allowed" : "local_only";
+        if (enterpriseSection) {
+            // 连接成功后弱化步骤区(引导已完成);步骤常驻供参考。
+            enterpriseSection.classList.toggle("ent-connected", active);
         }
-        if (!active && enterpriseNativeGuide) {
-            // 指引仅在启用失败时展开;成功/未配置态收起。
-            enterpriseNativeGuide.classList.add("hidden");
+        if (enterpriseNativeGuide) {
+            // 步骤常驻;此处清除失败高亮(失败路径会重新加上)。
+            enterpriseNativeGuide.classList.remove("attention");
         }
+        renderEnterpriseBadge(active, info);
+        const suffix = active ? postureSuffix(info && info.posture_tier) : "";
         setEnterpriseStatus(
             active
-                ? "已启用本机引擎：检查在本机完成，原文不出设备。"
+                ? `已启用本机引擎：检查在本机完成，原文不出设备。${suffix}`
                 : "未配置扫描后端：企业模式当前仍使用普通保护。",
             active ? "ok" : "",
         );
@@ -126,7 +161,7 @@ import { normalizeCustomRiskRuleInput } from "./redaction-rules.js";
 
     async function refreshEnterpriseBackend() {
         const resp = await sendRuntimeMessage({ type: "vigil_get_enterprise_backend" });
-        syncEnterpriseUi(resp && resp.backend === "native_host" ? "native_host" : "none");
+        syncEnterpriseUi(resp && resp.backend === "native_host" ? "native_host" : "none", resp);
     }
 
     async function setEnterpriseBackend(backend) {
@@ -380,10 +415,10 @@ import { normalizeCustomRiskRuleInput } from "./redaction-rules.js";
                 setEnterpriseStatus("正在探测本机引擎…");
                 const probe = await sendRuntimeMessage({ type: "vigil_probe_native_host" });
                 if (!probe || !probe.ok) {
-                    // 探测失败不保存(fail-closed 且不把用户锁进全阻断);展开指引。
+                    // 探测失败不保存(fail-closed 且不把用户锁进全阻断);高亮引导步骤。
                     await setEnterpriseBackend("none");
                     syncEnterpriseUi("none");
-                    if (enterpriseNativeGuide) enterpriseNativeGuide.classList.remove("hidden");
+                    if (enterpriseNativeGuide) enterpriseNativeGuide.classList.add("attention");
                     setEnterpriseStatus(
                         `未连接到本机引擎（${(probe && probe._error) || "未知错误"}）。请按下方指引完成安装与注册后重试。`,
                         "warn",
@@ -392,7 +427,8 @@ import { normalizeCustomRiskRuleInput } from "./redaction-rules.js";
                 }
                 const resp = await setEnterpriseBackend("native_host");
                 if (resp && resp.ok) {
-                    syncEnterpriseUi("native_host");
+                    // probe 响应已带姿态观测 —— 启用瞬间即显示当前姿态档。
+                    syncEnterpriseUi("native_host", probe);
                 } else {
                     syncEnterpriseUi("none");
                     setEnterpriseStatus(`启用失败：${(resp && resp._error) || "未知错误"}`, "warn");

--- a/extensions/chrome-mv3/popup.js
+++ b/extensions/chrome-mv3/popup.js
@@ -169,20 +169,39 @@ import { normalizeCustomSiteInput } from "./custom-sites.js";
             li.classList.add("event-row");
 
             const iconClass = actionIconClass(it.action);
-            const iconText = actionIconText(it.action);
             const findingNames = Array.isArray(it.findings) && it.findings.length > 0
                 ? it.findings.map(findingLabel).join("、")
-                : "风险内容";
+                : "敏感内容";
+            // 动作 → 如实文案:阻断 = 已阻断;脱敏 = 建议脱敏;其它风险 = 检测到。
+            // (allow 已在 background 侧不入列,此处不会出现「未见风险」被说成检测到。)
+            const verb =
+                it.action === "block"
+                    ? "已阻断"
+                    : it.action === "confirm_redact" || it.action === "redact"
+                      ? "建议脱敏"
+                      : "检测到";
 
-            li.innerHTML = `
-                <div class="event-row-icon ${iconClass}">${iconText}</div>
-                <div class="event-row-body">
-                    <div class="title">${eventKindLabel(it.event_kind)}检测到 ${findingNames}</div>
-                    <div class="meta">${it.origin || "当前网站"} · ${fmtTs(it.ts)}</div>
-                </div>
-                <div class="event-row-arrow">›</div>
-            `;
+            // **全 DOM + textContent 构建**(不用 innerHTML):origin / finding 名等
+            // 均来自 backend,按「backend 数据一律纯文本插入」安全契约杜绝任何注入。
+            const icon = document.createElement("div");
+            icon.className = `event-row-icon ${iconClass}`;
+            icon.textContent = actionIconText(it.action);
 
+            const body = document.createElement("div");
+            body.className = "event-row-body";
+            const title = document.createElement("div");
+            title.className = "title";
+            title.textContent = `${eventKindLabel(it.event_kind)}${verb} ${findingNames}`;
+            const meta = document.createElement("div");
+            meta.className = "meta";
+            meta.textContent = `${it.origin || "当前网站"} · ${fmtTs(it.ts)}`;
+            body.append(title, meta);
+
+            const arrow = document.createElement("div");
+            arrow.className = "event-row-arrow";
+            arrow.textContent = "›";
+
+            li.append(icon, body, arrow);
             listEl.appendChild(li);
         }
     }
@@ -196,13 +215,19 @@ import { normalizeCustomSiteInput } from "./custom-sites.js";
         const resp = await sendRuntimeMessage({ type: "vigil_get_mode" });
         const mode = resp && resp.mode === "enterprise" ? "enterprise" : "consumer";
         if (mode === "enterprise") {
-            // 企业模式:标出实际扫描后端(本机引擎 = 检查在本机 Vigils 进程完成)。
+            // 企业模式:标出实际扫描后端(本机引擎 = 检查在本机 Vigils 进程完成),
+            // 并附观测后缀:ML = 本机 daemon 语义增强参与;严格 = 跟随系统姿态命中即阻断。
             const backendResp = await sendRuntimeMessage({ type: "vigil_get_enterprise_backend" });
             const backend =
                 backendResp && backendResp.backend === "native_host" ? "native_host" : "none";
             if (statusText) {
-                statusText.textContent =
-                    backend === "native_host" ? "企业保护 · 本机引擎" : "企业保护";
+                let label = "企业保护";
+                if (backend === "native_host") {
+                    label = "企业保护 · 本机引擎";
+                    if (backendResp && backendResp.engine === "hardfp+ml") label += " · ML";
+                    if (backendResp && backendResp.posture_tier === "strict") label += " · 严格";
+                }
+                statusText.textContent = label;
             }
             setHeaderStatus("ok");
         }

--- a/extensions/chrome-mv3/providers/native-host-provider.js
+++ b/extensions/chrome-mv3/providers/native-host-provider.js
@@ -103,6 +103,15 @@ export function createNativeHostProvider(options = {}) {
         if (typeof resp.redacted_text === "string") {
             result.redacted_text = resp.redacted_text;
         }
+        // Phase 2「策略+观测」契约字段(host 每响应携带,闭集校验后透传;非闭集值丢弃
+        // =旧 host / 漂移容错):posture_tier = 系统姿态(posture.json)映射的建议档,
+        // pipeline 据此做只收紧的姿态升级;engine = 本次参与引擎(观测标注)。
+        if (resp.posture_tier === "balanced" || resp.posture_tier === "strict") {
+            result.posture_tier = resp.posture_tier;
+        }
+        if (resp.engine === "hardfp" || resp.engine === "hardfp+ml") {
+            result.engine = resp.engine;
+        }
         return result;
     }
 

--- a/extensions/chrome-mv3/scanner-pipeline.js
+++ b/extensions/chrome-mv3/scanner-pipeline.js
@@ -56,6 +56,34 @@ export function mergeScanResults(requestId, results) {
     };
 }
 
+/**
+ * 姿态跟随(Phase 2「策略+观测」):把 enterprise provider(本机引擎)带回的系统姿态
+ * 建议档应用到**合并后的最终决策**上。纯函数,只收紧:
+ *
+ *   - `postureTier === "strict"` 且最终 action 为 confirm_redact → 升级 block
+ *     (系统姿态严格 = 命中即阻断,不走用户确认;posture.json medium/high 由 host 侧
+ *     映射为 strict);
+ *   - allow(无命中)与 block(已最严)在任何姿态下都**不动**——姿态绝不放宽;
+ *   - `postureTier` 非闭集成员(null / 旧 host 缺省 / 漂移值)→ 原样返回 = 现状行为。
+ *
+ * 同时把 posture_tier / engine 附着到结果上(观测:popup 企业标注 / options 状态行),
+ * 无论是否发生升级 —— 附着基于 provider 实际回报,不基于本函数是否收紧。
+ */
+export function applyPostureTier(result, postureTier, engine) {
+    if (!result || typeof result !== "object") return result;
+    const annotated = { ...result };
+    if (postureTier === "balanced" || postureTier === "strict") {
+        annotated.posture_tier = postureTier;
+    }
+    if (engine === "hardfp" || engine === "hardfp+ml") {
+        annotated.engine = engine;
+    }
+    if (annotated.posture_tier === "strict" && annotated.action === "confirm_redact") {
+        return { ...annotated, action: "block", posture_escalated: true };
+    }
+    return annotated;
+}
+
 function lengthBucket(text) {
     const length = typeof text === "string" ? text.length : 0;
     if (length <= 100) return "0-100";
@@ -103,10 +131,17 @@ export async function checkWithScannerPipeline(request, options = {}) {
             dataPolicy,
             localResult,
         });
-        return mergeScanResults(request && request.request_id ? request.request_id : "", [
+        const merged = mergeScanResults(request && request.request_id ? request.request_id : "", [
             localResult,
             enterpriseResult,
         ]);
+        // 姿态跟随:从 enterprise 结果**独立**取姿态档再应用到合并结果 —— 不依赖
+        // enterprise 恰好是 merge 的最严者(本地更严时姿态升级依然要生效)。
+        return applyPostureTier(
+            merged,
+            enterpriseResult && enterpriseResult.posture_tier,
+            enterpriseResult && enterpriseResult.engine,
+        );
     } catch {
         return {
             request_id: request && request.request_id ? request.request_id : "",

--- a/extensions/chrome-mv3/tests/content-script-source.test.mjs
+++ b/extensions/chrome-mv3/tests/content-script-source.test.mjs
@@ -42,7 +42,42 @@ test("risk prompt anchors to the active input when available", () => {
     assert.match(source, /function positionRiskPrompt\(\)/);
     assert.match(source, /riskPromptTarget\s*=\s*getInputFrameTarget\(anchor\)\s*\|\|\s*anchor/);
     assert.match(source, /data-vigil-risk-arrow/);
-    assert.match(source, /showRiskPrompt\(resp,\s*target,\s*\(/);
+    assert.match(source, /showRiskPrompt\(resp,\s*target,\s*(?:async\s*)?\(/);
     assert.match(source, /showBlockPrompt\(resp,\s*target\)/);
-    assert.match(source, /showRiskPrompt\(resp,\s*primaryInput,\s*\(/);
+    assert.match(source, /showRiskPrompt\(resp,\s*primaryInput,\s*(?:async\s*)?\(/);
+});
+
+// 防回归:弹卡回调的写回**不得**再用「当前文本 === 检查/提交时刻文本」严格相等守门
+// (富文本框架异步 normalize 会让相等恒失败 → 写回被拒/检查被弃)。TOCTOU 改为
+// 以「写回前对当前文本重新送检(recheck)」收口:写回的永远是当前内容的最新裁决。
+test("write-back guards recheck current text instead of strict equality", () => {
+    assert.doesNotMatch(source, /getText\(\)\s*!==\s*originalText/);
+    assert.doesNotMatch(source, /getText\(\)\s*!==\s*latestAgain/);
+    assert.doesNotMatch(source, /getText\(\)\s*!==\s*pasteSnapshot\.text/);
+    const rechecks = source.match(/const recheck = await callBackground\(/g) || [];
+    assert.ok(rechecks.length >= 3, `expect >=3 recheck sites, got ${rechecks.length}`);
+});
+
+// 防回归:input 检查往返**后**不得再用 `after.seq !== next.seq` 放弃弹卡 —— 真实站点
+// (ChatGPT ProseMirror)在往返期间 re-render 会派发额外 input 使 seq 递增,该守卫会把弹卡
+// 静默杀掉。弹卡须无条件基于 SW 判定(与移除 latestAgain 同类)。
+test("prompt is unconditional after check roundtrip (no after.seq gate)", () => {
+    assert.doesNotMatch(source, /after\.seq\s*!==\s*next\.seq/);
+});
+
+// 构建标记必须存在,供排查时确认用户装的是最新版(区分「代码 bug」vs「装的是旧版」)。
+test("content script writes a build marker for version confirmation", () => {
+    assert.match(source, /data-vigil-build/);
+    assert.match(source, /VIGIL_BUILD\s*=\s*"20\d\d-\d\d-\d\d/);
+});
+
+// 防回归:手动输入的防抖检查**不得**再用「fire 时刻文本 === 排程时刻文本」的严格比较
+// 来跳过 —— 真实富文本框架(ProseMirror 类)在防抖窗口内异步 normalize 文本会让二者不等,
+// 导致手动输入永不弹卡(用户报告的「粘贴弹卡、手动输入不提醒」根因,已 Edge 真机正反对照
+// 坐实)。自写循环防护仍用 `lastWritten` 精确匹配守住。
+test("manual-input debounce does not skip on framework text mutation", () => {
+    // 旧 bug 形态:`latest !== next.lastText` 直接 return。这行不得复现。
+    assert.doesNotMatch(source, /latest\s*!==\s*next\.lastText/);
+    // 修复形态:以 fire 时刻当前文本为准检查;仅对「扩展自写值」精确匹配跳过防循环。
+    assert.match(source, /if\s*\(latest\s*===\s*current\.lastWritten\)\s*return;/);
 });

--- a/extensions/chrome-mv3/tests/native-host-provider.test.mjs
+++ b/extensions/chrome-mv3/tests/native-host-provider.test.mjs
@@ -147,3 +147,51 @@ test("malformed finding entries are dropped and kinds are length-capped", async 
         "非字符串/空条目丢弃;超长 kind 截断",
     );
 });
+
+// ───────────── Phase 2「策略+观测」:posture_tier / engine 契约字段透传 ─────────────
+
+test("passes through posture_tier and engine when host sends closed-set values", async () => {
+    const fake = fakeChrome();
+    const provider = createNativeHostProvider({ chromeApi: fake.chromeApi });
+    const checking = provider.check(request("plain text"));
+    fake.emit({
+        request_id: "33333333-3333-4333-8333-333333333333",
+        action: "allow",
+        findings: [],
+        posture_tier: "strict",
+        engine: "hardfp+ml",
+    });
+    const result = await checking;
+    assert.equal(result.posture_tier, "strict");
+    assert.equal(result.engine, "hardfp+ml");
+});
+
+test("drops posture_tier and engine outside the closed sets (host drift tolerance)", async () => {
+    const fake = fakeChrome();
+    const provider = createNativeHostProvider({ chromeApi: fake.chromeApi });
+    const checking = provider.check(request("plain text"));
+    fake.emit({
+        request_id: "33333333-3333-4333-8333-333333333333",
+        action: "allow",
+        findings: [],
+        posture_tier: "paranoid",
+        engine: "turbo",
+    });
+    const result = await checking;
+    assert.equal(Object.hasOwn(result, "posture_tier"), false);
+    assert.equal(Object.hasOwn(result, "engine"), false);
+});
+
+test("legacy host response without the new fields keeps prior shape", async () => {
+    const fake = fakeChrome();
+    const provider = createNativeHostProvider({ chromeApi: fake.chromeApi });
+    const checking = provider.check(request("plain text"));
+    fake.emit({
+        request_id: "33333333-3333-4333-8333-333333333333",
+        action: "allow",
+        findings: [],
+    });
+    const result = await checking;
+    assert.equal(Object.hasOwn(result, "posture_tier"), false);
+    assert.equal(Object.hasOwn(result, "engine"), false);
+});

--- a/extensions/chrome-mv3/tests/scanner-pipeline.test.mjs
+++ b/extensions/chrome-mv3/tests/scanner-pipeline.test.mjs
@@ -265,3 +265,117 @@ test("enterprise native host failure fails closed to block with local findings k
     assert.equal(result.error, "enterprise_provider_failed");
     assert.ok(result.findings.some((f) => f.kind === "github_token"), "本地 findings 保留");
 });
+
+// ───────────── Phase 2「策略+观测」:applyPostureTier 姿态跟随(只收紧) ─────────────
+
+import { applyPostureTier } from "../scanner-pipeline.js";
+
+function resultOf(action, extra = {}) {
+    return { request_id: "r", action, findings: [], source: "pipeline", ...extra };
+}
+
+test("applyPostureTier: strict escalates confirm_redact to block and marks it", () => {
+    const out = applyPostureTier(resultOf("confirm_redact"), "strict", "hardfp+ml");
+    assert.equal(out.action, "block");
+    assert.equal(out.posture_escalated, true);
+    assert.equal(out.posture_tier, "strict");
+    assert.equal(out.engine, "hardfp+ml");
+});
+
+test("applyPostureTier: never loosens — allow and block untouched under any tier", () => {
+    for (const tier of ["strict", "balanced", "paranoid", null, undefined]) {
+        assert.equal(applyPostureTier(resultOf("allow"), tier).action, "allow");
+        assert.equal(applyPostureTier(resultOf("block"), tier).action, "block");
+    }
+});
+
+test("applyPostureTier: balanced / invalid / missing tier keep confirm_redact as-is", () => {
+    assert.equal(applyPostureTier(resultOf("confirm_redact"), "balanced").action, "confirm_redact");
+    assert.equal(applyPostureTier(resultOf("confirm_redact"), "paranoid").action, "confirm_redact");
+    assert.equal(applyPostureTier(resultOf("confirm_redact"), null).action, "confirm_redact");
+    // 非闭集值不得附着
+    assert.equal(
+        Object.hasOwn(applyPostureTier(resultOf("confirm_redact"), "paranoid"), "posture_tier"),
+        false,
+    );
+});
+
+test("enterprise pipeline: host posture strict escalates merged confirm_redact to block", async () => {
+    // 本地 consumer 命中 github_token → confirm_redact;enterprise(本机引擎)allow 但携
+    // posture_tier=strict → 姿态独立于「谁更严」生效,最终 block。
+    const enterpriseProvider = {
+        name: "native_host",
+        async check() {
+            return {
+                request_id: "22222222-2222-4222-8222-222222222222",
+                action: "allow",
+                findings: [],
+                source: "native_host",
+                posture_tier: "strict",
+                engine: "hardfp",
+            };
+        },
+    };
+    const result = await checkWithScannerPipeline(
+        request("token ghp_abcdefghijklmnopqrstuvwxyz1234567890ABCD"),
+        {
+            mode: "enterprise",
+            enterprise: { provider: enterpriseProvider, dataPolicy: "raw_allowed" },
+        },
+    );
+    assert.equal(result.action, "block");
+    assert.equal(result.posture_escalated, true);
+    assert.equal(result.posture_tier, "strict");
+    assert.deepEqual(result.findings.map((f) => f.kind), ["github_token"]);
+});
+
+test("enterprise pipeline: balanced posture keeps confirm_redact flow", async () => {
+    const enterpriseProvider = {
+        name: "native_host",
+        async check() {
+            return {
+                request_id: "22222222-2222-4222-8222-222222222222",
+                action: "allow",
+                findings: [],
+                source: "native_host",
+                posture_tier: "balanced",
+                engine: "hardfp+ml",
+            };
+        },
+    };
+    const result = await checkWithScannerPipeline(
+        request("token ghp_abcdefghijklmnopqrstuvwxyz1234567890ABCD"),
+        {
+            mode: "enterprise",
+            enterprise: { provider: enterpriseProvider, dataPolicy: "raw_allowed" },
+        },
+    );
+    assert.equal(result.action, "confirm_redact");
+    assert.equal(Object.hasOwn(result, "posture_escalated"), false);
+    assert.equal(result.posture_tier, "balanced");
+    assert.equal(result.engine, "hardfp+ml");
+});
+
+test("enterprise pipeline: legacy host without posture_tier behaves exactly as before", async () => {
+    const enterpriseProvider = {
+        name: "native_host",
+        async check() {
+            return {
+                request_id: "22222222-2222-4222-8222-222222222222",
+                action: "allow",
+                findings: [],
+                source: "native_host",
+            };
+        },
+    };
+    const result = await checkWithScannerPipeline(
+        request("token ghp_abcdefghijklmnopqrstuvwxyz1234567890ABCD"),
+        {
+            mode: "enterprise",
+            enterprise: { provider: enterpriseProvider, dataPolicy: "raw_allowed" },
+        },
+    );
+    assert.equal(result.action, "confirm_redact");
+    assert.equal(Object.hasOwn(result, "posture_tier"), false);
+    assert.equal(Object.hasOwn(result, "posture_escalated"), false);
+});

--- a/extensions/chrome-mv3/tests/ui-copy-source.test.mjs
+++ b/extensions/chrome-mv3/tests/ui-copy-source.test.mjs
@@ -104,6 +104,21 @@ test("popup renders safety events in plain language", () => {
     assert.doesNotMatch(js, /toUpperCase\(\)/);
 });
 
+// 防回归:事件列表只记**风险**事件,allow(未见风险)不入列 —— 否则简单文本的
+// 正常放行会被显示成「检测到风险」(用户报告的误报)。且 popup 事件行**不得**用
+// innerHTML 拼接 backend 数据(纯文本 textContent,杜绝注入)。
+test("only risk events are recorded; simple/allow input is not shown as a risk", () => {
+    const background = read("extensions/chrome-mv3/background.js");
+    // recordFinding 必须在 `resp.action !== "allow"` 守卫内
+    assert.match(background, /resp\.action\s*!==\s*"allow"[\s\S]{0,120}recordFinding\(/);
+});
+
+test("popup event rows are built with DOM/textContent, never innerHTML", () => {
+    const js = read("extensions/chrome-mv3/popup.js");
+    assert.doesNotMatch(js, /\.innerHTML\s*=/);
+    assert.match(js, /\.textContent\s*=/);
+});
+
 test("options defaults to consumer settings and hides enterprise diagnostics as advanced", () => {
     const html = read("extensions/chrome-mv3/options.html");
     assert.match(html, /推荐保护/);
@@ -129,4 +144,29 @@ test("options exposes custom risk types only inside advanced settings", () => {
     assert.match(source, /vigil_add_custom_risk_rule/);
     assert.match(source, /vigil_remove_custom_risk_rule/);
     assert.doesNotMatch(html, /正则表达式/);
+});
+
+// 防回归:企业引导是「价值卡 + 状态徽章 + 三步引导」,而非密集表单;且不得再出现
+// 那个只读、纯摆设的「数据策略」下拉(disabled select 徒增困惑)。徽章的能力 chip 必须
+// 由 renderEnterpriseBadge 依据本机引擎真实回报的 engine/posture_tier 渲染。
+test("enterprise guide is a value+steps+status onboarding, not a dense form", () => {
+    const html = read("extensions/chrome-mv3/options.html");
+    const js = read("extensions/chrome-mv3/options.js");
+    // 价值卡 + 三步引导 + 状态徽章的结构标记
+    assert.match(html, /class="[^"]*enterprise-guide/);
+    assert.match(html, /class="ent-benefits"/);
+    assert.match(html, /<ol[^>]*id="enterprise-native-guide"[^>]*class="ent-steps"/);
+    assert.match(html, /class="ent-step-n"/);
+    assert.match(html, /id="enterprise-badge"/);
+    // 三步的关键文案(顺序即引导路径)
+    assert.match(html, /安装 Vigils CLI 或桌面版/);
+    assert.match(html, /用扩展 ID 注册本机引擎/);
+    assert.match(html, /开启「本机 Vigils 引擎」/);
+    // 摆设的只读数据策略下拉已移除
+    assert.doesNotMatch(html, /enterprise-data-policy/);
+    assert.doesNotMatch(html, /metadata_only/);
+    // 徽章 chip 走真实观测字段(engine / posture_tier),非硬编码
+    assert.match(js, /function renderEnterpriseBadge/);
+    assert.match(js, /info\.engine === "hardfp\+ml"/);
+    assert.match(js, /info\.posture_tier === "strict"/);
 });


### PR DESCRIPTION
Parity port of the internal extension increments since the consumer/enterprise
convergence:

- content script runs at document_start so site scripts cannot out-register the
  guard listeners (SPA capture listeners were starving paste interception)
- manual-input debounce gains a max-wait so framework re-render input heartbeats
  cannot starve the check forever; the prompt is presented unconditionally once
  the engine reports risk (framework text normalization no longer swallows it)
- write-back rechecks the current text instead of strict snapshot equality
  (TOCTOU-safe: newly added secrets never slip through) and pastes accumulate at
  the caret instead of being rejected as "content changed"
- activity feed only records actual risk interventions; popup event rows are
  built with DOM/textContent, never innerHTML
- enterprise provider propagates engine + posture_tier; scanner pipeline
  escalates confirm_redact to block under strict posture (tighten-only)
- branded prompt card (shield icon, finding chips, trust line, tone-colored top
  edge); options enterprise section redesigned as value card + status badge +
  3-step onboarding with capability chips driven by real engine/posture
  observability
- node tests 72/72 (+16 vs main) incl. new source-level anti-regression gates

CWS note: manifest version intentionally stays 0.2.0; store publish remains a
separate step.

**Verification**
- `node --test extensions/chrome-mv3/tests/*.test.mjs`: **72/72** (main: 56)
- Real-browser (Edge headless + CDP, masqueraded chat page): consumer prompt card warn/block states, redacted write-back (`[REDACTED]` + toast), private-key block leaves the input untouched; enterprise onboarding idle + connected badge with capability chips (`hardfp`, `balanced posture`) against a real native host.
- Extension directory is now byte-identical with the internal tree (parity discipline).