### PR TITLE
docs: pairing guide catches up with the shipped enterprise backend

### DIFF
--- a/docs/book/src/getting-started/installation.zh-CN.md
+++ b/docs/book/src/getting-started/installation.zh-CN.md
@@ -72,7 +72,10 @@ vigil-hub setup       # 自动探测 Claude Code / Codex / Cursor 并接好守�
 
 在 AI 网站上粘贴/提交前先脱敏密钥与 PII。从 Chrome 应用商店一键安装
 [**Vigils Browser Guard**](https://chromewebstore.google.com/detail/vigils-browser-guard/ffmgaglmcimapacgmoejaobfjdpmopch) ——
-普通模式开箱即用,无需桌面 App。可选:配合桌面 App 的 native host 解锁深度脱敏。
+普通模式开箱即用,无需桌面 App。可选深度脱敏:安装 Vigils CLI,用扩展 ID 注册 native host
+(`vigil-native-host install --extension-id <ID>`,ID 在扩展「选项 → 高级设置」里可复制),
+再到选项页企业模式下选择「本机 Vigils 引擎」——检查将路由到本机引擎(硬指纹 + daemon
+运行时的 ML PII 识别),原文不出设备。
 开发版:`chrome://extensions` → 开 **开发者模式** → **加载已解压的扩展程序** → 选 `extensions/chrome-mv3/`。
 
 ---

--- a/extensions/chrome-mv3/README.md
+++ b/extensions/chrome-mv3/README.md
@@ -16,7 +16,7 @@ In the default consumer mode, it does not require a Native Host, desktop app, or
 - **Contextual page prompt**: Risk prompts appear near the active input instead of being hidden in a page corner.
 - **One-click site protection**: The popup shows the current page status and lets you add custom HTTPS sites.
 - **Safe event history**: The popup shows only risk type, website, and action metadata. It does not store original text.
-- **Enterprise-ready interface**: Future enterprise providers can use Native Host, localhost agent, HTTPS API, or Wasm.
+- **Enterprise backend (optional)**: route checks to the locally installed Vigils engine over Native Host — the first shipped enterprise provider. Localhost agent, HTTPS API, and Wasm remain planned interfaces.
 
 ## Use Cases
 
@@ -78,11 +78,16 @@ Consumer mode follows these rules:
 - Page prompts are rendered with DOM APIs and `textContent`, not `innerHTML`
 - Unknown or invalid decisions fail closed and are blocked by default
 
-Enterprise mode is a reserved capability, not the default path for everyday users. Native Host is only one possible future enterprise provider implementation.
+Enterprise mode is optional and off by default. Its first shipped backend is the **local Vigils
+engine** over Native Host: install the Vigils CLI, register the host with your extension ID
+(`vigil-native-host install --extension-id <ID>` — the ID is shown under Options → Advanced),
+then pick "Local Vigils engine" in the enterprise section of Options. Checks then run in a local
+process (hard fingerprints, plus ML PII when the daemon runs); raw text never leaves the device,
+and an unreachable host blocks instead of silently downgrading.
 
 ## Install and Try
 
-The current version is intended for development-mode loading:
+Install from the Chrome Web Store (see below), or load the directory as a development build:
 
 1. Open Chrome `chrome://extensions/`
 2. Enable Developer mode
@@ -150,7 +155,7 @@ extensions/chrome-mv3/
 ├── scanner-pipeline.js
 ├── providers/
 │   ├── consumer-js-provider.js
-│   └── enterprise-provider.js
+│   └── native-host-provider.js
 └── tests/
 ```
 
@@ -161,7 +166,7 @@ Core layers:
 - `custom-sites.js`: Normalizes user-provided HTTPS domains for optional protection.
 - `redaction-rules.js`: Browser-local detection, redaction, and custom prefix-based risk rules.
 - `risk-decision.js`: Converts scan results into `allow`, `confirm_redact`, or `block`.
-- `scanner-pipeline.js`: Combines the consumer provider and future enterprise providers.
+- `scanner-pipeline.js`: Combines the consumer provider and enterprise providers (e.g. the Native Host provider).
 
 ## Development and Tests
 

--- a/extensions/chrome-mv3/README.zh-CN.md
+++ b/extensions/chrome-mv3/README.zh-CN.md
@@ -16,7 +16,7 @@ Vigils Browser Guard 是一个 Chrome MV3 扩展，用来在你把密钥、token
 - **贴近输入框提示**: 风险提示会优先出现在输入框附近，而不是藏在页面角落。
 - **一键保护网站**: Popup 会显示当前页面保护状态，并支持添加自定义 HTTPS 网站。
 - **安全事件记录**: Popup 只展示风险类型、网站和处理结果，不保存原文。
-- **企业接口预留**: 后续可接入 Native Host、localhost agent、企业 HTTPS API 或 Wasm provider。
+- **企业后端（可选）**: 可将检查路由到本机安装的 Vigils 引擎（Native Host）——首个真实落地的企业 provider；localhost agent、企业 HTTPS API、Wasm 仍是预留接口。
 
 ## 适用场景
 
@@ -78,11 +78,14 @@ Vigils 适合经常把代码、配置、日志或环境变量粘贴到 AI 工具
 - 页面提示使用 DOM API 和 `textContent` 渲染，不使用 `innerHTML`
 - 未知或异常的风险决策按 fail-closed 处理，默认阻断
 
-企业模式是预留能力，不是普通用户默认路径。Native Host 只是未来企业 provider 的一种实现方式。
+企业模式可选、默认关闭。首个真实后端是 **本机 Vigils 引擎**（Native Host）：安装 Vigils CLI，
+用扩展 ID 注册 host（`vigil-native-host install --extension-id <ID>`，ID 在「选项 → 高级设置」
+可复制），再到选项页企业区选择「本机 Vigils 引擎」。此后检查在本机进程内完成（硬指纹 +
+daemon 运行时的 ML PII 识别），原文不出设备；host 不可达时阻断而非静默降级。
 
 ## 安装与体验
 
-当前版本适合开发模式加载：
+推荐从 Chrome 应用商店安装（见下文）；开发构建可加载本目录：
 
 1. 打开 Chrome `chrome://extensions/`
 2. 开启 Developer mode
@@ -148,7 +151,7 @@ extensions/chrome-mv3/
 ├── scanner-pipeline.js
 ├── providers/
 │   ├── consumer-js-provider.js
-│   └── enterprise-provider.js
+│   └── native-host-provider.js
 └── tests/
 ```
 
@@ -159,7 +162,7 @@ extensions/chrome-mv3/
 - `custom-sites.js`: 规范化用户添加的 HTTPS 自定义保护域名。
 - `redaction-rules.js`: 浏览器内扫描、脱敏规则和自定义前缀风险类型。
 - `risk-decision.js`: 将扫描结果转为 `allow`、`confirm_redact` 或 `block`。
-- `scanner-pipeline.js`: 普通 provider 与企业 provider 的组合入口。
+- `scanner-pipeline.js`: 普通 provider 与企业 provider（如 Native Host provider）的组合入口。
 
 ## 开发与测试
 


### PR DESCRIPTION
- installation.zh-CN.md §4: the Chinese page still carried the old one-line
  promise ("pair with the desktop app's native host") with no steps — mirror
  the English page's real pairing steps (install CLI, `vigil-native-host
  install --extension-id <ID>`, pick "Local Vigils engine" in Options).
- extension README (en/zh): enterprise mode was still described as a
  reserved/future capability and the project tree listed a non-existent
  enterprise-provider.js — state the shipped local-engine backend with the
  actual pairing steps, point installs at the Chrome Web Store first, and fix
  the tree (providers/native-host-provider.js).

Verified on real machine against the published v0.5.0-beta.1 artifacts: the
documented install command registers (manifest + HKCU keys), `setup --status`
shows the browser-guard line, the extension pairs and scans through the
published host (posture chip appears after the first real check).