### PR TITLE
release: v0.5.0 — the browser line joins the control plane, stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,55 @@ All notable changes to Vigils are documented here. The format follows
 
 ---
 
+## [v0.5.0] — 2026-07-08 — the browser line joins the control plane: store pairing, posture-aware guard, hook hardening
+
+The stable roll-up of v0.5.0-beta.1. The browser extension stops being an island: the Chrome Web
+Store build ([Vigils Browser Guard](https://chromewebstore.google.com/detail/vigils-browser-guard/ffmgaglmcimapacgmoejaobfjdpmopch)
+0.3.0, now live) pairs with the locally installed Vigils engine, the desktop app and CLI can
+finally see the browser line, and the hook path gains two hardening features. Hard floors are
+untouched.
+
+### Added
+
+- **Browser ⇄ engine link** (#57). The native messaging host joins the daemon as its second ML
+  client: browser checks get the same local ML PII augmentation as the hook path (`engine.json`
+  gated; daemon absent → fail-closed to the hard-fingerprint floor, never fail-open).
+- **First enterprise backend in the extension** (#58). Options can route checks to the local
+  Vigils engine over native messaging — the permission is optional and only requested on explicit
+  enable, raw text stays on the device, and an unreachable host blocks instead of silently
+  downgrading.
+- **Browser events in the control plane** (#59, #60, #62). Activity Feed shows browser
+  paste/input/submit interventions; Protection Overview gains a browser-guard card with
+  registration + engine state and 24-hour check/block/redact counts.
+- **`setup --status` browser line** (#61). Native-host registration state next to the hook and
+  MCP lines — the turnkey status now covers all three defense lines.
+- **Posture propagation** (#62, #64). The host reports `posture_tier`/`engine`; under a strict
+  posture the extension escalates confirm-redact to block (tighten-only, allow/block never move).
+- **Command Guard file-write flank** (#63). Write/Edit tools that persist into shell rc files,
+  crontabs, or `.git/hooks` are now classified like their shell-command equivalents.
+
+### Fixed
+
+- **Inline interventions on real rich-text editors** (#64). The content script runs at
+  `document_start` so site capture listeners can no longer starve the guard; the manual-input
+  debounce gains a max-wait so framework re-render heartbeats cannot postpone the check forever;
+  the prompt is presented unconditionally once the engine reports risk; write-back rechecks the
+  current text instead of strict snapshot equality, and repeated pastes accumulate at the caret.
+- **Activity feed honesty** (#64). Normal allows are no longer recorded as "risk detected", and
+  popup event rows are built with DOM/textContent, never innerHTML.
+- **Hook panic guard** (#65). The hook decision+output path is wrapped in `catch_unwind`: an
+  unexpected panic converges to the CLI's Deny shape (Claude: exit 2) instead of exiting 101,
+  which agents treat as non-blocking fail-open.
+
+### Changed
+
+- **Extension UX** (#64, #66). Branded prompt card (shield icon, finding chips, trust line,
+  tone-colored top edge); the enterprise section is a value card + status badge + 3-step
+  onboarding instead of a dense form. Manifest 0.3.0 is live on the Chrome Web Store.
+- **Pairing documentation matches the shipped backend** (#68). The README (en/zh) and the
+  installation guide walk through the real three-step pairing flow (install the engine →
+  register the extension id → enable in options) instead of a future promise.
+
 ## [v0.5.0-beta.1] — 2026-07-07 — the browser line joins the control plane: local-engine pairing, posture-aware guard, hook hardening
 
 The browser extension stops being an island: the Chrome Web Store build (0.3.0) can pair with the

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -8,6 +8,49 @@ Vigils 的所有重要变更记录于此。格式遵循
 
 ---
 
+## [v0.5.0] — 2026-07-08 — 浏览器防线接入控制平面:商店版配对、姿态感知守护、hook 加固
+
+v0.5.0-beta.1 的稳定汇总。浏览器扩展不再是孤岛:Chrome Web Store 版本
+([Vigils Browser Guard](https://chromewebstore.google.com/detail/vigils-browser-guard/ffmgaglmcimapacgmoejaobfjdpmopch)
+0.3.0,已上架)可与本机安装的 Vigils 引擎配对,桌面端与 CLI 终于能看见浏览器防线,hook 路径
+新增两项加固。硬地板不动。
+
+### 新增
+
+- **浏览器 ⇄ 引擎连接**(#57)。native messaging host 成为 daemon 的第二个 ML 客户端:浏览器
+  检查获得与 hook 路径一致的本机 ML PII 增强(`engine.json` 门控;daemon 缺席 → fail-closed
+  回落硬指纹地板,绝不 fail-open)。
+- **扩展首个企业后端**(#58)。选项页可将检查路由到本机 Vigils 引擎(native messaging)——
+  权限为可选、仅在显式启用时请求,原文不出设备,host 不可达时阻断而非静默降级。
+- **浏览器事件进控制平面**(#59、#60、#62)。事件中心显示浏览器粘贴/输入/发送介入;防护总览
+  新增浏览器防线卡:注册与引擎状态 + 近 24 小时检查/拦截/脱敏计数。
+- **`setup --status` 浏览器行**(#61)。native host 注册态与 hook、MCP 并列——turnkey 状态
+  自此覆盖三条防线。
+- **姿态下发**(#62、#64)。host 回报 `posture_tier`/`engine`;strict 姿态下扩展将
+  confirm-redact 升级为 block(只收紧,allow/block 恒不动)。
+- **Command Guard 文件写入侧翼**(#63)。Write/Edit 工具向 shell rc、crontab、`.git/hooks`
+  的持久化落点写入,现与等价 shell 命令同样分类。
+
+### 修复
+
+- **真实富文本编辑器上的内联介入**(#64)。content script 提前到 `document_start`,站点
+  capture 监听不再饿死守门;手动输入防抖增加最长等待,框架重渲染心跳无法永久推迟检查;
+  引擎判定有风险后弹卡无条件呈现;写回前对当前文本重新检查而非严格快照等值,连续粘贴在
+  光标处叠加。
+- **事件中心如实化**(#64)。正常放行不再记为「检测到风险」;popup 事件行全部用
+  DOM/textContent 构建,不用 innerHTML。
+- **hook panic 兜底**(#65)。hook 决策+输出整体包进 `catch_unwind`:未预期 panic 收敛为
+  该 CLI 的 Deny 形状(Claude 为 exit 2),而非以 101 退出被 agent 视为 non-blocking
+  fail-open。
+
+### 变更
+
+- **扩展 UX**(#64、#66)。品牌化弹卡(盾徽、风险 chip、信任行、tone 色顶边);企业连接区
+  改为「价值卡 + 状态徽章 + 三步引导」,替代密集表单。manifest 0.3.0 已在 Chrome Web Store
+  上架。
+- **配对文档与已落地后端对齐**(#68)。README(中/英)与安装指南给出真实三步配对流程
+  (安装引擎 → 以扩展 ID 注册 → 选项页启用),不再是未来式承诺。
+
 ## [v0.5.0-beta.1] — 2026-07-07 — 浏览器防线接入控制平面:本机引擎配对、姿态感知守护、hook 加固
 
 浏览器扩展不再是孤岛:Chrome Web Store 版本(0.3.0)可与本机安装的 Vigils 引擎配对,桌面端与

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5790,7 +5790,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vigil-audit"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "hex",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-browser"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "once_cell",
  "regex",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-daemon-ipc"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "dirs 6.0.0",
  "interprocess",
@@ -5836,7 +5836,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-desktop"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "blake2",
@@ -5872,7 +5872,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-firewall"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "dunce",
  "hex",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-http-auth"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -5913,7 +5913,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-http-transport"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -5947,7 +5947,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-hub-cli"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "clap",
  "dirs 6.0.0",
@@ -5987,7 +5987,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-lease"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "hex",
  "keyring",
@@ -6005,7 +6005,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-mcp"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "hex",
  "once_cell",
@@ -6030,7 +6030,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-native-host"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "clap",
  "dirs 6.0.0",
@@ -6045,7 +6045,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-policy"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -6055,7 +6055,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-redaction"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "dirs 5.0.1",
@@ -6077,7 +6077,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-runner"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "cap-std",
  "dunce",
@@ -6098,7 +6098,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-runner-types"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "dunce",
  "serde",
@@ -6107,7 +6107,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-sandbox-linux"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "landlock",
  "libc",
@@ -6117,7 +6117,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-sdk"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "serde_json",
  "uuid",
@@ -6131,7 +6131,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-types"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -6139,7 +6139,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-ui-protocol"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_jcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0-beta.1"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Vigils",
-  "version": "0.5.0-beta.1",
+  "version": "0.5.0",
   "identifier": "ai.vigils.desktop",
   "mainBinaryName": "vigils",
   "build": {

--- a/crates/vigil-audit/Cargo.toml
+++ b/crates/vigil-audit/Cargo.toml
@@ -19,10 +19,10 @@ workspace = true
 test-util = []
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.5.0-beta.1" }
+vigil-types = { path = "../vigil-types", version = "0.5.0" }
 # I01 扩展依赖:fail-closed 入口自检(ADR 0002 §D1)。
 # I00 的 "只能依赖 vigil-types" 约束是 I00 阶段性规则,I01 按 ADR 0002 明确放开。
-vigil-redaction = { path = "../vigil-redaction", version = "0.5.0-beta.1" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.5.0" }
 
 # I01 核心依赖
 rusqlite = { workspace = true }

--- a/crates/vigil-firewall/Cargo.toml
+++ b/crates/vigil-firewall/Cargo.toml
@@ -14,12 +14,12 @@ categories = ["api-bindings", "authentication"]
 workspace = true
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.5.0-beta.1" }
-vigil-policy = { path = "../vigil-policy", version = "0.5.0-beta.1" }
-vigil-audit = { path = "../vigil-audit", version = "0.5.0-beta.1" }
+vigil-types = { path = "../vigil-types", version = "0.5.0" }
+vigil-policy = { path = "../vigil-policy", version = "0.5.0" }
+vigil-audit = { path = "../vigil-audit", version = "0.5.0" }
 # ISS-010: T0 preflight 扫描(vigil-firewall 在 evaluate 前调 scan_text 产 PII findings)。
 # 依赖方向 T1 → T0 合法(vigil-redaction 纯函数、无反向依赖)。
-vigil-redaction = { path = "../vigil-redaction", version = "0.5.0-beta.1" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.5.0" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/vigil-lease/Cargo.toml
+++ b/crates/vigil-lease/Cargo.toml
@@ -20,8 +20,8 @@ default = []
 os-keychain = ["dep:keyring"]
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.5.0-beta.1" }
-vigil-audit = { path = "../vigil-audit", version = "0.5.0-beta.1" }
+vigil-types = { path = "../vigil-types", version = "0.5.0" }
+vigil-audit = { path = "../vigil-audit", version = "0.5.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/vigil-mcp/Cargo.toml
+++ b/crates/vigil-mcp/Cargo.toml
@@ -20,24 +20,24 @@ workspace = true
 ort = ["vigil-redaction/ort"]
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.5.0-beta.1" }
-vigil-audit = { path = "../vigil-audit", version = "0.5.0-beta.1" }
-vigil-firewall = { path = "../vigil-firewall", version = "0.5.0-beta.1" }
-vigil-redaction = { path = "../vigil-redaction", version = "0.5.0-beta.1" }
+vigil-types = { path = "../vigil-types", version = "0.5.0" }
+vigil-audit = { path = "../vigil-audit", version = "0.5.0" }
+vigil-firewall = { path = "../vigil-firewall", version = "0.5.0" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.5.0" }
 # I07.5+ (ADR 0007 §I-7.1):共享 Native spawn env 政策 helper(apply_native_env_policy)。
 # ADR 0018 v0.13 split:改依赖 vigil-runner-types(pure types + env policy,0 vigil
 # deps,unblock SDK publish chain),不再拉 vigil-runner concrete impl(wasmtime 等)。
-vigil-runner-types = { path = "../vigil-runner-types", version = "0.5.0-beta.1" }
+vigil-runner-types = { path = "../vigil-runner-types", version = "0.5.0" }
 # v0.5 P1 ADR 0014 α2:`pub fn Hub::resolve_approval` 用到的 typed 协议结构
 # (ResolveApprovalReq / ApprovalAction / ApprovalResolutionDto)。
 # vigil-ui-protocol 自身只依赖 vigil-types / vigil-audit / vigil-runner,
 # 与 vigil-mcp 现有 deps 无循环。
-vigil-ui-protocol = { path = "../vigil-ui-protocol", version = "0.5.0-beta.1" }
+vigil-ui-protocol = { path = "../vigil-ui-protocol", version = "0.5.0" }
 # 可逆脱敏 Slice 2:复用 `SecretValue`(Zeroizing/non-Debug/单一 expose)的值卫生装
 # Hub-owned `SecretAliasMap`。**只取值包装**,不引 LeaseBroker 审批门控语义(设计 D2:
 # broker mint-time 3-tuple 绑定与"运行时选 tool"现实冲突)。不启 os-keychain feature
 # —— keyring 读取在 vigil-hub-cli(已带该 feature)。
-vigil-lease = { path = "../vigil-lease", version = "0.5.0-beta.1" }
+vigil-lease = { path = "../vigil-lease", version = "0.5.0" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -52,7 +52,7 @@ once_cell = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 rusqlite = { workspace = true }
-vigil-policy = { path = "../vigil-policy", version = "0.5.0-beta.1" }
+vigil-policy = { path = "../vigil-policy", version = "0.5.0" }
 # α2 集成测试 `tests/resolve_approval.rs` 用 Ledger 真实建 approval + 调
 # `Hub::resolve_approval` 全链路验证 approve / deny / cancel(已是 main dep,
 # 此处显式声明仅为 IDE / `cargo metadata` 可读性)。

--- a/crates/vigil-policy/Cargo.toml
+++ b/crates/vigil-policy/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["api-bindings", "authentication"]
 workspace = true
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.5.0-beta.1" }
+vigil-types = { path = "../vigil-types", version = "0.5.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/vigil-sdk/Cargo.toml
+++ b/crates/vigil-sdk/Cargo.toml
@@ -23,14 +23,14 @@ ort = ["vigil-firewall/ort", "vigil-redaction/ort"]
 
 [dependencies]
 # Stable SDK re-exports;path-dep,locked to workspace version
-vigil-types = { path = "../vigil-types", version = "0.5.0-beta.1" }
-vigil-firewall = { path = "../vigil-firewall", version = "0.5.0-beta.1" }
-vigil-redaction = { path = "../vigil-redaction", version = "0.5.0-beta.1" }
-vigil-mcp = { path = "../vigil-mcp", version = "0.5.0-beta.1" }
+vigil-types = { path = "../vigil-types", version = "0.5.0" }
+vigil-firewall = { path = "../vigil-firewall", version = "0.5.0" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.5.0" }
+vigil-mcp = { path = "../vigil-mcp", version = "0.5.0" }
 # v0.16 FirewallBuilder facade:内部装配用(Ledger / PolicyEngine + default_ruleset)。
 # **不** re-export —— 仅 firewall_builder 内化使用,守 SDK 边界。
-vigil-audit = { path = "../vigil-audit", version = "0.5.0-beta.1" }
-vigil-policy = { path = "../vigil-policy", version = "0.5.0-beta.1" }
+vigil-audit = { path = "../vigil-audit", version = "0.5.0" }
+vigil-policy = { path = "../vigil-policy", version = "0.5.0" }
 # decide_call 便捷方法生成 invocation_id(UUIDv4);内部用,不进 SDK public API。
 uuid = { workspace = true }
 # decide_call 的 args 形参类型(serde_json::Value 已是 ToolInvocation.args 的公开类型,不扩面)。

--- a/crates/vigil-ui-protocol/Cargo.toml
+++ b/crates/vigil-ui-protocol/Cargo.toml
@@ -14,11 +14,11 @@ categories = ["data-structures", "api-bindings"]
 workspace = true
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.5.0-beta.1" }
-vigil-audit = { path = "../vigil-audit", version = "0.5.0-beta.1" }
+vigil-types = { path = "../vigil-types", version = "0.5.0" }
+vigil-audit = { path = "../vigil-audit", version = "0.5.0" }
 # ADR 0018 v0.13 split:改依赖 vigil-runner-types(pure types,0 vigil deps),
 # 不再拉 vigil-runner concrete(wasmtime/sandbox-linux),unblock SDK publish。
-vigil-runner-types = { path = "../vigil-runner-types", version = "0.5.0-beta.1" }
+vigil-runner-types = { path = "../vigil-runner-types", version = "0.5.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
## What

Stable roll-up of **v0.5.0-beta.1** (#57–#66) plus the pairing-guide truth-up (#68). Version bump across the workspace `Cargo.toml`, `tauri.conf.json`, all 26 inter-crate path-dep pins, and `Cargo.lock`; bilingual CHANGELOG `## [v0.5.0]` entries (the release workflow extracts stable notes from these — required for stable tags).

The Chrome Web Store build 0.3.0 is **live**, and its enterprise pairing promise is exactly what this release delivers to end users (posture-aware native-host backend + hook hardening + browser line in the control plane).

## Acceptance evidence (published beta.1 artifacts, not local builds)

- Local packaging audit **26/0**: 27 assets, 6 CLI sha256 (zero CRLF), per-platform arch, `vigil-native-host` bundled ×3, ORT dylib exe-adjacent ×3, minisign crypto verify 3/3, OTA manifests ×3 + 302.
- Linux **13/0 + daemon-regression 2/0** (turnkey 738MB model → warm-load → hook; fail-closed bare AWS key; ML semantic PII; ML-SKIP closure; functional-sweep 18/0; stale-socket kill-9 rebind).
- macOS **13/0 + 2/0** (same matrix; historical R1 peer-creds & stale-socket blockers keep passing).
- Windows VM **5/0** (version, ORT dll LoadLibrary, turnkey, named-pipe R1).
- Store-distributed CRX (0.3.0) byte-matches the repo source (only Google-injected `update_url` + `_metadata/` differ); release `vigils-chrome-extension.zip` byte-matches the tag.

## Gates

Remote workspace `cargo update -w` lock-identity **True**, fmt (LF semantics) / clippy `-D warnings` / test all green. Release-workflow stale-pin and version-consistency assertions pre-verified locally (all 26 pins at `0.5.0`).