### PR TITLE
fix(hook): panic-proof the hook exit path (catch_unwind fail-closed guard)

### DIFF
--- a/apps/vigil-hub-cli/src/hook.rs
+++ b/apps/vigil-hub-cli/src/hook.rs
@@ -473,6 +473,34 @@ pub fn respond(outcome: &HookOutcome, cli: CliKind) -> HookResponse {
     }
 }
 
+/// hook 进程退出码的 **panic 兜底**(纵深防御,VIGIL 全用户面审核 P1):跑决策+输出闭包,
+/// 任何未预期 panic(逻辑 bug、`println!` 撞 broken pipe 等)一律收敛为该 CLI 的 **Deny**
+/// 形状退出码,绝不让 unwind 逃逸成 Rust panic 退出(码 101)—— Claude 把非 2 的退出视为
+/// non-blocking fail-open,即"hook 崩溃 = 放行",违背 [`run`] 声明的 fail-closed 契约。
+///
+/// 兜底分支用**不 panic 的 write**(`writeln!` 忽略错误)输出 deny 决策:stdout 可能已断
+/// (broken pipe 正是可达的 panic 源),此时 Claude 靠 exit 2 仍硬拦截;JSON 型 CLI
+/// (Codex/Gemini/Cursor)尽力而为输出 deny JSON。正常路径零行为变化。
+///
+/// `AssertUnwindSafe`:闭包内全是 one-shot hook 进程的局部状态(stdin lock / 配置快照),
+/// panic 后本进程随即退出,无跨 unwind 状态复用,断言成立。
+pub fn exit_code_guarded(cli: CliKind, f: impl FnOnce() -> u8) -> u8 {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).unwrap_or_else(|_| {
+        use std::io::Write;
+        let resp = respond(
+            &HookOutcome::Deny("Vigil hook: internal error (blocked fail-closed).".into()),
+            cli,
+        );
+        if let Some(out) = &resp.stdout {
+            let _ = writeln!(std::io::stdout(), "{out}");
+        }
+        if let Some(err) = &resp.stderr {
+            let _ = writeln!(std::io::stderr(), "{err}");
+        }
+        resp.exit_code
+    })
+}
+
 /// Claude 的 α2 注入响应:`hookSpecificOutput` 携带重写后的 `tool_input`(`updatedInput`)。
 /// `permissionDecision=allow` 表示按重写输入放行。`updated_input` 含真值,但仅作为给宿主
 /// 执行的载体输出(模型可见 transcript 仍是原占位符);`note`(reason)**不含真值**。
@@ -2451,6 +2479,34 @@ fn safe_tool_name(name: &str) -> String {
 mod tests {
     use super::*;
     use crate::posture::PostureProfile;
+
+    // ── exit_code_guarded:panic 兜底安全命门(审核 P1 HOOK-PANIC)──────────────────
+
+    /// panic → Claude 收敛为 deny 的 exit 2(绝不 unwind 成 101 fail-open)。
+    #[test]
+    fn exit_code_guarded_panic_converges_to_claude_deny_exit2() {
+        let code = exit_code_guarded(CliKind::Claude, || panic!("boom"));
+        assert_eq!(code, 2);
+    }
+
+    /// panic → JSON 型 CLI(Codex/Gemini/Cursor)收敛为各自 deny 形状的 exit 0
+    /// (deny 决策经 stdout JSON 尽力而为;exit code 与 respond 的 Deny 分支一致)。
+    #[test]
+    fn exit_code_guarded_panic_converges_to_json_cli_deny_exit0() {
+        for cli in [CliKind::Codex, CliKind::Gemini, CliKind::Cursor] {
+            let code = exit_code_guarded(cli, || panic!("boom"));
+            let expect = respond(&HookOutcome::Deny("x".into()), cli).exit_code;
+            assert_eq!(code, expect, "{cli:?} panic 兜底应与 Deny 形状同 exit code");
+            assert_eq!(code, 0);
+        }
+    }
+
+    /// 无 panic 时守卫透明:闭包返回什么就是什么(正常路径零行为变化)。
+    #[test]
+    fn exit_code_guarded_passthrough_without_panic() {
+        assert_eq!(exit_code_guarded(CliKind::Claude, || 0), 0);
+        assert_eq!(exit_code_guarded(CliKind::Claude, || 2), 2);
+    }
 
     // ── ADR 0024 hook-ML PII 增强(wire 应用原语单测已随函数移至 vigil-daemon-ipc::wire)──
 

--- a/apps/vigil-hub-cli/src/main.rs
+++ b/apps/vigil-hub-cli/src/main.rs
@@ -538,33 +538,43 @@ fn main() -> std::process::ExitCode {
             // engine.json(GUI 控制平面写的全局偏好)决定 hook 是否经常驻 daemon 走 ML PII 增强
             // (ADR 0024)。持久化 = standing 偏好 → best-effort(daemon 缺则降级硬指纹;D8)。hook 由
             // agent 以固定注册参数调起,无 `--engine` flag → 仅读 engine.json(显式覆盖留 serve/wrap)。
-            let loaded_engine =
-                engine_config::default_engine_path().map(|p| engine_config::load_engine(&p));
-            if let Some(w) = loaded_engine.as_ref().and_then(|l| l.warning.as_deref()) {
-                eprintln!("vigil-hook: {w}");
-            }
-            let engine = loaded_engine.and_then(|l| l.mode);
-            let injection =
-                build_injection_config(args.inject, args.secrets.as_deref(), args.inject_ttl_secs);
-            let hook_args = HookArgs {
-                ledger_path: args.ledger,
-                cli: args.cli,
-                injection,
-                redact_results: args.redact_results,
-                engine,
-                ..HookArgs::default()
-            };
-            let stdin = std::io::stdin();
-            let mut reader = stdin.lock();
-            let outcome = hook::run(&hook_args, &mut reader);
-            let resp = hook::respond(&outcome, args.cli);
-            if let Some(out) = &resp.stdout {
-                println!("{out}");
-            }
-            if let Some(err) = &resp.stderr {
-                eprintln!("{err}");
-            }
-            std::process::ExitCode::from(resp.exit_code)
+            // 纵深兜底(审核 P1):决策 + 输出整体经 exit_code_guarded —— 任何未预期 panic
+            // (含 broken-pipe 下 println! panic)收敛为本 CLI 的 Deny 形状(Claude=exit 2),
+            // 绝不 unwind 成 exit 101(Claude 视非 2 退出为 non-blocking fail-open)。
+            let cli = args.cli;
+            let code = hook::exit_code_guarded(cli, || {
+                let loaded_engine =
+                    engine_config::default_engine_path().map(|p| engine_config::load_engine(&p));
+                if let Some(w) = loaded_engine.as_ref().and_then(|l| l.warning.as_deref()) {
+                    eprintln!("vigil-hook: {w}");
+                }
+                let engine = loaded_engine.and_then(|l| l.mode);
+                let injection = build_injection_config(
+                    args.inject,
+                    args.secrets.as_deref(),
+                    args.inject_ttl_secs,
+                );
+                let hook_args = HookArgs {
+                    ledger_path: args.ledger,
+                    cli,
+                    injection,
+                    redact_results: args.redact_results,
+                    engine,
+                    ..HookArgs::default()
+                };
+                let stdin = std::io::stdin();
+                let mut reader = stdin.lock();
+                let outcome = hook::run(&hook_args, &mut reader);
+                let resp = hook::respond(&outcome, cli);
+                if let Some(out) = &resp.stdout {
+                    println!("{out}");
+                }
+                if let Some(err) = &resp.stderr {
+                    eprintln!("{err}");
+                }
+                resp.exit_code
+            });
+            std::process::ExitCode::from(code)
         }
         Some(Command::Setup(args)) => {
             if args.all {


### PR DESCRIPTION
Depth-of-defense port (internal user-surface audit P1): the hook branch had no
panic guard — any unexpected panic (a logic bug, or println! hitting a broken
pipe) exited with code 101, which Claude treats as non-blocking fail-open: a
crashed hook meant the tool call was allowed through, violating run()'s declared
fail-closed contract.

- hook.rs: pub fn exit_code_guarded(cli, f) wraps the decision+output closure in
  catch_unwind(AssertUnwindSafe); the panic branch emits this CLI's Deny shape
  with non-panicking writes (Claude = exit 2 + stderr; Codex/Gemini/Cursor =
  exit 0 + best-effort deny JSON). Normal path: zero behavioral change.
- main.rs: the hook branch now runs entirely inside exit_code_guarded.
- +3 unit tests: panic converges to Claude exit 2 / panic matches the JSON CLIs'
  Deny shape / guard is transparent without panic.

hook.rs is now byte-identical across repos.

Verification: workspace fmt / clippy (-D warnings) / test all green (0 FAILED).