### PR TITLE
docs: version-agnostic example output in the install verify step

### DIFF
--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -136,7 +136,7 @@ vigil-native-host install --extension-id <EXTENSION_ID>
 
 ```powershell
 # Windows
-.\vigil-hub.exe --version      # 应打印 vigil-hub 版本号(如 vigil-hub 0.4.6)
+.\vigil-hub.exe --version      # 应打印所装 release 的版本号(与下载的 tag 一致)
 .\vigil-native-host.exe status # 应打印 installed: true + manifest 路径
 ```
 


### PR DESCRIPTION
The `--version` verify example printed a hard-coded `vigil-hub 0.4.6`, which goes stale on every release (it already lagged v0.5.0). Reworded to describe the expected shape instead of a literal version — this line never needs a bump again.