### PR TITLE
feat(cli): three new MCP gateway surfaces (Kimi CLI / ZCode / pi) + agent-surface hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,53 @@ All notable changes to Vigils are documented here. The format follows
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **Three new MCP gateway surfaces: Kimi CLI, ZCode, pi.** `setup --mcp` / `setup --all` (and
+  `--doctor`, `--status`, `quickstart`) now auto-detect and protect:
+  - **Kimi CLI** (Moonshot) — `~/.kimi/mcp.json` (standard top-level `mcpServers`), server-id
+    namespace `kimi-`. Kimi's hook surface is deliberately **not** registered: it is Beta and
+    officially fail-open (a crashed or timed-out hook allows the action), which does not meet
+    Vigils' enforcement semantics; re-evaluated at GA.
+  - **ZCode** (Z.ai) — the nested `mcp.servers` key inside `~/.zcode/cli/config.json`, via a
+    dedicated pipeline (contract evidenced from the vendor's shipped application code, not
+    third-party writeups). Extra GUI fields such as `enabled` are preserved verbatim; close ZCode
+    before `--apply`. Namespace `zcode-`. The workspace-level `.zcode/config.json` (in-repo) and
+    the shared `~/.agents/mcp.json` fallback are deliberately untouched.
+  - **pi** (badlogic) — `$PI_AGENT_DIR/mcp.json` (default `~/.pi/agent/`, honors
+    `PI_CODING_AGENT_DIR`/`PI_AGENT_DIR`), the pi-mcp-adapter convention file; pi itself ships no
+    built-in MCP. A missing file is honestly reported as "nothing to protect" and never created.
+    Namespace `pi-`.
+
+### Fixed
+
+- **Agent-surface hardening** (from a two-track adversarial code review of the integration
+  surface):
+  - `CODEX_HOME` split: the MCP wrap surface previously hard-coded `~/.codex/config.toml` while
+    the hook surface honored `$CODEX_HOME` — MCP servers of custom-home Codex installs were
+    silently unprotected and invisible to `--status`/`--doctor`. Both now resolve through the
+    same path (with guard tests).
+  - Managed-entry grammar unified: classification (`AlreadyWrapped`) and restore (`unwrap`) now
+    accept exactly the same wrap grammar (sentinel must sit immediately before `--`), closing a
+    state where an entry counted as protected but could not be uninstalled, and a spoofed
+    sentinel could dodge wrapping.
+  - Supported-agent registry SSOT: the agent list previously lived in 4 call sites
+    (status counts / doctor / apply orchestration / quickstart); adding an agent could silently
+    miss one. Now a single `all_json_mcp_agents()` registry with a validated-prefix constructor
+    (charset + reserved `user`/`local`/`codex` namespaces) and registry-driven invariant tests.
+  - Root-shape strictness: a present-but-wrong-typed `mcpServers` (JSON) / `mcp_servers` (TOML)
+    was silently treated as "no servers" (config present yet fully unprotected, no signal). Now
+    aborts as an unsupported shape; Codex inline-table form gains support; `--doctor` reports a
+    `ConfigError` row.
+  - `--status` honesty: per-agent MCP counts no longer collapse "config exists but unreadable /
+    unparsable" into `0` — a distinct config-error state is shown instead.
+  - Preview/apply server-id parity: the preview used to hand-concatenate `<prefix>-<name>` while
+    apply slugs + hashes names; both now derive through the same function.
+  - The pre-apply PATH warning (underlying program not resolvable) now covers every surface
+    (Claude user+local / Codex / ZCode / JSON-agent registry), labeled per surface.
+
 ## [v0.5.0] — 2026-07-08 — the browser line joins the control plane: store pairing, posture-aware guard, hook hardening
 
 The stable roll-up of v0.5.0-beta.1. The browser extension stops being an island: the Chrome Web

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -8,6 +8,46 @@ Vigils 的所有重要变更记录于此。格式遵循
 
 ---
 
+## [Unreleased]
+
+### 新增
+
+- **MCP 网关新增三个 agent 接入面:Kimi CLI / ZCode / pi。** `setup --mcp` / `setup --all`
+  (及 `--doctor`、`--status`、`quickstart`)现可自动探测并保护:
+  - **Kimi CLI**(Moonshot)—— `~/.kimi/mcp.json`(标准顶层 `mcpServers`),server-id 命名空间
+    `kimi-`。Kimi 的 hook 面**刻意不注册**:该功能为 Beta 且官方 fail-open(hook 崩溃/超时 =
+    放行),不满足 Vigils 的强保护语义;GA 后重评。
+  - **ZCode**(Z.ai)—— `~/.zcode/cli/config.json` 内嵌套的 `mcp.servers` 键,独立专线
+    (契约取证自 vendor 实际发布的应用代码,非第三方资料)。`enabled` 等 GUI 附加字段逐字
+    保留;`--apply` 前请关闭 ZCode。命名空间 `zcode-`。工作区级 `.zcode/config.json`(项目内
+    文件)与共享 `~/.agents/mcp.json` fallback 刻意不碰。
+  - **pi**(badlogic)—— `$PI_AGENT_DIR/mcp.json`(默认 `~/.pi/agent/`,支持
+    `PI_CODING_AGENT_DIR`/`PI_AGENT_DIR`),即 pi-mcp-adapter 约定文件;pi 本体无内置 MCP。
+    文件不存在即如实报告"无可保护项",绝不代为创建。命名空间 `pi-`。
+
+### 修复
+
+- **agent 接入面系统性加固**(双线对抗性代码评审产出):
+  - `CODEX_HOME` 分裂:MCP wrap 面此前硬编码 `~/.codex/config.toml`,而 hook 面尊重
+    `$CODEX_HOME` —— 自定义目录的 Codex 安装其 MCP server 全部静默漏保护且
+    `--status`/`--doctor` 不可见。现两面共用同一路径解析(带守门测试)。
+  - 托管条目 grammar 统一:分类(`AlreadyWrapped`)与还原(`unwrap`)现接受完全一致的 wrap
+    grammar(sentinel 必须紧邻 `--`),堵住"计为已保护却无法卸载"的假托管态,以及伪造
+    sentinel 逃逸包裹的口子。
+  - 受支持 agent 清单 SSOT:清单此前散落 4 处调用点(status 计数 / doctor / apply 编排 /
+    quickstart),新增 agent 可能静默漏一处。现收敛为 `all_json_mcp_agents()` 单一 registry +
+    受校验前缀构造器(字符集 + `user`/`local`/`codex` 保留命名空间)+ registry 驱动的
+    invariant 测试。
+  - 根形状严格化:`mcpServers`(JSON)/ `mcp_servers`(TOML)**存在但类型错**此前被静默当作
+    "没有 server"(配置在场却完全不受保护、无任何信号)。现按不支持形状 abort;Codex 内联表
+    形态顺带获得支持;`--doctor` 输出 `ConfigError` 行。
+  - `--status` 诚实化:逐 agent MCP 计数不再把"配置存在但读不了/解析失败"折叠成 `0`,
+    改为独立的配置错误状态。
+  - preview 与 apply 的 server-id 同源:预览此前手拼 `<prefix>-<name>`,apply 则做
+    slug + 哈希规约;现共用同一派生函数。
+  - apply 前 PATH 预警(底层程序不可解析)扩展到全部接入面(Claude user+local / Codex /
+    ZCode / JSON-agent registry),并按接入面标注。
+
 ## [v0.5.0] — 2026-07-08 — 浏览器防线接入控制平面:商店版配对、姿态感知守护、hook 加固
 
 v0.5.0-beta.1 的稳定汇总。浏览器扩展不再是孤岛:Chrome Web Store 版本

--- a/apps/vigil-hub-cli/src/main.rs
+++ b/apps/vigil-hub-cli/src/main.rs
@@ -602,7 +602,12 @@ fn main() -> std::process::ExitCode {
                         // `--mcp` turnkey 用户未保护)。逐 agent 统计(F-6:只报 Claude 会让
                         // setup --all 保护的 Codex/Cursor 覆盖面在 status 里不可见)。
                         let mcp_counts = dirs::home_dir()
-                            .map(|h| setup_mcp::wrapped_server_counts_all_agents(&h))
+                            .map(|h| {
+                                setup_mcp::wrapped_server_counts_all_agents(
+                                    &h,
+                                    &setup_mcp::AgentEnv::from_process_env(),
+                                )
+                            })
                             .unwrap_or_default();
                         let code = print_setup_report(lang, &setup_args, &report, &mcp_counts);
                         // 其余 agent 的 hook 注册面(Codex/Gemini/Cursor):检测到才注册,逐面诚实
@@ -859,6 +864,8 @@ fn setup_mcp_dispatch(
         .map_err(|_| setup::SetupError::MissingCurrentExe)?
         .to_string_lossy()
         .to_string();
+    // 生产 env 快照(CODEX_HOME / PI_AGENT_DIR):只在此入口读一次,库函数全注入式。
+    let agent_env = setup_mcp::AgentEnv::from_process_env();
     // wrap 网关姿态:默认 monitor(观察放行+脱敏+审计+裸 secret 拦截);`--enforce` 升级为 default-deny
     // 硬拦。第三方 server 工具名不在 effect 词表 → enforce 一律 default-deny = server 全不可用,故默认 monitor
     // 让 turnkey 接入即可用且仍守全部硬地板(详见 CliSetupArgs::enforce doc)。
@@ -871,32 +878,39 @@ fn setup_mcp_dispatch(
             // 开始 spawn)在 stderr 明确告警,而非仅 help 文案 / 事后表头。
             match lang {
                 Lang::En => eprintln!(
-                    "[vigil-hub] --probe will briefly START each configured MCP server (Claude / Codex / \
-                     Cursor / Windsurf) — running its startup code — to test a real MCP handshake, then \
+                    "[vigil-hub] --probe will briefly START each configured MCP server (across every \
+                     supported agent) — running its startup code — to test a real MCP handshake, then \
                      stop it. Ctrl-C to abort."
                 ),
                 Lang::Zh => eprintln!(
-                    "[vigil-hub] --probe 会短暂启动每个已配置的 MCP 服务器(Claude / Codex / Cursor / \
-                     Windsurf)—— 执行其启动代码 —— 以测试真实 MCP 握手,随后停止它。Ctrl-C 可中止。"
+                    "[vigil-hub] --probe 会短暂启动每个已配置的 MCP 服务器(覆盖全部受支持 agent)\
+                     —— 执行其启动代码 —— 以测试真实 MCP 握手,随后停止它。Ctrl-C 可中止。"
                 ),
             }
             Some(setup_mcp::DOCTOR_PROBE_TIMEOUT)
         } else {
             None
         };
-        let rows = setup_mcp::run_doctor(&home, probe_timeout)?;
+        let rows = setup_mcp::run_doctor(&home, &agent_env, probe_timeout)?;
         Ok(print_mcp_doctor(lang, &rows))
     } else if args.uninstall {
-        // 所有 agent 接入面都还原:Claude + Codex + Cursor + Windsurf(各独立文件,逐一诚实报告)。
+        // 所有 agent 接入面都还原:Claude + Codex + 全部 JSON-agent registry(各独立文件,逐一诚实报告)。
         let rep = setup_mcp::run_uninstall(&home, args.dry_run)?;
         let mut code = print_mcp_apply(lang, &rep, "uninstall");
         code = run_codex_leg(
             lang,
-            setup_mcp::run_codex_uninstall(&home, args.dry_run),
+            setup_mcp::run_codex_uninstall(&home, agent_env.codex_home.as_deref(), args.dry_run),
             "uninstall",
             code,
         );
-        for agent in json_mcp_agents(&home) {
+        code = run_json_agent_leg(
+            lang,
+            setup_mcp::run_zcode_uninstall(&home, args.dry_run),
+            "ZCode",
+            "uninstall",
+            code,
+        );
+        for agent in setup_mcp::all_json_mcp_agents(&home, &agent_env) {
             code = run_json_agent_leg(
                 lang,
                 setup_mcp::run_json_agent_uninstall(&agent, args.dry_run),
@@ -908,31 +922,46 @@ fn setup_mcp_dispatch(
         Ok(code)
     } else if args.apply {
         // 所有面都保护(turnkey:一条命令覆盖用户全部 agent 接入面)。
-        // #16:apply 前先查底层程序在 PATH 是否可解析(apply 后条目变 AlreadyWrapped 不再可查)。
-        let unresolvable = setup_mcp::unresolvable_wrappables(&home);
+        // #16:apply 前先查**全部接入面**底层程序在 PATH 是否可解析(apply 后条目变 AlreadyWrapped
+        // 不再可查;此前只查 Claude user scope,其余面无同款即时预警 —— review 2026-07-17 LOW-1)。
+        let unresolvable = setup_mcp::unresolvable_wrappables(&home, &agent_env);
         let rep = setup_mcp::run_apply(&home, &exe, args.dry_run, args.user_scope_only, monitor)?;
         let mut code = print_mcp_apply(lang, &rep, "apply");
         // #16:非阻塞 WARN —— 底层程序找不到的 server 仍被 wrap(配置正确),但会在 agent 启动时静默
         // 失败,故诚实告知(避免"Protected"虚假安全感)。
-        for (name, prog) in &unresolvable {
+        for (agent_label, name, prog) in &unresolvable {
             match lang {
                 Lang::En => eprintln!(
-                    "  WARNING: MCP server '{name}' command '{prog}' not found on PATH; once wrapped it \
-                     will fail when the agent starts it (install it or fix the path in your config)"
+                    "  WARNING: [{agent_label}] MCP server '{name}' command '{prog}' not found on PATH; \
+                     once wrapped it will fail when the agent starts it (install it or fix the path in \
+                     your config)"
                 ),
                 Lang::Zh => eprintln!(
-                    "  警告:MCP 服务器 '{name}' 的命令 '{prog}' 不在 PATH 中;一旦被 wrap,agent 启动它时 \
-                     会失败(请安装它,或在配置里修好路径)"
+                    "  警告:[{agent_label}] MCP 服务器 '{name}' 的命令 '{prog}' 不在 PATH 中;一旦被 \
+                     wrap,agent 启动它时会失败(请安装它,或在配置里修好路径)"
                 ),
             }
         }
         code = run_codex_leg(
             lang,
-            setup_mcp::run_codex_apply(&home, &exe, args.dry_run, monitor),
+            setup_mcp::run_codex_apply(
+                &home,
+                agent_env.codex_home.as_deref(),
+                &exe,
+                args.dry_run,
+                monitor,
+            ),
             "apply",
             code,
         );
-        for agent in json_mcp_agents(&home) {
+        code = run_json_agent_leg(
+            lang,
+            setup_mcp::run_zcode_apply(&home, &exe, args.dry_run, monitor),
+            "ZCode",
+            "apply",
+            code,
+        );
+        for agent in setup_mcp::all_json_mcp_agents(&home, &agent_env) {
             code = run_json_agent_leg(
                 lang,
                 setup_mcp::run_json_agent_apply(&agent, &exe, args.dry_run, monitor),
@@ -946,14 +975,14 @@ fn setup_mcp_dispatch(
         let rep = setup_mcp::run_preview(&home, &exe, monitor)?;
         let code = print_mcp_preview(lang, &rep);
         // 预览只读:某 agent 配置 malformed 不硬 abort(什么都没写),优雅降级为一行提示而非突兀报错。
-        match setup_mcp::run_codex_preview(&home, &exe, monitor) {
+        match setup_mcp::run_codex_preview(&home, agent_env.codex_home.as_deref(), &exe, monitor) {
             Ok(codex) => print_codex_preview(lang, &codex),
             Err(e) => {
                 println!();
                 println!(
                     "  {}{}",
                     tr(lang, "Codex CLI config: ", "Codex CLI 配置:"),
-                    setup_mcp::codex_config_path(&home).display()
+                    setup_mcp::codex_config_path(&home, agent_env.codex_home.as_deref()).display()
                 );
                 match lang {
                     Lang::En => println!(
@@ -965,7 +994,27 @@ fn setup_mcp_dispatch(
                 }
             }
         }
-        for agent in json_mcp_agents(&home) {
+        // ZCode(嵌套键专线;报告结构与 JSON-agent 同款,渲染复用)。
+        match setup_mcp::run_zcode_preview(&home, &exe, monitor) {
+            Ok(r) => print_json_agent_preview(lang, &r),
+            Err(e) => {
+                println!();
+                println!(
+                    "  {}{}",
+                    tr(lang, "ZCode config: ", "ZCode 配置:"),
+                    setup_mcp::zcode_config_path(&home).display()
+                );
+                match lang {
+                    Lang::En => println!(
+                        "  (could not read it: {e} -- fix the file to preview/protect ZCode MCP servers)"
+                    ),
+                    Lang::Zh => println!(
+                        "  (无法读取:{e} —— 修好该文件以预览 / 保护 ZCode 的 MCP 服务器)"
+                    ),
+                }
+            }
+        }
+        for agent in setup_mcp::all_json_mcp_agents(&home, &agent_env) {
             match setup_mcp::run_json_agent_preview(&agent, &exe, monitor) {
                 Ok(r) => print_json_agent_preview(lang, &r),
                 Err(e) => {
@@ -995,14 +1044,6 @@ fn setup_mcp_dispatch(
         }
         Ok(code)
     }
-}
-
-/// turnkey 覆盖的"JSON `mcpServers` 形态"agent 列表(Cursor + Windsurf)。新增同形态 agent 只在此扩列。
-fn json_mcp_agents(home: &std::path::Path) -> [setup_mcp::JsonMcpAgent; 2] {
-    [
-        setup_mcp::JsonMcpAgent::cursor(home),
-        setup_mcp::JsonMcpAgent::windsurf(home),
-    ]
 }
 
 /// 运行 Codex 接入面的一步(apply/uninstall)并**诚实处理半应用状态**(Codex review #7 MEDIUM):
@@ -1355,14 +1396,27 @@ fn run_setup_all(
             // `run_*_leg` **诚实半应用报告**(不回滚已应用面 —— 各面独立、各自可逆)。op 在 dry-run 时为
             // "preview";各步只认 apply/uninstall(dry 措辞由报告里 dry_run 决定)。
             let exe_str = exe.to_string_lossy().to_string();
+            let agent_env = setup_mcp::AgentEnv::from_process_env();
             let mcp_op = if args.uninstall { "uninstall" } else { "apply" };
             let codex_res = if args.uninstall {
-                setup_mcp::run_codex_uninstall(&home, args.dry_run)
+                setup_mcp::run_codex_uninstall(&home, agent_env.codex_home.as_deref(), args.dry_run)
             } else {
-                setup_mcp::run_codex_apply(&home, &exe_str, args.dry_run, monitor)
+                setup_mcp::run_codex_apply(
+                    &home,
+                    agent_env.codex_home.as_deref(),
+                    &exe_str,
+                    args.dry_run,
+                    monitor,
+                )
             };
             code = run_codex_leg(lang, codex_res, mcp_op, code);
-            for agent in json_mcp_agents(&home) {
+            let zcode_res = if args.uninstall {
+                setup_mcp::run_zcode_uninstall(&home, args.dry_run)
+            } else {
+                setup_mcp::run_zcode_apply(&home, &exe_str, args.dry_run, monitor)
+            };
+            code = run_json_agent_leg(lang, zcode_res, "ZCode", mcp_op, code);
+            for agent in setup_mcp::all_json_mcp_agents(&home, &agent_env) {
                 let res = if args.uninstall {
                     setup_mcp::run_json_agent_uninstall(&agent, args.dry_run)
                 } else {
@@ -1715,21 +1769,34 @@ fn print_mcp_doctor(lang: Lang, rows: &[setup_mcp::McpDoctorRow]) -> std::proces
             "  {}",
             tr(
                 lang,
-                "No MCP servers found across Claude / Codex / Cursor / Windsurf (nothing to check).",
-                "Claude / Codex / Cursor / Windsurf 均未找到 MCP 服务器(无需检查)。",
+                "No MCP servers found across any supported agent (nothing to check).",
+                "所有受支持 agent 均未找到 MCP 服务器(无需检查)。",
             )
         );
         return std::process::ExitCode::SUCCESS;
     }
+    // agent 显示名集合(registry + Codex;本程序固定字面量,非用户输入):doctor 行的 scope 若命中
+    // 即"某 agent 面",否则是 Claude 的 user/项目路径。此前硬编码三家,新增 agent 的行会被误判成
+    // Claude local 项目渲染为 `local:<agent>`(review 2026-07-17 MED-2)。路径参数只为取名,传空即可。
+    let agent_labels: Vec<&'static str> = ["Codex", "ZCode"]
+        .into_iter()
+        .chain(
+            setup_mcp::all_json_mcp_agents(
+                std::path::Path::new(""),
+                &setup_mcp::AgentEnv::default(),
+            )
+            .iter()
+            .map(|a| a.display_name),
+        )
+        .collect();
     let mut failed = 0usize;
     for r in rows {
-        // scope 标注:Claude user / Claude 项目路径(local) / 其它 agent(Codex/Cursor/Windsurf)。
-        // 三个 agent 名是本程序固定字面量(非用户输入),据此与 Claude 的 user/local-path 区分。wrapped
-        // 标注是否已受 Vigil 保护。全部过 scrub。
+        // scope 标注:Claude user / Claude 项目路径(local) / 其它 agent 面。wrapped 标注是否已受
+        // Vigil 保护。全部过 scrub。
         let name = scrub(&r.name);
         let scope = match r.scope.as_str() {
             "user" => "user".to_string(),
-            "Codex" | "Cursor" | "Windsurf" => r.scope.clone(),
+            s if agent_labels.contains(&s) => r.scope.clone(),
             other => format!("local:{}", scrub(other)),
         };
         let guard = if r.wrapped { " [vigil-wrapped]" } else { "" };
@@ -2355,10 +2422,17 @@ fn print_json_agent_preview(lang: Lang, r: &setup_mcp::JsonAgentPreviewReport) {
             r.wrappable_count()
         ),
     }
-    // server-id 派生须与 apply 一致(`<prefix>-<name>`)。prefix 是 &'static str,闭包捕获。
+    // server-id 派生与 apply 同源(json_agent_server_id SSOT)—— 此前手拼 `{prefix}-{name}`,
+    // 名含大写/空格时与 apply 的 slug+hash 规约不一致(review 2026-07-17 MED-6)。
     let prefix = r.id_prefix;
     for s in &r.servers {
-        print_mcp_server_preview(lang, &r.exe, |n| format!("{prefix}-{n}"), s, r.monitor);
+        print_mcp_server_preview(
+            lang,
+            &r.exe,
+            |n| setup_mcp::json_agent_server_id(prefix, n),
+            s,
+            r.monitor,
+        );
     }
 }
 
@@ -2435,10 +2509,17 @@ fn print_setup_report(
     lang: Lang,
     args: &SetupArgs,
     r: &setup::SetupReport,
-    mcp_counts: &[(&'static str, usize)],
+    mcp_counts: &[(&'static str, setup_mcp::AgentWrapStatus)],
 ) -> std::process::ExitCode {
     use setup::ProtectionState;
-    let mcp_wrapped: usize = mcp_counts.iter().map(|(_, n)| n).sum();
+    use setup_mcp::AgentWrapStatus;
+    let mcp_wrapped: usize = mcp_counts
+        .iter()
+        .map(|(_, st)| match st {
+            AgentWrapStatus::Wrapped(n) => *n,
+            AgentWrapStatus::ConfigError => 0,
+        })
+        .sum();
     if args.status {
         let self_test = setup::doctor_self_test();
         println!("{}", tr(lang, "Vigil status", "Vigil 状态"));
@@ -2493,17 +2574,29 @@ fn print_setup_report(
                 ProtectionState::NotInstalled => tr(lang, "not installed", "未安装"),
             }
         );
+        // 逐 agent 明细(非零项 + ConfigError 项):用户能一眼确认 setup --all 的全局覆盖面。
+        // ConfigError(配置在但读/解析失败)**必须**出现在明细里 —— 此前被折叠成 0,配置损坏的
+        // agent 与"未配置"不可区分,status 呈现虚假"全部正常"(review 2026-07-17 MED-4)。
+        let mut detail: Vec<String> = Vec::new();
+        let mut config_errors = 0usize;
+        for (name, st) in mcp_counts {
+            match st {
+                AgentWrapStatus::Wrapped(n) if *n > 0 => detail.push(format!("{name} {n}")),
+                AgentWrapStatus::Wrapped(_) => {}
+                AgentWrapStatus::ConfigError => {
+                    config_errors += 1;
+                    detail.push(format!(
+                        "{name} {}",
+                        tr(lang, "CONFIG ERROR", "配置读取失败")
+                    ));
+                }
+            }
+        }
         println!(
             "  {}{}",
             tr(lang, "MCP gateway:   ", "MCP 网关:     "),
-            if mcp_wrapped > 0 {
-                // 逐 agent 明细(只列非零项):用户能一眼确认 setup --all 的全局覆盖面。
-                let detail = mcp_counts
-                    .iter()
-                    .filter(|(_, n)| *n > 0)
-                    .map(|(name, n)| format!("{name} {n}"))
-                    .collect::<Vec<_>>()
-                    .join(" / ");
+            if mcp_wrapped > 0 || config_errors > 0 {
+                let detail = detail.join(" / ");
                 match lang {
                     Lang::En => format!("{mcp_wrapped} server(s) wrapped ({detail})"),
                     Lang::Zh => format!("已防护 {mcp_wrapped} 个服务器({detail})"),
@@ -2512,6 +2605,16 @@ fn print_setup_report(
                 tr(lang, "no servers wrapped", "尚未防护任何服务器").to_string()
             }
         );
+        if config_errors > 0 {
+            println!(
+                "  {}",
+                tr(
+                    lang,
+                    "                (a config exists but could not be checked -- run `vigil-hub setup --mcp --doctor` for details)",
+                    "                (有配置存在但无法检查 —— 运行 `vigil-hub setup --mcp --doctor` 查看详情)",
+                )
+            );
+        }
         // 浏览器防线(可选层):native host 注册态。直调 install::status(纯文件/注册表
         // 只读,与桌面 Protection Overview 卡同源判定 is_registered,防重实现漂移)。
         println!(

--- a/apps/vigil-hub-cli/src/quickstart.rs
+++ b/apps/vigil-hub-cli/src/quickstart.rs
@@ -10,7 +10,7 @@
 use std::path::Path;
 
 use crate::i18n::Lang;
-use crate::setup_mcp::{self, JsonMcpAgent, McpServerClass};
+use crate::setup_mcp::{self, McpServerClass};
 
 /// 单 agent 的 MCP server 分类计数。
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -145,8 +145,9 @@ pub fn run(home: &Path, exe: &str, lang: Lang) -> i32 {
         Err(e) => println!("{}", could_not_read(lang, "Claude Code", e)),
     }
 
-    // Codex(`~/.codex/config.toml`)。
-    match setup_mcp::run_codex_preview(home, exe, monitor) {
+    // Codex(`$CODEX_HOME/config.toml`)。生产 env 快照只在此入口读一次(库函数注入式)。
+    let agent_env = setup_mcp::AgentEnv::from_process_env();
+    match setup_mcp::run_codex_preview(home, agent_env.codex_home.as_deref(), exe, monitor) {
         Ok(r) => {
             let c = count_servers(&r.servers);
             println!("{}", agent_line(lang, "Codex", c.total() > 0, c));
@@ -155,8 +156,18 @@ pub fn run(home: &Path, exe: &str, lang: Lang) -> i32 {
         Err(e) => println!("{}", could_not_read(lang, "Codex", e)),
     }
 
-    // Cursor + Windsurf(JSON `mcpServers` 形态)。
-    for agent in [JsonMcpAgent::cursor(home), JsonMcpAgent::windsurf(home)] {
+    // ZCode(`~/.zcode/cli/config.json` 嵌套 `mcp.servers` 专线)。
+    match setup_mcp::run_zcode_preview(home, exe, monitor) {
+        Ok(r) => {
+            let c = count_servers(&r.servers);
+            println!("{}", agent_line(lang, "ZCode", c.total() > 0, c));
+            total_unprotected += c.unprotected;
+        }
+        Err(e) => println!("{}", could_not_read(lang, "ZCode", e)),
+    }
+
+    // 全部 JSON `mcpServers` 形态 agent(registry SSOT:Cursor / Windsurf / Kimi / pi)。
+    for agent in setup_mcp::all_json_mcp_agents(home, &agent_env) {
         match setup_mcp::run_json_agent_preview(&agent, exe, monitor) {
             Ok(r) => {
                 let c = count_servers(&r.servers);

--- a/apps/vigil-hub-cli/src/setup_hooks.rs
+++ b/apps/vigil-hub-cli/src/setup_hooks.rs
@@ -118,8 +118,13 @@ pub struct AgentHookSpec {
     versioned_root: bool,
 }
 
-/// 解析 `$CODEX_HOME`:env 非空白 → 该值(`~`/`~/...` 展开到 home);否则默认 `~/.codex`。
-fn resolve_codex_home(home: &Path, env_val: Option<&str>) -> PathBuf {
+/// 通用 agent 配置目录解析:env 非空白 → 该值(`~`/`~/...` 展开到 home);否则 `default()`。
+/// Codex(`CODEX_HOME`)与 pi(`PI_AGENT_DIR`)共用同一展开语义(SSOT,注入式可测)。
+pub(crate) fn resolve_agent_dir(
+    home: &Path,
+    env_val: Option<&str>,
+    default: impl FnOnce() -> PathBuf,
+) -> PathBuf {
     match env_val.map(str::trim).filter(|s| !s.is_empty()) {
         Some("~") => home.to_path_buf(),
         Some(s) => {
@@ -129,8 +134,16 @@ fn resolve_codex_home(home: &Path, env_val: Option<&str>) -> PathBuf {
                 PathBuf::from(s)
             }
         }
-        None => home.join(".codex"),
+        None => default(),
     }
+}
+
+/// 解析 `$CODEX_HOME`:env 非空白 → 该值(`~`/`~/...` 展开到 home);否则默认 `~/.codex`。
+/// `pub(crate)`:MCP 接入面([`crate::setup_mcp::codex_config_path`])与 hook 注册面共用**同一**
+/// 解析(SSOT)—— 此前 MCP 面固定 `~/.codex`,自定义 `CODEX_HOME` 的用户其 MCP server 全部
+/// 漏保护且 status/doctor 不可见(agent-surface review 2026-07-17 HIGH-1)。
+pub(crate) fn resolve_codex_home(home: &Path, env_val: Option<&str>) -> PathBuf {
+    resolve_agent_dir(home, env_val, || home.join(".codex"))
 }
 
 /// Codex CLI 注册面规格。`codex_home_env` = `CODEX_HOME` 环境变量值(生产由 [`all_agent_specs`] 读)。

--- a/apps/vigil-hub-cli/src/setup_mcp.rs
+++ b/apps/vigil-hub-cli/src/setup_mcp.rs
@@ -56,6 +56,32 @@ const MAX_CLAUDE_JSON_BYTES: u64 = 256 * 1024 * 1024;
 /// `--vigil-managed-mcp` clap flag 一致;也是 `wrap` 子命令忽略的托管标记。
 pub const VIGIL_MANAGED_MCP_MARKER: &str = "--vigil-managed-mcp";
 
+/// arg 是否 sentinel token(精确 `--vigil-managed-mcp` 或 `--vigil-managed-mcp=...` 形态)。
+fn is_sentinel_token(a: &str) -> bool {
+    a == VIGIL_MANAGED_MCP_MARKER || a.starts_with(&format!("{VIGIL_MANAGED_MCP_MARKER}="))
+}
+
+/// sentinel 在 `args` 中的位置(首个命中;无 → `None`)。
+fn sentinel_pos(args: &[Value]) -> Option<usize> {
+    args.iter()
+        .position(|a| a.as_str().map(is_sentinel_token).unwrap_or(false))
+}
+
+/// Vigil 标准托管 wrap 条目的**唯一** grammar 判定(classify 与 unwrap 共用,SSOT):
+/// `args[0]=="wrap"` ∧ sentinel 存在 ∧ sentinel **紧邻** `--`([`wrapped_argv`] 恒产出该形态,
+/// Vigil 从未写出过其它形态)。此前 classify 只要求 sentinel **在任意位置**:手改出的
+/// `args[0]=="wrap"` + sentinel 不邻 `--` 条目被分类 AlreadyWrapped(status 计入已保护),
+/// [`unwrap_entry`] 却反解不出(None)→ **不可逆的假托管态**(review 2026-07-17 HIGH-2)。
+/// 统一后这类条目按普通条目处理:command 含 vigil-hub 的落 #15 wrapper-前缀 Skipped(不动),
+/// 纯第三方伪标记条目则被当普通 server 正常保护(不再因自带 sentinel 逃逸 wrap = 收窄 fail-open)。
+fn is_managed_wrap_args(args: &[Value]) -> bool {
+    let args0_wrap = args.first().and_then(Value::as_str) == Some("wrap");
+    args0_wrap
+        && sentinel_pos(args)
+            .map(|i| args.get(i + 1).and_then(Value::as_str) == Some("--"))
+            .unwrap_or(false)
+}
+
 /// 一个枚举到的 MCP server 条目分类。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum McpServerClass {
@@ -119,8 +145,47 @@ pub fn read_claude_json(path: &Path) -> Result<Option<Value>, SetupError> {
     }
 }
 
+/// 校验已解析 JSON 配置的 **MCP 根形状**(读层之后、分类之前的统一守门):根必须是 object;
+/// `mcpServers` **存在则必须**是 object;`projects`(Claude 专有)存在则必须是 object,其每个
+/// 项目的 `mcpServers` 同。键**不存在** = 合法"未配置"(绝大多数用户),不报错。
+///
+/// **为什么必须 abort 而不是静默空**:此前"存在但类型错"(如 `"mcpServers": []` / 字符串)被
+/// `as_object()` 折叠成"无 server" → preview/apply 假成功、status 报 0、doctor 无行 —— 配置
+/// 在场却完全不受保护,用户得不到任何"Vigil 读不懂它"的信号(fail-open;review 2026-07-17
+/// MED-1)。与 hook 注册面 [`crate::setup_hooks`] 的 `ensure_agent_shape` 同纪律:绝不臆测。
+pub fn ensure_mcp_root_shape(cfg: &Value, path: &Path) -> Result<(), SetupError> {
+    let bad = |field: &'static str| {
+        Err(SetupError::UnsupportedConfigShape {
+            path: path.to_path_buf(),
+            field,
+        })
+    };
+    if !cfg.is_object() {
+        return bad("<root>");
+    }
+    if let Some(v) = cfg.get("mcpServers") {
+        if !v.is_object() {
+            return bad("mcpServers");
+        }
+    }
+    if let Some(projects) = cfg.get("projects") {
+        let Some(po) = projects.as_object() else {
+            return bad("projects");
+        };
+        for proj in po.values() {
+            if let Some(v) = proj.get("mcpServers") {
+                if !v.is_object() {
+                    return bad("projects.*.mcpServers");
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 /// 从已解析的 `~/.claude.json` 枚举 **user scope**(顶层 `mcpServers`)的 server 并分类。
-/// 纯函数 —— 不碰文件系统,fixture 直接可测。无 `mcpServers` / 形状不符 → 空 Vec(无可保护项)。
+/// 纯函数 —— 不碰文件系统,fixture 直接可测。无 `mcpServers` / 形状不符 → 空 Vec(无可保护项;
+/// "存在但类型错"的根形状由调用方先经 [`ensure_mcp_root_shape`] 拦截)。
 pub fn classify_user_scope_servers(claude_cfg: &Value) -> Vec<McpServerClass> {
     let Some(servers) = claude_cfg.get("mcpServers").and_then(Value::as_object) else {
         return Vec::new();
@@ -148,17 +213,15 @@ fn classify_one(name: &str, entry: &Value) -> McpServerClass {
             .map(|s| s.eq_ignore_ascii_case("vigil-hub") || s.eq_ignore_ascii_case("vigil-hub.exe"))
             .unwrap_or(false);
         let args0 = args.first().and_then(Value::as_str);
-        let has_sentinel = args.iter().filter_map(Value::as_str).any(|a| {
-            a == VIGIL_MANAGED_MCP_MARKER || a.starts_with(&format!("{VIGIL_MANAGED_MCP_MARKER}="))
-        });
+        let has_sentinel = args.iter().filter_map(Value::as_str).any(is_sentinel_token);
 
-        // ① 已托管:`args[0]=="wrap"` + sentinel 即足够。
-        //    **DEF-002 trigger B 修复**:不再要求 command basename==vigil-hub —— 否则从改名 / 带版本号
+        // ① 已托管:与 [`unwrap_entry`] **同一** grammar([`is_managed_wrap_args`]:args[0]=="wrap"
+        //    + sentinel 紧邻 `--`)—— 分类说"已托管"的,反解必然能还原(可逆性闭环)。
+        //    **DEF-002 trigger B 修复**:不要求 command basename==vigil-hub —— 否则从改名 / 带版本号
         //    的二进制(如 `vigil-hub-0.1.4`、符号链接 `vh`)再跑 setup 时,已 wrap 的条目认不出 → 被
-        //    二次 wrap。sentinel 是 Vigil 自有标记、args[0]=="wrap" 锚定为本网关 shim,二者合取后第三方
-        //    server 不可能误命中(其 args[0] 不会是 "wrap";仅自带 `--vigil-managed-mcp` 参数也因 args[0]
-        //    ≠ "wrap" 被排除,原 Codex review 关切的 fail-open 仍被堵)。
-        if args0 == Some("wrap") && has_sentinel {
+        //    二次 wrap。sentinel + args[0]=="wrap" + 紧邻 `--` 的合取后第三方 server 不可能误命中
+        //    (其 args[0] 不会是 "wrap";仅自带 `--vigil-managed-mcp` 参数也被排除,fail-open 仍被堵)。
+        if is_managed_wrap_args(args) {
             return McpServerClass::AlreadyWrapped { name: name.into() };
         }
 
@@ -455,40 +518,97 @@ pub fn wrapped_server_count(home: &Path) -> usize {
     user + local
 }
 
-/// `setup --status` 的逐 agent MCP 网关覆盖统计:`(agent 显示名, 已 wrap 数)`,恒含四个 agent
-/// (0 也返回,渲染层自行取舍)。此前 status 只报 Claude Code 的计数 —— `setup --all` 保护了
-/// Codex/Cursor 的二十余个 server 后,用户无从确认全局覆盖面。best-effort 只读:配置缺失 /
-/// 解析失败按 0 计,状态报告不因单个 agent 配置损坏而失败(与 [`wrapped_server_count`] 同口径)。
-pub fn wrapped_server_counts_all_agents(home: &Path) -> Vec<(&'static str, usize)> {
+/// `setup --status` 单 agent 的 MCP 网关覆盖状态。此前返回裸 usize,读/解析失败被折叠成 0 ——
+/// 配置存在却损坏/不可读的 agent 与"未配置"不可区分,status 呈现虚假的"全部正常"视图
+/// (review 2026-07-17 MED-4)。`ConfigError` 态让渲染层能诚实提示"配置在但查不了,去跑 doctor"。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentWrapStatus {
+    /// 配置可读(或不存在 = 0):已被 Vigil wrap 的 server 数。
+    Wrapped(usize),
+    /// 配置**存在但读取/解析/根形状失败** —— server 可能存在但对 status 不可见,绝不谎报 0。
+    ConfigError,
+}
+
+/// `setup --status` 的逐 agent MCP 网关覆盖统计:`(agent 显示名, 状态)`,恒含全部接入面
+/// (Claude + Codex + 全部 [`all_json_mcp_agents`] registry;0 也返回,渲染层自行取舍)。
+/// best-effort 只读(单 agent 配置损坏不使整个 status 失败),但**不再**把读失败折叠成 0
+/// (诚实三态,见 [`AgentWrapStatus`])。`env` 注入式(测试 `AgentEnv::default()`)。
+pub fn wrapped_server_counts_all_agents(
+    home: &Path,
+    env: &AgentEnv,
+) -> Vec<(&'static str, AgentWrapStatus)> {
+    use AgentWrapStatus::{ConfigError, Wrapped};
     let wrapped_in = |cfg: &Value| {
         classify_user_scope_servers(cfg)
             .iter()
             .filter(|c| matches!(c, McpServerClass::AlreadyWrapped { .. }))
             .count()
     };
-    let json_agent = |a: &JsonMcpAgent| {
-        read_claude_json(&a.config_path)
-            .ok()
-            .flatten()
-            .map(|cfg| wrapped_in(&cfg))
-            .unwrap_or(0)
+    // Claude:user scope + local scope 合计(与 [`wrapped_server_count`] 同口径,但读失败诚实报错)。
+    let claude_path = claude_json_path(home);
+    let claude = match read_claude_json(&claude_path) {
+        Ok(Some(cfg)) => match ensure_mcp_root_shape(&cfg, &claude_path) {
+            Ok(()) => Wrapped(
+                wrapped_in(&cfg)
+                    + classify_local_scope_servers(&cfg)
+                        .iter()
+                        .filter(|(_, c)| matches!(c, McpServerClass::AlreadyWrapped { .. }))
+                        .count(),
+            ),
+            Err(_) => ConfigError,
+        },
+        Ok(None) => Wrapped(0),
+        Err(_) => ConfigError,
     };
-    let codex = read_codex_config(&codex_config_path(home))
-        .ok()
-        .flatten()
-        .map(|doc| {
-            classify_codex_servers(&doc)
-                .iter()
-                .filter(|c| matches!(c, McpServerClass::AlreadyWrapped { .. }))
-                .count()
-        })
-        .unwrap_or(0);
-    vec![
-        ("Claude Code", wrapped_server_count(home)),
-        ("Codex", codex),
-        ("Cursor", json_agent(&JsonMcpAgent::cursor(home))),
-        ("Windsurf", json_agent(&JsonMcpAgent::windsurf(home))),
-    ]
+    let codex_path = codex_config_path(home, env.codex_home.as_deref());
+    let codex = match read_codex_config(&codex_path) {
+        Ok(Some(doc)) => match ensure_codex_root_shape(&doc, &codex_path) {
+            Ok(()) => Wrapped(
+                classify_codex_servers(&doc)
+                    .iter()
+                    .filter(|c| matches!(c, McpServerClass::AlreadyWrapped { .. }))
+                    .count(),
+            ),
+            Err(_) => ConfigError,
+        },
+        Ok(None) => Wrapped(0),
+        Err(_) => ConfigError,
+    };
+    let zcode_path = zcode_config_path(home);
+    let zcode = match read_claude_json(&zcode_path) {
+        Ok(Some(cfg)) => match ensure_zcode_root_shape(&cfg, &zcode_path) {
+            Ok(()) => Wrapped(
+                zcode_servers_obj(&cfg)
+                    .map(|m| {
+                        m.iter()
+                            .filter(|(name, entry)| {
+                                matches!(
+                                    classify_one(name, entry),
+                                    McpServerClass::AlreadyWrapped { .. }
+                                )
+                            })
+                            .count()
+                    })
+                    .unwrap_or(0),
+            ),
+            Err(_) => ConfigError,
+        },
+        Ok(None) => Wrapped(0),
+        Err(_) => ConfigError,
+    };
+    let mut out = vec![("Claude Code", claude), ("Codex", codex), ("ZCode", zcode)];
+    for agent in all_json_mcp_agents(home, env) {
+        let st = match read_claude_json(&agent.config_path) {
+            Ok(Some(cfg)) => match ensure_mcp_root_shape(&cfg, &agent.config_path) {
+                Ok(()) => Wrapped(wrapped_in(&cfg)),
+                Err(_) => ConfigError,
+            },
+            Ok(None) => Wrapped(0),
+            Err(_) => ConfigError,
+        };
+        out.push((agent.display_name, st));
+    }
+    out
 }
 
 /// `setup --mcp`(只读)的预览报告 —— 供 CLI 层渲染。
@@ -534,11 +654,14 @@ pub fn run_preview(home: &Path, exe: &str, monitor: bool) -> Result<McpPreviewRe
     let path = claude_json_path(home);
     let cfg = read_claude_json(&path)?;
     let (exists, servers, local_servers) = match cfg {
-        Some(v) => (
-            true,
-            classify_user_scope_servers(&v),
-            classify_local_scope_servers(&v),
-        ),
+        Some(v) => {
+            ensure_mcp_root_shape(&v, &path)?; // 存在但类型错的 mcpServers 绝不静默当"无 server"
+            (
+                true,
+                classify_user_scope_servers(&v),
+                classify_local_scope_servers(&v),
+            )
+        }
         None => (false, Vec::new(), Vec::new()),
     };
     Ok(McpPreviewReport {
@@ -566,6 +689,9 @@ pub fn run(monitor: bool) -> Result<McpPreviewReport, SetupError> {
 //
 // **自描述可逆**:wrap 条目保留原 `env`/`type`/未知字段**逐字**,只改 `command`+`args`;`--` 之后
 // 即原始 argv → uninstall 从 wrap 条目**自还原**,无需独立 snapshot 文件(reversal 信息随条目走)。
+// **可逆边界(诚实声明,review 2026-07-17 MED-3)**:还原目标是**语义等价的可运行形态**,非字节级
+// 快照 —— classify 的刻意归一化(#14 单串 command 拆分、首尾空白 trim、缺失 `args` 还原后成 `[]`)
+// 不可逆转回原病态形态;整个文件也经 pretty-print 重写(键序/未知字段保留,空白/缩进可能变)。
 // 写盘经 `setup::atomic_write_with_backup`(原子 temp+rename + 备份 + preserve_order 保留用户键序)。
 // **仅 user scope**(顶层 mcpServers);local scope(`projects.<path>.mcpServers`)有未保护 server 时
 // **fail-closed 拒绝**(Codex setup_mcp review guardrail:漏 scope=fail-open),除非 `--user-scope-only`。
@@ -602,24 +728,15 @@ fn wrap_entry(
 fn unwrap_entry(wrapped: &Value) -> Option<Value> {
     let obj = wrapped.as_object()?;
     let args = obj.get("args")?.as_array()?;
-    let args0_wrap = args.first().and_then(Value::as_str) == Some("wrap");
-    // **sentinel-anchored 分隔符**:`wrapped_argv` 里 sentinel **紧跟** `--`,故 separator = sentinel_idx+1。
-    // **不**用 `position("--")` 找第一个 `--` —— 若 server 名 / env-key 字面恰是 `--`(病态但可能)会撞
-    // 错分隔符导致还原失败/错乱。锚定 sentinel 后取其紧邻 `--` 才鲁棒(name/env-key 在 sentinel 之前)。
-    let sent = args.iter().position(|a| {
-        a.as_str()
-            .map(|s| {
-                s == VIGIL_MANAGED_MCP_MARKER
-                    || s.starts_with(&format!("{VIGIL_MANAGED_MCP_MARKER}="))
-            })
-            .unwrap_or(false)
-    })?;
-    if args.get(sent + 1).and_then(Value::as_str) != Some("--") {
-        return None; // sentinel 后必紧跟 `--`;否则非 Vigil 标准 wrap 形态,不动(fail-safe)
+    // 与 classify 的 AlreadyWrapped **同一** grammar([`is_managed_wrap_args`],SSOT):
+    // args[0]=="wrap" + sentinel 存在 + sentinel **紧邻** `--`。
+    // **sentinel-anchored 分隔符**:**不**用 `position("--")` 找第一个 `--` —— 若 server 名 /
+    // env-key 字面恰是 `--`(病态但可能)会撞错分隔符导致还原失败/错乱。锚定 sentinel 后取其
+    // 紧邻 `--` 才鲁棒(name/env-key 在 sentinel 之前)。
+    if !is_managed_wrap_args(args) {
+        return None; // 非 Vigil 标准 wrap 形态,不动(fail-safe)
     }
-    if !args0_wrap {
-        return None;
-    }
+    let sent = sentinel_pos(args)?;
     // sentinel 之后第 2 元素起即原始 argv(逐字还原)。
     let orig = &args[sent + 2..];
     let orig_cmd = orig.first()?.as_str()?;
@@ -775,20 +892,46 @@ impl McpApplyReport {
     }
 }
 
-/// #16:列出 user scope 配置里 Wrappable server 中底层程序在宿主 PATH **不可解析**的 `(name, program)`。
-/// 供 `setup --mcp --apply` 后**非阻塞 WARN** —— 避免给"Protected"虚假安全感(底层程序坏/未装时
-/// server 在 agent 启动才静默失败,无 Vigil 关联提示)。必须在 apply **之前**对原始配置调用(apply 后
-/// 条目变 AlreadyWrapped 不再 Wrappable)。复用网关同款 `resolve_program`(SSOT)。
-pub fn unresolvable_wrappables(home: &Path) -> Vec<(String, String)> {
-    let path = claude_json_path(home);
-    let Ok(Some(cfg)) = read_claude_json(&path) else {
-        return Vec::new();
-    };
-    let mut out = Vec::new();
-    for class in classify_user_scope_servers(&cfg) {
+/// #16:列出**全部接入面**(Claude user+local / Codex / JSON-agent registry)Wrappable server 中
+/// 底层程序在宿主 PATH **不可解析**的 `(接入面标签, server 名, program)`。供 `setup --mcp --apply`
+/// 后**非阻塞 WARN** —— 避免给"Protected"虚假安全感(底层程序坏/未装时 server 在 agent 启动才
+/// 静默失败,无 Vigil 关联提示)。此前只查 Claude user scope,其余面 wrap 后没有同款即时预警
+/// (review 2026-07-17 LOW-1)。必须在 apply **之前**对原始配置调用(apply 后条目变 AlreadyWrapped
+/// 不再 Wrappable)。复用网关同款 `resolve_program`(SSOT)。best-effort 只读:读失败按无警告处理
+/// (apply 自身会对该面诚实报错,此处不重复)。
+pub fn unresolvable_wrappables(home: &Path, env: &AgentEnv) -> Vec<(String, String, String)> {
+    let mut out: Vec<(String, String, String)> = Vec::new();
+    let mut push_unresolvable = |label: &str, class: McpServerClass| {
         if let McpServerClass::Wrappable { name, command, .. } = class {
             if vigil_mcp::stdio::resolve_program(&command).is_err() {
-                out.push((name, command));
+                out.push((label.to_string(), name, command));
+            }
+        }
+    };
+    if let Ok(Some(cfg)) = read_claude_json(&claude_json_path(home)) {
+        for class in classify_user_scope_servers(&cfg) {
+            push_unresolvable("Claude Code", class);
+        }
+        for (_proj, class) in classify_local_scope_servers(&cfg) {
+            push_unresolvable("Claude Code (project)", class);
+        }
+    }
+    if let Ok(Some(doc)) = read_codex_config(&codex_config_path(home, env.codex_home.as_deref())) {
+        for class in classify_codex_servers(&doc) {
+            push_unresolvable("Codex", class);
+        }
+    }
+    if let Ok(Some(cfg)) = read_claude_json(&zcode_config_path(home)) {
+        if let Some(servers) = zcode_servers_obj(&cfg) {
+            for (name, entry) in servers {
+                push_unresolvable("ZCode", classify_one(name, entry));
+            }
+        }
+    }
+    for agent in all_json_mcp_agents(home, env) {
+        if let Ok(Some(cfg)) = read_claude_json(&agent.config_path) {
+            for class in classify_user_scope_servers(&cfg) {
+                push_unresolvable(agent.display_name, class);
             }
         }
     }
@@ -807,7 +950,10 @@ pub fn run_apply(
 ) -> Result<McpApplyReport, SetupError> {
     let path = claude_json_path(home);
     let cfg = match read_claude_json(&path)? {
-        Some(v) => v,
+        Some(v) => {
+            ensure_mcp_root_shape(&v, &path)?; // 类型错的根形状绝不改写(abort-on-unexpected)
+            v
+        }
         None => {
             return Ok(McpApplyReport {
                 claude_json: path,
@@ -850,7 +996,10 @@ pub fn run_apply(
 pub fn run_uninstall(home: &Path, dry_run: bool) -> Result<McpApplyReport, SetupError> {
     let path = claude_json_path(home);
     let cfg = match read_claude_json(&path)? {
-        Some(v) => v,
+        Some(v) => {
+            ensure_mcp_root_shape(&v, &path)?; // 读不懂的形状绝不声称"还原了 0 个"
+            v
+        }
         None => {
             return Ok(McpApplyReport {
                 claude_json: path,
@@ -898,9 +1047,15 @@ pub fn run_uninstall(home: &Path, dry_run: bool) -> Result<McpApplyReport, Setup
 // **server-id 命名空间**:Codex 条目派生 `codex-<name>`,与 user scope 的 `user-` / local scope 的
 // `local-` **可证不相交**(共享账本里跨 agent 同名 server 身份不塌缩)。
 
-/// Codex CLI 的 MCP 配置文件路径(`~/.codex/config.toml`)。
-pub fn codex_config_path(home: &Path) -> PathBuf {
-    home.join(".codex").join("config.toml")
+/// Codex CLI 的 MCP 配置文件路径:`$CODEX_HOME/config.toml`(默认 `~/.codex/config.toml`)。
+///
+/// `codex_home_env` = `CODEX_HOME` 环境变量值,**注入式**(生产经 [`codex_home_env`] 读;测试传
+/// `None`/fixture 值,绝不受开发机真实 env 污染)。解析复用 hook 注册面的
+/// [`crate::setup_hooks::resolve_codex_home`](SSOT)—— 此前本面固定 `~/.codex`,与 hook 面分裂:
+/// 自定义 `CODEX_HOME` 的用户 hook 写进真实 Codex 目录、MCP wrap 却读写不存在的 `~/.codex`,
+/// 其全部 server 漏保护且 status/doctor/quickstart 不可见(review 2026-07-17 HIGH-1)。
+pub fn codex_config_path(home: &Path, codex_home_env: Option<&str>) -> PathBuf {
+    crate::setup_hooks::resolve_codex_home(home, codex_home_env).join("config.toml")
 }
 
 /// 为 Codex `[mcp_servers.<name>]` 条目派生 server-id:`codex-<组件>`。
@@ -941,12 +1096,30 @@ pub fn read_codex_config(path: &Path) -> Result<Option<DocumentMut>, SetupError>
     }
 }
 
-/// 取 `[mcp_servers]` 表(标准 sub-table 形态;`mcp_servers = {..}` 内联 / 缺省 → `None` = 无可保护项)。
-fn codex_servers_table(doc: &DocumentMut) -> Option<&toml_edit::Table> {
-    doc.get("mcp_servers").and_then(|i| i.as_table())
+/// 校验 Codex `config.toml` 的 MCP 根形状:`mcp_servers` **存在则必须**是 table-like
+/// (`[mcp_servers.x]` 标准 sub-table 或 `mcp_servers = {..}` 内联表都合法)。缺省 = 未配置,合法。
+/// 存在但是标量/数组等 → abort —— 此前与"缺失"合并成 `None` 静默当 0 项(fail-open;
+/// review 2026-07-17 MED-1 Codex 侧),与 JSON 面 [`ensure_mcp_root_shape`] 同纪律。
+pub fn ensure_codex_root_shape(doc: &DocumentMut, path: &Path) -> Result<(), SetupError> {
+    match doc.get("mcp_servers") {
+        None => Ok(()),
+        Some(i) if i.as_table_like().is_some() => Ok(()),
+        Some(_) => Err(SetupError::UnsupportedConfigShape {
+            path: path.to_path_buf(),
+            field: "mcp_servers",
+        }),
+    }
 }
-fn codex_servers_table_mut(doc: &mut DocumentMut) -> Option<&mut toml_edit::Table> {
-    doc.get_mut("mcp_servers").and_then(|i| i.as_table_mut())
+
+/// 取 `[mcp_servers]` 表。`as_table_like`:标准 sub-table 与 `mcp_servers = {..}` 内联表**都**
+/// 支持(此前只认 `as_table()`,内联形态被静默当 0 项 = 漏保护;形状异常由
+/// [`ensure_codex_root_shape`] 在调用方先拦)。缺省 → `None` = 无可保护项。
+fn codex_servers_table(doc: &DocumentMut) -> Option<&dyn toml_edit::TableLike> {
+    doc.get("mcp_servers").and_then(|i| i.as_table_like())
+}
+fn codex_servers_table_mut(doc: &mut DocumentMut) -> Option<&mut dyn toml_edit::TableLike> {
+    doc.get_mut("mcp_servers")
+        .and_then(|i| i.as_table_like_mut())
 }
 
 /// 把一个 `toml_edit` 条目桥接成 `serde_json::Value`,喂给共享的 [`classify_one`]。
@@ -1148,17 +1321,21 @@ pub struct CodexApplyReport {
     pub backup: Option<PathBuf>,
 }
 
-/// 读真实 `~/.codex/config.toml`(IO 边界)→ 枚举 + 分类,产出只读预览。**不写任何东西**。
-/// `home` / `exe` 注入 → 测试走 fixture 而**绝不**碰真实用户配置。
+/// 读真实 `$CODEX_HOME/config.toml`(IO 边界)→ 枚举 + 分类,产出只读预览。**不写任何东西**。
+/// `home` / `codex_home_env` / `exe` 全注入 → 测试走 fixture 而**绝不**碰真实用户配置。
 pub fn run_codex_preview(
     home: &Path,
+    codex_home_env: Option<&str>,
     exe: &str,
     monitor: bool,
 ) -> Result<CodexPreviewReport, SetupError> {
-    let path = codex_config_path(home);
+    let path = codex_config_path(home, codex_home_env);
     let doc = read_codex_config(&path)?;
     let (exists, servers) = match doc {
-        Some(d) => (true, classify_codex_servers(&d)),
+        Some(d) => {
+            ensure_codex_root_shape(&d, &path)?; // 存在但非 table-like 绝不静默当 0 项
+            (true, classify_codex_servers(&d))
+        }
         None => (false, Vec::new()),
     };
     Ok(CodexPreviewReport {
@@ -1173,13 +1350,17 @@ pub fn run_codex_preview(
 /// `setup --mcp --apply`(Codex 面):读 → wrap 全部 Wrappable → 格式保留原子写。`dry_run` 只算不写。
 pub fn run_codex_apply(
     home: &Path,
+    codex_home_env: Option<&str>,
     exe: &str,
     dry_run: bool,
     monitor: bool,
 ) -> Result<CodexApplyReport, SetupError> {
-    let path = codex_config_path(home);
+    let path = codex_config_path(home, codex_home_env);
     let mut doc = match read_codex_config(&path)? {
-        Some(d) => d,
+        Some(d) => {
+            ensure_codex_root_shape(&d, &path)?; // 类型错的根形状绝不改写
+            d
+        }
         None => {
             return Ok(CodexApplyReport {
                 codex_config: path,
@@ -1209,10 +1390,17 @@ pub fn run_codex_apply(
 }
 
 /// `setup --mcp --uninstall`(Codex 面):读 → 还原所有 Vigil 托管条目 → 格式保留原子写。`dry_run` 只算不写。
-pub fn run_codex_uninstall(home: &Path, dry_run: bool) -> Result<CodexApplyReport, SetupError> {
-    let path = codex_config_path(home);
+pub fn run_codex_uninstall(
+    home: &Path,
+    codex_home_env: Option<&str>,
+    dry_run: bool,
+) -> Result<CodexApplyReport, SetupError> {
+    let path = codex_config_path(home, codex_home_env);
     let mut doc = match read_codex_config(&path)? {
-        Some(d) => d,
+        Some(d) => {
+            ensure_codex_root_shape(&d, &path)?; // 读不懂的形状绝不声称"还原了 0 个"
+            d
+        }
         None => {
             return Ok(CodexApplyReport {
                 codex_config: path,
@@ -1240,56 +1428,137 @@ pub fn run_codex_uninstall(home: &Path, dry_run: bool) -> Result<CodexApplyRepor
     })
 }
 
-// ============================ JSON `mcpServers` agent 接入面(Cursor / Windsurf) ============================
+// ============================ JSON `mcpServers` agent 接入面(Cursor / Windsurf / Kimi / pi) ============================
 //
-// Cursor(`~/.cursor/mcp.json`)与 Windsurf(`~/.codeium/windsurf/mcp_config.json`)的 MCP 配置**形态与
+// Cursor(`~/.cursor/mcp.json`)、Windsurf(`~/.codeium/windsurf/mcp_config.json`)、Kimi CLI
+// (`~/.kimi/mcp.json`)与 pi(`$PI_AGENT_DIR/mcp.json`,经 pi-mcp-adapter)的 MCP 配置**形态与
 // Claude user scope 完全一致**:专用 JSON 文件、顶层 `mcpServers` 对象、条目 `command`/`args`/`env`、
 // 远程用 `url`(Windsurf 另用 `serverUrl`,已并入 `classify_one` 远程检测)。故**直接复用 Claude 路径的
 // read/classify/wrap/unwrap/atomic-write 机制**,仅 config 路径与 server-id 前缀不同;无 `projects.*` 嵌套
-// (那是 Claude 专有),只处理顶层 scope。server-id 用 `<prefix>-<name>`(`cursor-`/`windsurf-`,与
-// `user-`/`local-`/`codex-` 命名空间不相交)。
+// (那是 Claude 专有),只处理顶层 scope。server-id 用 `<prefix>-<name>`(与 `user-`/`local-`/`codex-`
+// 命名空间不相交,前缀合法性由 [`JsonMcpAgent::new`] 门禁)。实例清单唯一来源 = [`all_json_mcp_agents`]。
 //
-// **范围**:Cursor + Windsurf —— 均为专用、安全可重写文件、零形态差异。Cline(globalStorage 路径随
+// **范围**:上述四家 —— 均为专用、安全可重写文件、零形态差异。Cline(globalStorage 路径随
 // VS Code 版本/fork 漂移 + 有删配置数据丢失史)、Zed(`context_servers` 键且嵌入共享 settings.json/JSONC)、
-// VS Code(`servers` 键 + 显式 `type`)形态/风险不同,留后续专门增量。
+// VS Code(`servers` 键 + 显式 `type`)形态/风险不同,留后续专门增量。ZCode(嵌套 `mcp.servers`
+// 键,GUI 管理的共享 `~/.zcode/cli/config.json`)**不走本通用管道** —— 已由下文独立专线覆盖
+// (契约 = 解包 vendor app.asar 实锤,见"ZCode 接入面"段)。Kimi 的 hook 面(`~/.kimi/config.toml`
+// `[[hooks]]`)**刻意不做**:Beta + 官方 fail-open(hook 超时/崩溃=放行),不满足 Vigil 强保护
+// 语义,等 GA 后独立评估。
 
-/// 一个"JSON `mcpServers` 形态"的 agent 接入面描述符(Cursor / Windsurf)。
+/// 生产环境变量快照(**注入式**):库函数绝不直接读 env —— 否则 fixture 测试会被开发机真实
+/// `CODEX_HOME`/`PI_AGENT_DIR` 污染,apply 类测试甚至可能误写真实配置。main/quickstart 生产
+/// 入口取一次后传引用;测试用 `AgentEnv::default()`(全 None = 全默认路径)或注入 fixture 值。
+#[derive(Debug, Clone, Default)]
+pub struct AgentEnv {
+    /// `CODEX_HOME`(Codex 配置根;`None` = 默认 `~/.codex`)。
+    pub codex_home: Option<String>,
+    /// pi 的 agent 配置目录(`None` = 默认 `~/.pi/agent`)。取自 `PI_CODING_AGENT_DIR`
+    /// (pi-mcp-adapter 文档对 mcp.json 点名的变量)或 `PI_AGENT_DIR`(pi 本体文档),前者优先。
+    pub pi_agent_dir: Option<String>,
+}
+
+impl AgentEnv {
+    /// 读真实进程环境(**仅生产调用点**;库/测试路径绝不调用)。
+    pub fn from_process_env() -> Self {
+        AgentEnv {
+            codex_home: std::env::var("CODEX_HOME").ok(),
+            pi_agent_dir: std::env::var("PI_CODING_AGENT_DIR")
+                .ok()
+                .or_else(|| std::env::var("PI_AGENT_DIR").ok()),
+        }
+    }
+}
+
+/// 一个"JSON `mcpServers` 形态"的 agent 接入面描述符(Cursor / Windsurf / Kimi / pi)。
 #[derive(Debug, Clone)]
 pub struct JsonMcpAgent {
     /// 人类可读名(报告/预览用)。
     pub display_name: &'static str,
     /// 配置文件绝对路径(已注入 home → 测试可指向 fixture,绝不碰真实用户配置)。
     pub config_path: PathBuf,
-    /// server-id 前缀(`cursor` / `windsurf`)。
+    /// server-id 前缀(`cursor` / `windsurf` / `kimi` / `pi`)。
     pub id_prefix: &'static str,
 }
 
 impl JsonMcpAgent {
+    /// 受校验构造器(所有预置构造器的唯一落点):`id_prefix` 必须非空、全 `[a-z0-9]`
+    /// (禁 `-`/`_`:防与 [`server_id_component`] 的 `-` 分隔产生歧义,并保持与既有前缀同形),
+    /// 且不得撞 `user`/`local`/`codex` 保留命名空间 —— 撞了 = 共享账本跨 agent 身份塌缩,
+    /// descriptor pin 与审批串号(review 2026-07-17 HIGH-3)。前缀是编译期字面量,违规属编程
+    /// bug → fail-fast panic;registry invariant 测试再兜跨实例唯一性(单实例校验查不了重复)。
+    fn new(display_name: &'static str, config_path: PathBuf, id_prefix: &'static str) -> Self {
+        assert!(
+            !id_prefix.is_empty()
+                && id_prefix
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()),
+            "JsonMcpAgent id_prefix must be non-empty [a-z0-9]+: {id_prefix:?}"
+        );
+        assert!(
+            !matches!(id_prefix, "user" | "local" | "codex"),
+            "JsonMcpAgent id_prefix collides with a reserved namespace: {id_prefix:?}"
+        );
+        JsonMcpAgent {
+            display_name,
+            config_path,
+            id_prefix,
+        }
+    }
     /// Cursor:`~/.cursor/mcp.json`(user scope;项目级 `<repo>/.cursor/mcp.json` 是独立提交文件,不碰)。
     pub fn cursor(home: &Path) -> Self {
-        JsonMcpAgent {
-            display_name: "Cursor",
-            config_path: home.join(".cursor").join("mcp.json"),
-            id_prefix: "cursor",
-        }
+        Self::new("Cursor", home.join(".cursor").join("mcp.json"), "cursor")
     }
     /// Windsurf:`~/.codeium/windsurf/mcp_config.json`(唯一 scope —— Windsurf 无项目级 MCP 配置)。
     pub fn windsurf(home: &Path) -> Self {
-        JsonMcpAgent {
-            display_name: "Windsurf",
-            config_path: home
-                .join(".codeium")
+        Self::new(
+            "Windsurf",
+            home.join(".codeium")
                 .join("windsurf")
                 .join("mcp_config.json"),
-            id_prefix: "windsurf",
-        }
+            "windsurf",
+        )
     }
-    /// 派生 server-id:`<prefix>-<name>`(与 `user-`/`local-`/`codex-` 命名空间不相交)。
-    /// 名经 [`server_id_component`] 规约(合法名原样;非法字符 slug + 哈希),前缀全在
-    /// `^[a-z0-9_-]+$` 字符集内,拼接后必合法。
-    fn server_id(&self, name: &str) -> String {
-        format!("{}-{}", self.id_prefix, server_id_component(name))
+    /// Kimi CLI(Moonshot):`~/.kimi/mcp.json`(官方文档核实 2026-07;标准顶层 `mcpServers`,
+    /// stdio `command`/`args`/`env` + 远程 `url`/`headers` —— 远程条目由 classify 诚实 Skip)。
+    pub fn kimi(home: &Path) -> Self {
+        Self::new("Kimi CLI", home.join(".kimi").join("mcp.json"), "kimi")
     }
+    /// pi(badlogic/pi-mono)**经 pi-mcp-adapter**:`$PI_AGENT_DIR/mcp.json`(默认 `~/.pi/agent/`)。
+    /// pi 本体**设计上无内置 MCP**;该文件是官方 MCP extension 示例与 pi-mcp-adapter 共同的
+    /// Pi-global 约定(标准顶层 `mcpServers`)。文件不存在 = 没装 adapter / 没配 MCP → 诚实
+    /// `exists:false`,绝不创建。产品文案点名 pi-mcp-adapter,不宣传"pi 原生 MCP"。自定义
+    /// agent dir 不并入 server-id(与 `CODEX_HOME` 自定义时 `codex-` 前缀不变的既有决策一致)。
+    pub fn pi(home: &Path, pi_agent_dir_env: Option<&str>) -> Self {
+        let dir = crate::setup_hooks::resolve_agent_dir(home, pi_agent_dir_env, || {
+            home.join(".pi").join("agent")
+        });
+        Self::new("pi", dir.join("mcp.json"), "pi")
+    }
+    /// 派生 server-id(经 [`json_agent_server_id`],preview 渲染与 apply 落盘同源)。
+    pub fn server_id(&self, name: &str) -> String {
+        json_agent_server_id(self.id_prefix, name)
+    }
+}
+
+/// JSON-agent 面 server-id 派生 SSOT:`<prefix>-<组件>`。preview 渲染与 apply 落盘**必须**同走
+/// 本函数 —— 此前 main.rs 预览手拼 `{prefix}-{name}`,名含大写/空格时与 apply 的 slug+hash 规约
+/// 不一致,预览展示错误甚至非法 id(review 2026-07-17 MED-6,F-4 的漏网点)。
+pub fn json_agent_server_id(prefix: &str, name: &str) -> String {
+    format!("{prefix}-{}", server_id_component(name))
+}
+
+/// 全部"JSON `mcpServers` 形态" agent 的**唯一清单**(SSOT)。status / doctor / preview / apply /
+/// uninstall / quickstart 一律遍历本函数 —— 此前 Cursor/Windsurf 在 4 处各自硬编码,新增 agent
+/// 漏一处即该功能的覆盖缺口(review 2026-07-17 MED-2)。**新增同形态 agent 只改这里**
+/// (registry invariant 测试自动覆盖新条目)。`env` 注入式(生产 [`AgentEnv::from_process_env`])。
+pub fn all_json_mcp_agents(home: &Path, env: &AgentEnv) -> Vec<JsonMcpAgent> {
+    vec![
+        JsonMcpAgent::cursor(home),
+        JsonMcpAgent::windsurf(home),
+        JsonMcpAgent::kimi(home),
+        JsonMcpAgent::pi(home, env.pi_agent_dir.as_deref()),
+    ]
 }
 
 /// JSON-agent 接入面的只读预览报告。
@@ -1344,7 +1613,10 @@ pub fn run_json_agent_preview(
 ) -> Result<JsonAgentPreviewReport, SetupError> {
     let cfg = read_claude_json(&agent.config_path)?;
     let (exists, servers) = match cfg {
-        Some(v) => (true, classify_user_scope_servers(&v)),
+        Some(v) => {
+            ensure_mcp_root_shape(&v, &agent.config_path)?; // 类型错绝不静默当"无 server"
+            (true, classify_user_scope_servers(&v))
+        }
         None => (false, Vec::new()),
     };
     Ok(JsonAgentPreviewReport {
@@ -1367,7 +1639,10 @@ pub fn run_json_agent_apply(
     monitor: bool,
 ) -> Result<JsonAgentApplyReport, SetupError> {
     let cfg = match read_claude_json(&agent.config_path)? {
-        Some(v) => v,
+        Some(v) => {
+            ensure_mcp_root_shape(&v, &agent.config_path)?; // 类型错的根形状绝不改写
+            v
+        }
         None => {
             return Ok(JsonAgentApplyReport {
                 display_name: agent.display_name,
@@ -1408,7 +1683,10 @@ pub fn run_json_agent_uninstall(
     dry_run: bool,
 ) -> Result<JsonAgentApplyReport, SetupError> {
     let cfg = match read_claude_json(&agent.config_path)? {
-        Some(v) => v,
+        Some(v) => {
+            ensure_mcp_root_shape(&v, &agent.config_path)?; // 读不懂的形状绝不声称"还原了 0 个"
+            v
+        }
         None => {
             return Ok(JsonAgentApplyReport {
                 display_name: agent.display_name,
@@ -1436,6 +1714,202 @@ pub fn run_json_agent_uninstall(
     Ok(JsonAgentApplyReport {
         display_name: agent.display_name,
         config_path: agent.config_path.clone(),
+        changed,
+        dry_run,
+        backup,
+    })
+}
+
+// ============================ ZCode 接入面(`~/.zcode/cli/config.json`,嵌套 `mcp.servers`) ============================
+//
+// ZCode(Z.ai 的 GLM 桌面 Agentic IDE)把 **用户级** MCP server 存在共享设置文件
+// `~/.zcode/cli/config.json` 的 **`mcp.servers`** 嵌套键下(非顶层 `mcpServers`,故不走
+// [`JsonMcpAgent`] 通用管道,单独一条与 Codex-TOML 并列的专线)。**契约来源 = vendor shipped
+// code**(2026-07-17 对 ZCode 3.3.6 安装包解包 app.asar 核实,非仅第三方博客):
+// - 路径:`resolveUserHomeDir()`(HOME→USERPROFILE→homedir)+ `[".zcode","cli"]/config.json`;
+//   GUI 的新增/编辑**始终写回** `.zcode`(workspace 级 `<ws>/.zcode/config.json` 是项目内文件,
+//   与 Cursor 项目级同决策 —— 不碰;`~/.agents/mcp.json` 兼容层是共享标准文件,defer,见下)。
+// - 读:`readServerMapFromJson`:`cfg.mcp.servers`,非 object 静默 `{}`(ZCode 自身容错;Vigil 侧
+//   仍按 abort-on-unexpected 纪律,存在但类型错 → 拒绝,绝不静默当 0)。
+// - 写:`saveMcpToUserDirectory` 是 **read-modify-write**(每次先重读文件再改单个 server),
+//   故 Vigil wrap 后 ZCode 保存**其它** server 不会覆掉 wrap;运行中编辑**同一** server 才会
+//   (用户显式行为)。风险模型与 Claude Code 并发写 claude.json 同构 → 同款缓解:用户须关闭
+//   ZCode 再 `--apply`(TOCTOU stamp + 备份兜底)。
+// - 条目:map value 原样存储,禁用时**附加** `enabled: false` 键(启用时删除该键)——
+//   [`classify_one`] 的 clone-保留-未知字段纪律天然兼容,`enabled:false` 条目照常 wrap
+//   (ZCode 仍视其为禁用;wrap 不改变 enabled 语义)。
+// - **已知边界(诚实声明)**:ZCode 在 `.zcode` 无任何条目时 fallback 读 `~/.agents/mcp.json`
+//   (共享标准文件,多宿主消费)。wrap 共享文件有跨宿主身份塌缩问题(单一 `zcode-` 前缀对
+//   非 ZCode 宿主是错误身份)→ 本增量不碰它;只用 `.zcode` 配置的用户(GUI 用户的默认形态)
+//   获得完整保护。
+//
+// 复用与 Claude/Codex/JSON-agent 完全相同的安全机制:[`classify_one`](全部护栏)、
+// [`wrapped_argv`]/[`unwrap_entry`](wrap/反解 SSOT)、[`wrap_servers_object`]/
+// [`unwrap_servers_object`](批量改写,仅 server-id 派生器不同)、
+// `atomic_write_with_backup`(原子写 + 备份 + preserve_order)。ZCode 专属的只有
+// "嵌套键取放"这一层。server-id 前缀 `zcode-`(与 `user-`/`local-`/`codex-` 及
+// JSON-agent registry 各前缀可证不相交,见 registry invariant 测试)。
+
+/// ZCode 用户级 MCP 配置路径(`~/.zcode/cli/config.json`)。
+pub fn zcode_config_path(home: &Path) -> PathBuf {
+    home.join(".zcode").join("cli").join("config.json")
+}
+
+/// 为 ZCode 条目派生 server-id:`zcode-<组件>`(命名空间与其它面不相交)。
+pub fn zcode_scope_server_id(name: &str) -> String {
+    format!("zcode-{}", server_id_component(name))
+}
+
+/// 校验 ZCode 配置的 MCP 根形状:根 object;`mcp` **存在则必须** object;`mcp.servers`
+/// **存在则必须** object。键不存在 = 未配置(合法)。类型错 → abort(与
+/// [`ensure_mcp_root_shape`] 同纪律 —— ZCode 自身对类型错静默 `{}`,Vigil 绝不效仿:
+/// 静默 = 配置在场却完全不受保护且无信号)。
+pub fn ensure_zcode_root_shape(cfg: &Value, path: &Path) -> Result<(), SetupError> {
+    let bad = |field: &'static str| {
+        Err(SetupError::UnsupportedConfigShape {
+            path: path.to_path_buf(),
+            field,
+        })
+    };
+    if !cfg.is_object() {
+        return bad("<root>");
+    }
+    match cfg.get("mcp") {
+        None => Ok(()),
+        Some(mcp) => {
+            let Some(mcp_obj) = mcp.as_object() else {
+                return bad("mcp");
+            };
+            match mcp_obj.get("servers") {
+                None => Ok(()),
+                Some(v) if v.is_object() => Ok(()),
+                Some(_) => bad("mcp.servers"),
+            }
+        }
+    }
+}
+
+/// 取 `mcp.servers` 嵌套 map(只读)。缺省 → `None` = 无可保护项(形状异常由
+/// [`ensure_zcode_root_shape`] 在调用方先拦)。
+fn zcode_servers_obj(cfg: &Value) -> Option<&serde_json::Map<String, Value>> {
+    cfg.get("mcp")?.get("servers")?.as_object()
+}
+fn zcode_servers_obj_mut(cfg: &mut Value) -> Option<&mut serde_json::Map<String, Value>> {
+    cfg.get_mut("mcp")?.get_mut("servers")?.as_object_mut()
+}
+
+/// 读真实 ZCode 配置(IO 边界)→ 枚举 + 分类,产出只读预览(复用 [`JsonAgentPreviewReport`]
+/// 结构;`id_prefix = "zcode"` 供渲染层派生与 apply 一致的 server-id)。**不写任何东西**。
+pub fn run_zcode_preview(
+    home: &Path,
+    exe: &str,
+    monitor: bool,
+) -> Result<JsonAgentPreviewReport, SetupError> {
+    let path = zcode_config_path(home);
+    let cfg = read_claude_json(&path)?; // 同款"读 + 解析 JSON"管道(大小上限/损坏 abort)
+    let (exists, servers) = match cfg {
+        Some(v) => {
+            ensure_zcode_root_shape(&v, &path)?;
+            let servers = zcode_servers_obj(&v)
+                .map(|m| {
+                    m.iter()
+                        .map(|(name, entry)| classify_one(name, entry))
+                        .collect()
+                })
+                .unwrap_or_default();
+            (true, servers)
+        }
+        None => (false, Vec::new()),
+    };
+    Ok(JsonAgentPreviewReport {
+        display_name: "ZCode",
+        config_path: path,
+        exists,
+        exe: exe.to_string(),
+        servers,
+        monitor,
+        id_prefix: "zcode",
+    })
+}
+
+/// `setup --mcp --apply`(ZCode 面):读 → wrap `mcp.servers` 全部 Wrappable → 原子写。
+/// `dry_run` 只算不写。**用户须关闭 ZCode 后再 apply**(见模块 doc 的并发风险声明)。
+pub fn run_zcode_apply(
+    home: &Path,
+    exe: &str,
+    dry_run: bool,
+    monitor: bool,
+) -> Result<JsonAgentApplyReport, SetupError> {
+    let path = zcode_config_path(home);
+    let cfg = match read_claude_json(&path)? {
+        Some(v) => {
+            ensure_zcode_root_shape(&v, &path)?;
+            v
+        }
+        None => {
+            return Ok(JsonAgentApplyReport {
+                display_name: "ZCode",
+                config_path: path,
+                changed: 0,
+                dry_run,
+                backup: None,
+            })
+        }
+    };
+    let stamp = std::fs::metadata(&path)
+        .ok()
+        .and_then(|m| m.modified().ok().map(|t| (t, m.len())));
+    let mut new_cfg = cfg.clone();
+    let changed = zcode_servers_obj_mut(&mut new_cfg)
+        .map(|servers| wrap_servers_object(servers, exe, monitor, zcode_scope_server_id))
+        .unwrap_or(0);
+    let backup = if !dry_run && changed > 0 {
+        crate::setup::atomic_write_with_backup(&path, &new_cfg, stamp)?
+    } else {
+        None
+    };
+    Ok(JsonAgentApplyReport {
+        display_name: "ZCode",
+        config_path: path,
+        changed,
+        dry_run,
+        backup,
+    })
+}
+
+/// `setup --mcp --uninstall`(ZCode 面):读 → self-describing 还原全部 Vigil 托管条目 → 原子写。
+pub fn run_zcode_uninstall(home: &Path, dry_run: bool) -> Result<JsonAgentApplyReport, SetupError> {
+    let path = zcode_config_path(home);
+    let cfg = match read_claude_json(&path)? {
+        Some(v) => {
+            ensure_zcode_root_shape(&v, &path)?;
+            v
+        }
+        None => {
+            return Ok(JsonAgentApplyReport {
+                display_name: "ZCode",
+                config_path: path,
+                changed: 0,
+                dry_run,
+                backup: None,
+            })
+        }
+    };
+    let stamp = std::fs::metadata(&path)
+        .ok()
+        .and_then(|m| m.modified().ok().map(|t| (t, m.len())));
+    let mut new_cfg = cfg.clone();
+    let changed = zcode_servers_obj_mut(&mut new_cfg)
+        .map(unwrap_servers_object)
+        .unwrap_or(0);
+    let backup = if !dry_run && changed > 0 {
+        crate::setup::atomic_write_with_backup(&path, &new_cfg, stamp)?
+    } else {
+        None
+    };
+    Ok(JsonAgentApplyReport {
+        display_name: "ZCode",
+        config_path: path,
         changed,
         dry_run,
         backup,
@@ -1655,14 +2129,18 @@ fn config_error_doctor_row(agent_label: &str, path: &Path, err: &SetupError) -> 
     }
 }
 
-/// 把一个 JSON-`mcpServers` agent(Cursor/Windsurf)顶层 server 逐个产出 doctor 行,追加到 `rows`。
-/// 配置不存在 → 无行(用户未用该 agent);读失败 → 一条 `ConfigError` 行(不 abort,计入失败)。`scope`=agent 名。
+/// 把一个 JSON-`mcpServers` agent(registry 内任一家)顶层 server 逐个产出 doctor 行,追加到 `rows`。
+/// 配置不存在 → 无行(用户未用该 agent);读失败**或根形状异常** → 一条 `ConfigError` 行
+/// (不 abort,计入失败 —— 形状异常同样意味着"server 可能在但 doctor 看不见")。`scope`=agent 名。
 fn append_json_agent_doctor_rows(
     agent: &JsonMcpAgent,
     probe_timeout: Option<Duration>,
     rows: &mut Vec<McpDoctorRow>,
 ) {
-    match read_claude_json(&agent.config_path) {
+    match read_claude_json(&agent.config_path).and_then(|cfg| match cfg {
+        Some(v) => ensure_mcp_root_shape(&v, &agent.config_path).map(|()| Some(v)),
+        None => Ok(None),
+    }) {
         Ok(Some(cfg)) => {
             if let Some(servers) = cfg.get("mcpServers").and_then(Value::as_object) {
                 for (name, entry) in servers {
@@ -1679,14 +2157,43 @@ fn append_json_agent_doctor_rows(
     }
 }
 
-/// Codex(TOML)doctor 行:每个 `mcp_servers` 条目桥接成 JSON(`item_to_json`)后复用 `doctor_row`。
-fn append_codex_doctor_rows(
+/// ZCode(嵌套 `mcp.servers`)doctor 行:逐条复用 `doctor_row`。读失败**或根形状异常** →
+/// `ConfigError` 行(不 abort,计入失败)。`scope`="ZCode"。
+fn append_zcode_doctor_rows(
     home: &Path,
     probe_timeout: Option<Duration>,
     rows: &mut Vec<McpDoctorRow>,
 ) {
-    let path = codex_config_path(home);
-    match read_codex_config(&path) {
+    let path = zcode_config_path(home);
+    match read_claude_json(&path).and_then(|cfg| match cfg {
+        Some(v) => ensure_zcode_root_shape(&v, &path).map(|()| Some(v)),
+        None => Ok(None),
+    }) {
+        Ok(Some(cfg)) => {
+            if let Some(servers) = zcode_servers_obj(&cfg) {
+                for (name, entry) in servers {
+                    rows.push(doctor_row(name, "ZCode", entry, probe_timeout));
+                }
+            }
+        }
+        Ok(None) => {}
+        Err(e) => rows.push(config_error_doctor_row("ZCode", &path, &e)),
+    }
+}
+
+/// Codex(TOML)doctor 行:每个 `mcp_servers` 条目桥接成 JSON(`item_to_json`)后复用 `doctor_row`。
+/// 读失败**或根形状异常**(存在但非 table-like)→ `ConfigError` 行(不 abort,计入失败)。
+fn append_codex_doctor_rows(
+    home: &Path,
+    codex_home_env: Option<&str>,
+    probe_timeout: Option<Duration>,
+    rows: &mut Vec<McpDoctorRow>,
+) {
+    let path = codex_config_path(home, codex_home_env);
+    match read_codex_config(&path).and_then(|doc| match doc {
+        Some(d) => ensure_codex_root_shape(&d, &path).map(|()| Some(d)),
+        None => Ok(None),
+    }) {
         Ok(Some(doc)) => {
             if let Some(servers) = codex_servers_table(&doc) {
                 for (name, item) in servers.iter() {
@@ -1704,8 +2211,9 @@ fn append_codex_doctor_rows(
     }
 }
 
-/// `setup --mcp --doctor`:对**所有** agent 接入面(Claude user+local / Codex / Cursor / Windsurf)的
-/// 每个 MCP server 做启动预检 —— 兑现"turnkey wrap 之后,所有 agent 的 server 是否还能起"。
+/// `setup --mcp --doctor`:对**所有** agent 接入面(Claude user+local / Codex / 全部
+/// [`all_json_mcp_agents`] registry)的每个 MCP server 做启动预检 —— 兑现"turnkey wrap 之后,
+/// 所有 agent 的 server 是否还能起"。
 ///
 /// `probe_timeout`:
 /// - `None`(默认 `--doctor`):**纯静态**(只验 `resolve_program` PATH 可解析,不 spawn,无副作用/无延迟)。
@@ -1718,11 +2226,15 @@ fn append_codex_doctor_rows(
 /// 一条诚实 Skipped 行,不 abort(读-only 健康检查应能跨 agent 看全,不因一个坏配置全瞎)。
 pub fn run_doctor(
     home: &Path,
+    env: &AgentEnv,
     probe_timeout: Option<Duration>,
 ) -> Result<Vec<McpDoctorRow>, SetupError> {
     let mut rows = Vec::new();
-    // Claude(~/.claude.json):user + local scope。malformed → abort(既有契约)。缺失 → 跳过(仍查其它 agent)。
-    if let Some(cfg) = read_claude_json(&claude_json_path(home))? {
+    // Claude(~/.claude.json):user + local scope。malformed / 根形状异常 → abort(既有契约)。
+    // 缺失 → 跳过(仍查其它 agent)。
+    let claude_path = claude_json_path(home);
+    if let Some(cfg) = read_claude_json(&claude_path)? {
+        ensure_mcp_root_shape(&cfg, &claude_path)?;
         if let Some(servers) = cfg.get("mcpServers").and_then(Value::as_object) {
             for (name, entry) in servers {
                 rows.push(doctor_row(name, "user", entry, probe_timeout));
@@ -1738,9 +2250,11 @@ pub fn run_doctor(
             }
         }
     }
-    // 其余 agent 面(best-effort,各自独立文件):Codex(TOML)+ Cursor + Windsurf(JSON)。
-    append_codex_doctor_rows(home, probe_timeout, &mut rows);
-    for agent in [JsonMcpAgent::cursor(home), JsonMcpAgent::windsurf(home)] {
+    // 其余 agent 面(best-effort,各自独立文件):Codex(TOML)+ ZCode(嵌套键)+ 全部
+    // JSON-agent registry。
+    append_codex_doctor_rows(home, env.codex_home.as_deref(), probe_timeout, &mut rows);
+    append_zcode_doctor_rows(home, probe_timeout, &mut rows);
+    for agent in all_json_mcp_agents(home, env) {
         append_json_agent_doctor_rows(&agent, probe_timeout, &mut rows);
     }
     Ok(rows)
@@ -1983,10 +2497,11 @@ mod tests {
             .to_string(),
         )
         .unwrap();
-        let u = unresolvable_wrappables(home);
+        let u = unresolvable_wrappables(home, &AgentEnv::default());
         assert!(
-            u.iter().any(|(n, _)| n == "badprog"),
-            "missing program must be flagged, got {:?}",
+            u.iter()
+                .any(|(label, n, _)| label == "Claude Code" && n == "badprog"),
+            "missing program must be flagged with its agent label, got {:?}",
             u
         );
     }
@@ -2080,8 +2595,478 @@ mod tests {
     fn no_mcp_servers_yields_empty() {
         assert!(classify_user_scope_servers(&json!({})).is_empty());
         assert!(classify_user_scope_servers(&json!({"mcpServers": {}})).is_empty());
-        // mcpServers 形状异常(数组而非对象)→ 容错空,不 panic
+        // mcpServers 形状异常(数组而非对象):classify 纯函数层容错空、不 panic ——
+        // 但 IO 入口(run_preview/apply/uninstall 等)已先经 ensure_mcp_root_shape **abort**,
+        // 生产路径绝不把类型错静默当"无 server"(见 mcp_root_shape_type_error_aborts)。
         assert!(classify_user_scope_servers(&json!({"mcpServers": []})).is_empty());
+    }
+
+    #[test]
+    fn mcp_root_shape_type_error_aborts() {
+        // review 2026-07-17 MED-1:`mcpServers` **存在但类型错** → 所有 IO 入口 abort
+        // (UnsupportedConfigShape),绝不静默当"没有 server"(fail-open)。键不存在仍是合法未配置。
+        let p = Path::new("/x/.claude.json");
+        assert!(ensure_mcp_root_shape(&json!({}), p).is_ok());
+        assert!(ensure_mcp_root_shape(&json!({"mcpServers": {}}), p).is_ok());
+        for bad in [
+            json!({"mcpServers": []}),
+            json!({"mcpServers": "oops"}),
+            json!({"mcpServers": 3}),
+            json!([1, 2]),
+            json!({"projects": "oops"}),
+            json!({"projects": {"/p": {"mcpServers": []}}}),
+        ] {
+            assert!(
+                matches!(
+                    ensure_mcp_root_shape(&bad, p),
+                    Err(SetupError::UnsupportedConfigShape { .. })
+                ),
+                "type-broken root shape must abort, got Ok for {bad}"
+            );
+        }
+        // IO 入口真接线(fixture):preview / apply / uninstall 全部 abort,文件一字不动。
+        let td = tempfile::TempDir::new().unwrap();
+        let home = td.path();
+        let raw = json!({"mcpServers": []}).to_string();
+        std::fs::write(home.join(".claude.json"), &raw).unwrap();
+        assert!(run_preview(home, "vigil-hub", true).is_err());
+        assert!(run_apply(home, "vigil-hub", false, false, true).is_err());
+        assert!(run_uninstall(home, false).is_err());
+        assert_eq!(
+            std::fs::read_to_string(home.join(".claude.json")).unwrap(),
+            raw,
+            "aborted run must leave the file byte-identical"
+        );
+        // JSON-agent 面同纪律。
+        std::fs::create_dir_all(home.join(".cursor")).unwrap();
+        std::fs::write(home.join(".cursor").join("mcp.json"), &raw).unwrap();
+        let agent = JsonMcpAgent::cursor(home);
+        assert!(run_json_agent_preview(&agent, "vigil-hub", true).is_err());
+        assert!(run_json_agent_apply(&agent, "vigil-hub", false, true).is_err());
+        assert!(run_json_agent_uninstall(&agent, false).is_err());
+    }
+
+    #[test]
+    fn codex_root_shape_type_error_aborts_and_inline_table_is_supported() {
+        // review 2026-07-17 MED-1(Codex 侧):`mcp_servers` 存在但非 table-like → abort;
+        // 内联表 `mcp_servers = {..}` 是合法 TOML,**必须**被枚举(此前被静默当 0 项 = 漏保护)。
+        let td = tempfile::TempDir::new().unwrap();
+        let home = td.path();
+        std::fs::create_dir_all(home.join(".codex")).unwrap();
+        let p = home.join(".codex").join("config.toml");
+        // 非 table-like → abort。
+        std::fs::write(&p, "mcp_servers = 3\n").unwrap();
+        assert!(run_codex_preview(home, None, "vigil-hub", true).is_err());
+        assert!(run_codex_apply(home, None, "vigil-hub", false, true).is_err());
+        // 内联表 → 正常枚举 + wrap。
+        std::fs::write(
+            &p,
+            "mcp_servers = { fs = { command = \"npx\", args = [\"-y\", \"srv\"] } }\n",
+        )
+        .unwrap();
+        let prev = run_codex_preview(home, None, "vigil-hub", true).unwrap();
+        assert_eq!(prev.wrappable_count(), 1, "inline table must be enumerated");
+        let rep = run_codex_apply(home, None, "vigil-hub", false, true).unwrap();
+        assert_eq!(rep.changed, 1, "inline-table entry must be wrappable");
+        let after = std::fs::read_to_string(&p).unwrap();
+        assert!(after.contains("--vigil-managed-mcp"), "wrapped: {after}");
+    }
+
+    #[test]
+    fn managed_wrap_grammar_is_symmetric_between_classify_and_unwrap() {
+        // review 2026-07-17 HIGH-2:classify 说 AlreadyWrapped ⟺ unwrap 能反解(同一 grammar)。
+        // 反例 1:sentinel 不紧邻 `--`(手改插参)→ 不是 AlreadyWrapped,unwrap 也是 None
+        //(此前 classify 认、unwrap 不认 → status 报已保护而 uninstall 还原不了 = 假托管态)。
+        let drifted = json!({"command": "vigil-hub",
+            "args": ["wrap", "--server-id", "x", "--vigil-managed-mcp", "EXTRA", "--", "npx", "y"]});
+        assert!(
+            !matches!(
+                classify_one("d", &drifted),
+                McpServerClass::AlreadyWrapped { .. }
+            ),
+            "sentinel not adjacent to `--` must NOT classify as AlreadyWrapped"
+        );
+        assert!(unwrap_entry(&drifted).is_none());
+        // 反例 2:第三方条目伪造 sentinel(command 非 vigil-hub、args[0]=="wrap"、sentinel 不邻 --)
+        // → 当普通 server 正常保护(不再因自带标记逃逸 wrap)。
+        let forged = json!({"command": "third-party-tool",
+            "args": ["wrap", "--vigil-managed-mcp", "X", "--", "npx", "srv"]});
+        assert!(
+            matches!(classify_one("f", &forged), McpServerClass::Wrappable { .. }),
+            "forged marker with drifted grammar must stay Wrappable, got {:?}",
+            classify_one("f", &forged)
+        );
+        // 正例:Vigil 真实产出的 wrap(sentinel 恒紧邻 --)→ 两边都认,往返成立。
+        let argv = wrapped_argv("vigil-hub", "user-x", "npx", &["y".into()], &[], true);
+        let real = json!({"command": argv[0],
+            "args": argv[1..].iter().map(|s| json!(s)).collect::<Vec<_>>()});
+        assert!(matches!(
+            classify_one("r", &real),
+            McpServerClass::AlreadyWrapped { .. }
+        ));
+        let restored = unwrap_entry(&real).expect("real wrap must unwrap");
+        assert_eq!(restored.get("command").unwrap(), "npx");
+    }
+
+    #[test]
+    fn wrap_status_reports_config_error_not_zero() {
+        // review 2026-07-17 MED-4:配置存在但损坏 → status 三态里是 ConfigError,绝不折叠成 0。
+        let td = tempfile::TempDir::new().unwrap();
+        let home = td.path();
+        std::fs::create_dir_all(home.join(".cursor")).unwrap();
+        std::fs::write(home.join(".cursor").join("mcp.json"), "{not json").unwrap();
+        let counts = wrapped_server_counts_all_agents(home, &AgentEnv::default());
+        let cursor = counts
+            .iter()
+            .find(|(n, _)| *n == "Cursor")
+            .expect("Cursor row");
+        assert_eq!(
+            cursor.1,
+            AgentWrapStatus::ConfigError,
+            "broken config must be ConfigError, not Wrapped(0)"
+        );
+        // 类型错的根形状同样 ConfigError(shape 校验一致过门)。
+        std::fs::create_dir_all(home.join(".kimi")).unwrap();
+        std::fs::write(
+            home.join(".kimi").join("mcp.json"),
+            json!({"mcpServers": []}).to_string(),
+        )
+        .unwrap();
+        let counts = wrapped_server_counts_all_agents(home, &AgentEnv::default());
+        let kimi = counts
+            .iter()
+            .find(|(n, _)| *n == "Kimi CLI")
+            .expect("Kimi row");
+        assert_eq!(kimi.1, AgentWrapStatus::ConfigError);
+        // 未配置(无文件)仍是 Wrapped(0):与"配置坏了"可区分。
+        let pi = counts.iter().find(|(n, _)| *n == "pi").expect("pi row");
+        assert_eq!(pi.1, AgentWrapStatus::Wrapped(0));
+    }
+
+    #[test]
+    fn json_agent_registry_invariants() {
+        // review 2026-07-17 HIGH-3 + MED-2:registry 是唯一清单 —— 前缀/显示名/路径必须两两不同,
+        // 前缀必须过构造器门禁(字符集 + 非保留)。**动态遍历** registry,新增 agent 自动被覆盖。
+        let home = Path::new("/h");
+        let env = AgentEnv {
+            codex_home: None,
+            pi_agent_dir: None,
+        };
+        let agents = all_json_mcp_agents(home, &env);
+        assert!(agents.len() >= 4, "cursor/windsurf/kimi/pi expected");
+        for a in &agents {
+            assert!(
+                !a.id_prefix.is_empty()
+                    && a.id_prefix
+                        .chars()
+                        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()),
+                "prefix charset: {}",
+                a.id_prefix
+            );
+            assert!(
+                !matches!(a.id_prefix, "user" | "local" | "codex"),
+                "reserved namespace: {}",
+                a.id_prefix
+            );
+        }
+        for i in 0..agents.len() {
+            for j in (i + 1)..agents.len() {
+                assert_ne!(agents[i].id_prefix, agents[j].id_prefix, "prefix dup");
+                assert_ne!(
+                    agents[i].display_name, agents[j].display_name,
+                    "display dup"
+                );
+                assert_ne!(
+                    agents[i].config_path, agents[j].config_path,
+                    "config path dup"
+                );
+            }
+        }
+        // 关键成员在场(专项守门:漏加 = 该 agent 全链路无保护)。
+        let prefixes: Vec<&str> = agents.iter().map(|a| a.id_prefix).collect();
+        for want in ["cursor", "windsurf", "kimi", "pi"] {
+            assert!(prefixes.contains(&want), "registry must contain {want}");
+        }
+    }
+
+    #[test]
+    fn preview_and_apply_server_id_agree_for_awkward_names() {
+        // review 2026-07-17 MED-6:非法字符名(大写/空格)时 preview 与 apply 的 id 派生必须同源。
+        let agent = JsonMcpAgent::cursor(Path::new("/h"));
+        for name in ["Playwright", "My Server", "纯中文"] {
+            assert_eq!(
+                agent.server_id(name),
+                json_agent_server_id("cursor", name),
+                "preview(json_agent_server_id) and apply(JsonMcpAgent::server_id) must agree"
+            );
+        }
+        // 合法名逐字保留(向后兼容既有账本身份)。
+        assert_eq!(agent.server_id("fs"), "cursor-fs");
+    }
+
+    #[test]
+    fn kimi_and_pi_paths_and_env_override() {
+        // C1/C2 接入契约:kimi 固定 ~/.kimi/mcp.json;pi 默认 ~/.pi/agent/mcp.json,
+        // 自定义 agent dir(PI_CODING_AGENT_DIR/PI_AGENT_DIR 注入)重定向,`~/` 展开到 home。
+        let home = Path::new("/h");
+        assert_eq!(
+            JsonMcpAgent::kimi(home).config_path,
+            home.join(".kimi").join("mcp.json")
+        );
+        assert_eq!(
+            JsonMcpAgent::pi(home, None).config_path,
+            home.join(".pi").join("agent").join("mcp.json")
+        );
+        assert_eq!(
+            JsonMcpAgent::pi(home, Some("/custom/pi")).config_path,
+            Path::new("/custom/pi").join("mcp.json")
+        );
+        assert_eq!(
+            JsonMcpAgent::pi(home, Some("~/mypi")).config_path,
+            home.join("mypi").join("mcp.json")
+        );
+        assert_eq!(
+            JsonMcpAgent::pi(home, Some("   ")).config_path,
+            home.join(".pi").join("agent").join("mcp.json"),
+            "blank env value falls back to default"
+        );
+    }
+
+    #[test]
+    fn kimi_wrap_roundtrip_and_pi_absent_is_honest_skip() {
+        // Kimi:官方文档形状 fixture(stdio + 远程混合)→ wrap 只动 stdio、远程 Skip;uninstall 还原。
+        let td = tempfile::TempDir::new().unwrap();
+        let home = td.path();
+        std::fs::create_dir_all(home.join(".kimi")).unwrap();
+        let orig = json!({"mcpServers": {
+            "chrome-devtools": {"command": "npx", "args": ["chrome-devtools-mcp@latest"],
+                                 "env": {"SOME_VAR": "value"}},
+            "context7": {"url": "https://mcp.context7.com/mcp",
+                          "headers": {"CONTEXT7_API_KEY": "k"}}
+        }});
+        std::fs::write(home.join(".kimi").join("mcp.json"), orig.to_string()).unwrap();
+        let kimi = JsonMcpAgent::kimi(home);
+        let prev = run_json_agent_preview(&kimi, "vigil-hub", true).unwrap();
+        assert_eq!(prev.wrappable_count(), 1, "stdio wrappable, remote skipped");
+        let rep = run_json_agent_apply(&kimi, "vigil-hub", false, true).unwrap();
+        assert_eq!(rep.changed, 1);
+        let wrapped: Value = serde_json::from_str(
+            &std::fs::read_to_string(home.join(".kimi").join("mcp.json")).unwrap(),
+        )
+        .unwrap();
+        let entry = &wrapped["mcpServers"]["chrome-devtools"];
+        assert_eq!(entry["command"], "vigil-hub");
+        assert_eq!(entry["args"][2], "kimi-chrome-devtools", "kimi- namespace");
+        assert_eq!(
+            entry["env"]["SOME_VAR"], "value",
+            "env preserved verbatim on the entry"
+        );
+        assert_eq!(
+            wrapped["mcpServers"]["context7"]["url"], "https://mcp.context7.com/mcp",
+            "remote entry untouched"
+        );
+        // uninstall:self-describing 还原(语义等价)。
+        let rep2 = run_json_agent_uninstall(&kimi, false).unwrap();
+        assert_eq!(rep2.changed, 1);
+        let restored: Value = serde_json::from_str(
+            &std::fs::read_to_string(home.join(".kimi").join("mcp.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(restored["mcpServers"]["chrome-devtools"]["command"], "npx");
+        assert_eq!(
+            restored["mcpServers"]["chrome-devtools"]["args"][0],
+            "chrome-devtools-mcp@latest"
+        );
+        // pi:文件不存在 → exists:false + 0 改动 + **绝不创建**文件/目录。
+        let pi = JsonMcpAgent::pi(home, None);
+        let prev = run_json_agent_preview(&pi, "vigil-hub", true).unwrap();
+        assert!(!prev.exists);
+        let rep = run_json_agent_apply(&pi, "vigil-hub", false, true).unwrap();
+        assert_eq!(rep.changed, 0);
+        assert!(
+            !home.join(".pi").exists(),
+            "absent pi config must never be created"
+        );
+    }
+
+    #[test]
+    fn zcode_nested_key_wrap_roundtrip_preserves_enabled_and_other_settings() {
+        // ZCode 契约(2026-07-17 解包 3.3.6 app.asar 核实):`~/.zcode/cli/config.json` 是共享
+        // 设置文件,MCP 在 `mcp.servers` 嵌套键;禁用条目带 `enabled:false` 附加键。wrap 必须:
+        // 只动 `mcp.servers` 内条目的 command/args;enabled 与文件内其它设置逐字保留;可逆。
+        let td = tempfile::TempDir::new().unwrap();
+        let home = td.path();
+        std::fs::create_dir_all(home.join(".zcode").join("cli")).unwrap();
+        let orig = json!({
+            "theme": "dark",
+            "mcp": {
+                "servers": {
+                    "memory": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-memory"]},
+                    "disabled-one": {"command": "npx", "args": ["srv"], "enabled": false},
+                    "remote": {"url": "https://example.com/mcp"}
+                },
+                "otherMcpSetting": 42
+            }
+        });
+        let p = zcode_config_path(home);
+        std::fs::write(&p, orig.to_string()).unwrap();
+
+        let prev = run_zcode_preview(home, "vigil-hub", true).unwrap();
+        assert!(prev.exists);
+        assert_eq!(prev.id_prefix, "zcode");
+        assert_eq!(
+            prev.wrappable_count(),
+            2,
+            "stdio(含 disabled)可保护,remote Skip"
+        );
+
+        let rep = run_zcode_apply(home, "vigil-hub", false, true).unwrap();
+        assert_eq!(rep.changed, 2);
+        let wrapped: Value = serde_json::from_str(&std::fs::read_to_string(&p).unwrap()).unwrap();
+        assert_eq!(wrapped["theme"], "dark", "非 MCP 设置逐字保留");
+        assert_eq!(wrapped["mcp"]["otherMcpSetting"], 42, "mcp 下其它键保留");
+        let mem = &wrapped["mcp"]["servers"]["memory"];
+        assert_eq!(mem["command"], "vigil-hub");
+        assert_eq!(mem["args"][2], "zcode-memory", "zcode- namespace");
+        assert_eq!(
+            wrapped["mcp"]["servers"]["disabled-one"]["enabled"], false,
+            "enabled:false 附加键逐字保留(wrap 不改变禁用语义)"
+        );
+        assert_eq!(
+            wrapped["mcp"]["servers"]["remote"]["url"], "https://example.com/mcp",
+            "远程条目不动"
+        );
+        // 幂等:再 apply 不二次 wrap。
+        let rep_again = run_zcode_apply(home, "vigil-hub", false, true).unwrap();
+        assert_eq!(rep_again.changed, 0, "already wrapped must be idempotent");
+        // uninstall 还原。
+        let rep2 = run_zcode_uninstall(home, false).unwrap();
+        assert_eq!(rep2.changed, 2);
+        let restored: Value = serde_json::from_str(&std::fs::read_to_string(&p).unwrap()).unwrap();
+        assert_eq!(restored["mcp"]["servers"]["memory"]["command"], "npx");
+        assert_eq!(
+            restored["mcp"]["servers"]["disabled-one"]["enabled"], false,
+            "还原后 enabled 仍在"
+        );
+        assert_eq!(restored["theme"], "dark");
+    }
+
+    #[test]
+    fn zcode_shape_errors_abort_and_missing_is_honest_skip() {
+        // `mcp` / `mcp.servers` 存在但类型错 → abort(ZCode 自身静默 {},Vigil 绝不效仿);
+        // 文件不存在 → exists:false,绝不创建。
+        let td = tempfile::TempDir::new().unwrap();
+        let home = td.path();
+        // 不存在:诚实跳过 + 不创建。
+        let prev = run_zcode_preview(home, "vigil-hub", true).unwrap();
+        assert!(!prev.exists);
+        assert_eq!(
+            run_zcode_apply(home, "vigil-hub", false, true)
+                .unwrap()
+                .changed,
+            0
+        );
+        assert!(
+            !home.join(".zcode").exists(),
+            "must never create the config"
+        );
+        // 类型错:abort 且文件一字不动。
+        std::fs::create_dir_all(home.join(".zcode").join("cli")).unwrap();
+        let p = zcode_config_path(home);
+        for bad in [
+            json!({"mcp": "oops"}).to_string(),
+            json!({"mcp": {"servers": []}}).to_string(),
+            json!({"mcp": {"servers": "x"}}).to_string(),
+        ] {
+            std::fs::write(&p, &bad).unwrap();
+            assert!(run_zcode_preview(home, "vigil-hub", true).is_err());
+            assert!(run_zcode_apply(home, "vigil-hub", false, true).is_err());
+            assert!(run_zcode_uninstall(home, false).is_err());
+            assert_eq!(std::fs::read_to_string(&p).unwrap(), bad, "file untouched");
+        }
+        // `mcp` 键缺省 = 未配置,合法(0 项,不报错)。
+        std::fs::write(&p, json!({"theme": "dark"}).to_string()).unwrap();
+        let prev = run_zcode_preview(home, "vigil-hub", true).unwrap();
+        assert!(prev.exists);
+        assert_eq!(prev.servers.len(), 0);
+        // doctor / counts 覆盖 ZCode 面。
+        std::fs::write(
+            &p,
+            json!({"mcp": {"servers": {"zz": {"command": "npx", "args": []}}}}).to_string(),
+        )
+        .unwrap();
+        let rows = run_doctor(home, &AgentEnv::default(), None).unwrap();
+        assert!(
+            rows.iter().any(|r| r.scope == "ZCode" && r.name == "zz"),
+            "doctor must cover the ZCode surface"
+        );
+        let counts = wrapped_server_counts_all_agents(home, &AgentEnv::default());
+        assert!(
+            counts.iter().any(|(n, _)| *n == "ZCode"),
+            "status must include the ZCode row"
+        );
+        // zcode- 前缀与 registry 各前缀 + 保留命名空间不相交(身份塌缩守门)。
+        let env = AgentEnv::default();
+        for a in all_json_mcp_agents(Path::new("/h"), &env) {
+            assert_ne!(
+                a.id_prefix, "zcode",
+                "zcode prefix reserved for the ZCode lane"
+            );
+        }
+        assert_eq!(
+            zcode_scope_server_id("My Srv"),
+            json_agent_server_id("zcode", "My Srv"),
+            "zcode id derivation must share the same component normalization"
+        );
+    }
+
+    #[test]
+    fn codex_home_env_redirects_all_codex_surfaces() {
+        // review 2026-07-17 HIGH-1 守门:自定义 CODEX_HOME 时,MCP 面(preview/apply/doctor/counts)
+        // 与 hook 面读写**同一**目录 —— 此前 MCP 面固定 ~/.codex,自定义用户全部 server 漏保护。
+        let td = tempfile::TempDir::new().unwrap();
+        let home = td.path();
+        let custom = home.join("custom-codex-home");
+        std::fs::create_dir_all(&custom).unwrap();
+        std::fs::write(
+            custom.join("config.toml"),
+            "[mcp_servers.fs]\ncommand = \"npx\"\nargs = [\"-y\", \"srv\"]\n",
+        )
+        .unwrap();
+        let env_val = custom.to_string_lossy().to_string();
+        // 路径解析一致(hook 面 SSOT)。
+        assert_eq!(
+            codex_config_path(home, Some(&env_val)),
+            custom.join("config.toml")
+        );
+        // 默认 home 下没有配置:不带 env → 未配置;带 env → 找到并可保护。
+        assert!(
+            !run_codex_preview(home, None, "vigil-hub", true)
+                .unwrap()
+                .exists
+        );
+        let prev = run_codex_preview(home, Some(&env_val), "vigil-hub", true).unwrap();
+        assert!(prev.exists);
+        assert_eq!(prev.wrappable_count(), 1);
+        let rep = run_codex_apply(home, Some(&env_val), "vigil-hub", false, true).unwrap();
+        assert_eq!(rep.changed, 1);
+        // doctor / counts 同样读自定义目录。
+        let env = AgentEnv {
+            codex_home: Some(env_val.clone()),
+            pi_agent_dir: None,
+        };
+        let rows = run_doctor(home, &env, None).unwrap();
+        assert!(
+            rows.iter().any(|r| r.scope == "Codex" && r.name == "fs"),
+            "doctor must see the custom CODEX_HOME server"
+        );
+        let counts = wrapped_server_counts_all_agents(home, &env);
+        assert!(
+            counts
+                .iter()
+                .any(|(n, st)| *n == "Codex" && *st == AgentWrapStatus::Wrapped(1)),
+            "status must count the wrapped server under custom CODEX_HOME, got {counts:?}"
+        );
     }
 
     #[test]
@@ -2691,7 +3676,7 @@ mod tests {
         )
         .unwrap();
 
-        let rows = run_doctor(home, None).unwrap();
+        let rows = run_doctor(home, &AgentEnv::default(), None).unwrap();
         let by = |n: &str| &rows.iter().find(|r| r.name == n).unwrap().status;
         assert!(
             matches!(by("good"), DoctorStatus::Launchable { .. }),
@@ -2728,7 +3713,7 @@ mod tests {
             json!({ "mcpServers": { "fs": wrapped } }).to_string(),
         )
         .unwrap();
-        let rows = run_doctor(home, None).unwrap();
+        let rows = run_doctor(home, &AgentEnv::default(), None).unwrap();
         assert_eq!(rows.len(), 1);
         assert!(rows[0].wrapped, "应识别为 Vigil 托管");
         assert!(
@@ -2740,7 +3725,9 @@ mod tests {
     #[test]
     fn run_doctor_empty_when_no_config() {
         let dir = tempfile::tempdir().unwrap();
-        assert!(run_doctor(dir.path(), None).unwrap().is_empty());
+        assert!(run_doctor(dir.path(), &AgentEnv::default(), None)
+            .unwrap()
+            .is_empty());
     }
 
     // ──────────────── D18 --probe:可 spawn argv+env 提取(纯函数,无 spawn) ────────────────
@@ -3061,7 +4048,7 @@ args = ["wrap", "--server-id", "codex-already", "--vigil-managed-mcp", "--", "np
         fs::write(&cfg, original).unwrap();
 
         // apply(monitor 姿态)
-        let rep = run_codex_apply(home, "vigil-hub", false, true).unwrap();
+        let rep = run_codex_apply(home, None, "vigil-hub", false, true).unwrap();
         assert_eq!(rep.changed, 1);
         assert!(rep.backup.is_some(), "写盘应留备份");
         let wrapped = fs::read_to_string(&cfg).unwrap();
@@ -3092,7 +4079,7 @@ args = ["wrap", "--server-id", "codex-already", "--vigil-managed-mcp", "--", "np
         assert!(fargs.iter().any(|a| a == "codex-filesystem"));
 
         // uninstall → 逐字还原
-        let rep2 = run_codex_uninstall(home, false).unwrap();
+        let rep2 = run_codex_uninstall(home, None, false).unwrap();
         assert_eq!(rep2.changed, 1);
         let restored = fs::read_to_string(&cfg).unwrap();
         let rdoc = restored.parse::<DocumentMut>().unwrap();
@@ -3128,13 +4115,13 @@ args = ["wrap", "--server-id", "codex-already", "--vigil-managed-mcp", "--", "np
         .unwrap();
 
         assert_eq!(
-            run_codex_apply(home, "vigil-hub", false, true)
+            run_codex_apply(home, None, "vigil-hub", false, true)
                 .unwrap()
                 .changed,
             1
         );
         assert_eq!(
-            run_codex_apply(home, "vigil-hub", false, true)
+            run_codex_apply(home, None, "vigil-hub", false, true)
                 .unwrap()
                 .changed,
             0,
@@ -3154,7 +4141,7 @@ args = ["wrap", "--server-id", "codex-already", "--vigil-managed-mcp", "--", "np
         let before = fs::read_to_string(&cfg).unwrap();
 
         assert!(matches!(
-            run_codex_apply(home, "vigil-hub", false, true),
+            run_codex_apply(home, None, "vigil-hub", false, true),
             Err(SetupError::MalformedConfig { .. })
         ));
         assert_eq!(
@@ -3169,10 +4156,14 @@ args = ["wrap", "--server-id", "codex-already", "--vigil-managed-mcp", "--", "np
     fn codex_no_config_is_noop() {
         let dir = tempfile::tempdir().unwrap();
         let home = dir.path();
-        let rep = run_codex_apply(home, "vigil-hub", false, true).unwrap();
+        let rep = run_codex_apply(home, None, "vigil-hub", false, true).unwrap();
         assert_eq!(rep.changed, 0);
         assert!(rep.backup.is_none());
-        assert!(!run_codex_preview(home, "vigil-hub", true).unwrap().exists);
+        assert!(
+            !run_codex_preview(home, None, "vigil-hub", true)
+                .unwrap()
+                .exists
+        );
     }
 
     /// 非法 server 名(含大写 / 点)→ Wrappable(F-4 修订:id 经 slug 化派生,不再要求用户改名)。
@@ -3428,7 +4419,7 @@ args = ["wrap", "--server-id", "codex-already", "--vigil-managed-mcp", "--", "np
     /// doctor 现在覆盖全部 4 个 agent 面:Claude / Codex / Cursor / Windsurf 的 server 都进 doctor 行,
     /// 各带正确 scope 标签;底层程序存在 → 全 Launchable。
     #[test]
-    fn doctor_covers_all_four_agents() {
+    fn doctor_covers_all_agents() {
         use std::fs;
         let dir = tempfile::tempdir().unwrap();
         let home = dir.path();
@@ -3465,13 +4456,29 @@ args = ["wrap", "--server-id", "codex-already", "--vigil-managed-mcp", "--", "np
             json!({"mcpServers": {"ws": {"command": real_str, "args": []}}}).to_string(),
         )
         .unwrap();
+        // Kimi CLI(JSON)
+        fs::create_dir_all(home.join(".kimi")).unwrap();
+        fs::write(
+            home.join(".kimi").join("mcp.json"),
+            json!({"mcpServers": {"km": {"command": real_str, "args": []}}}).to_string(),
+        )
+        .unwrap();
+        // pi(JSON,pi-mcp-adapter 约定路径)
+        fs::create_dir_all(home.join(".pi").join("agent")).unwrap();
+        fs::write(
+            home.join(".pi").join("agent").join("mcp.json"),
+            json!({"mcpServers": {"pp": {"command": real_str, "args": []}}}).to_string(),
+        )
+        .unwrap();
 
-        let rows = run_doctor(home, None).unwrap();
+        let rows = run_doctor(home, &AgentEnv::default(), None).unwrap();
         let scope_of = |n: &str| rows.iter().find(|r| r.name == n).map(|r| r.scope.as_str());
         assert_eq!(scope_of("cl"), Some("user"), "Claude user scope");
         assert_eq!(scope_of("cx"), Some("Codex"));
         assert_eq!(scope_of("cu"), Some("Cursor"));
         assert_eq!(scope_of("ws"), Some("Windsurf"));
+        assert_eq!(scope_of("km"), Some("Kimi CLI"));
+        assert_eq!(scope_of("pp"), Some("pi"));
         assert!(
             rows.iter()
                 .all(|r| matches!(r.status, DoctorStatus::Launchable { .. })),
@@ -3493,7 +4500,7 @@ args = ["wrap", "--server-id", "codex-already", "--vigil-managed-mcp", "--", "np
              args = [\"wrap\", \"--server-id\", \"codex-cx\", \"--vigil-managed-mcp\", \"--\", \"definitely-not-a-real-prog-xyz789\", \"x\"]\n",
         )
         .unwrap();
-        let rows = run_doctor(home, None).unwrap();
+        let rows = run_doctor(home, &AgentEnv::default(), None).unwrap();
         let cx = rows.iter().find(|r| r.name == "cx").unwrap();
         assert_eq!(cx.scope, "Codex");
         assert!(cx.wrapped, "应识别为 Vigil 托管");
@@ -3522,7 +4529,7 @@ args = ["wrap", "--server-id", "codex-already", "--vigil-managed-mcp", "--", "np
         fs::create_dir_all(home.join(".cursor")).unwrap();
         fs::write(home.join(".cursor").join("mcp.json"), "}{ not json").unwrap();
 
-        let rows = run_doctor(home, None).unwrap(); // 不 abort
+        let rows = run_doctor(home, &AgentEnv::default(), None).unwrap(); // 不 abort
         assert!(
             rows.iter().any(|r| r.name == "cl" && r.scope == "user"),
             "Claude 行仍在"
@@ -3551,7 +4558,7 @@ args = ["wrap", "--server-id", "codex-already", "--vigil-managed-mcp", "--", "np
         let home = dir.path();
         fs::write(home.join(".claude.json"), "}{ broken").unwrap();
         assert!(matches!(
-            run_doctor(home, None),
+            run_doctor(home, &AgentEnv::default(), None),
             Err(SetupError::MalformedConfig { .. })
         ));
     }

--- a/docs/book/src/getting-started/agent-integration.md
+++ b/docs/book/src/getting-started/agent-integration.md
@@ -7,7 +7,8 @@ Put **Vigils** in front of your AI agent's tools, so every tool call your agent 
 PII), and — when risky — sent to **approval**. Everything runs locally; nothing leaves your
 machine.
 
-Works with any MCP-capable agent: **Claude Code**, **Codex**, **Cursor**, **Zed**, OpenCode,
+Works with any MCP-capable agent: **Claude Code**, **Codex**, **Cursor**, **Zed**, **Kimi CLI**,
+**ZCode**, **pi**, OpenCode,
 Continue, and more.
 
 ## How it works
@@ -70,7 +71,29 @@ vigil-hub verify                  # after using your agent: confirm the tamper-e
 vigil-hub setup --all --uninstall # remove everything (config restored byte-for-byte)
 ```
 
-Restart Claude Code and you're protected. The rest of this guide is the **manual path** — use it
+Restart Claude Code and you're protected.
+
+**What `setup` auto-detects** (2026-07):
+
+| Agent | Hook (native-tool gate) | MCP wrap (server gateway) | Config touched |
+|---|---|---|---|
+| Claude Code | ✅ | ✅ (user + local scope) | `~/.claude/settings.json` + `~/.claude.json` |
+| Codex CLI | ✅ | ✅ (honors `$CODEX_HOME`) | `$CODEX_HOME/hooks.json` + `config.toml` |
+| Gemini CLI | ✅ | — (MCP lives inside the shared `settings.json`; later increment) | `~/.gemini/settings.json` |
+| Cursor | ✅ | ✅ | `~/.cursor/hooks.json` + `mcp.json` |
+| Windsurf | — | ✅ | `~/.codeium/windsurf/mcp_config.json` |
+| Kimi CLI | — (hooks are Beta and officially fail-open; deferred until GA) | ✅ | `~/.kimi/mcp.json` |
+| ZCode | — (plugin-only hook surface) | ✅ (close ZCode before `--apply`) | `mcp.servers` inside `~/.zcode/cli/config.json` |
+| pi | — (no hook mechanism) | ✅ (via the [pi-mcp-adapter](https://github.com/nicobailon/pi-mcp-adapter) convention file — pi ships no built-in MCP) | `$PI_AGENT_DIR/mcp.json` (default `~/.pi/agent/`) |
+
+> ZCode notes: the workspace-level `<project>/.zcode/config.json` is an in-repo file (may be
+> committed) and is deliberately left alone; the shared `~/.agents/mcp.json` fallback is not
+> rewritten either (multi-host file, identity ownership unsettled). Users who configure MCP in
+> ZCode's settings panel (which always writes back to the user-level `.zcode` config) get full
+> protection. For pi, a missing `mcp.json` simply means "nothing to protect" — the file is never
+> created for you.
+
+The rest of this guide is the **manual path** — use it
 for non-Claude agents (Codex / Cursor / Zed / …) or when you want explicit control over the
 `serve` gateway and its `upstreams.json`.
 

--- a/docs/book/src/getting-started/agent-integration.zh-CN.md
+++ b/docs/book/src/getting-started/agent-integration.zh-CN.md
@@ -6,7 +6,8 @@
 **防火墙**（默认拒绝）、**审计**（防篡改哈希链）、**脱敏**（密钥 / PII），高危调用还会进入
 **人工审批**。全部本地运行，数据不外传。
 
-支持任何兼容 MCP 的 agent：**Claude Code**、**Codex**、**Cursor**、**Zed**、OpenCode、Continue 等。
+支持任何兼容 MCP 的 agent：**Claude Code**、**Codex**、**Cursor**、**Zed**、**Kimi CLI**、
+**ZCode**、**pi**、OpenCode、Continue 等。
 
 ## 工作原理
 
@@ -64,7 +65,27 @@ vigil-hub verify                  # 用过 agent 后:确认防篡改审计链完
 vigil-hub setup --all --uninstall # 移除全部(配置逐字节还原)
 ```
 
-重启 Claude Code 即受保护。本指南余下部分是**手动路径** —— 用于非 Claude agent(Codex / Cursor /
+重启 Claude Code 即受保护。
+
+**`setup` 自动探测覆盖面**（2026-07）：
+
+| Agent | Hook（原生工具守门） | MCP wrap（server 网关） | 涉及配置 |
+|---|---|---|---|
+| Claude Code | ✅ | ✅（user + local scope） | `~/.claude/settings.json` + `~/.claude.json` |
+| Codex CLI | ✅ | ✅（尊重 `$CODEX_HOME`） | `$CODEX_HOME/hooks.json` + `config.toml` |
+| Gemini CLI | ✅ | —（MCP 嵌在共享 `settings.json`，留后续增量） | `~/.gemini/settings.json` |
+| Cursor | ✅ | ✅ | `~/.cursor/hooks.json` + `mcp.json` |
+| Windsurf | — | ✅ | `~/.codeium/windsurf/mcp_config.json` |
+| Kimi CLI | —（hooks 为 Beta 且官方 fail-open，等 GA 再评） | ✅ | `~/.kimi/mcp.json` |
+| ZCode | —（仅 plugin 形态 hook） | ✅（`--apply` 前请先关闭 ZCode） | `~/.zcode/cli/config.json` 的 `mcp.servers` |
+| pi | —（无 hook 机制） | ✅（经 [pi-mcp-adapter](https://github.com/nicobailon/pi-mcp-adapter) 约定文件 —— pi 本体无内置 MCP） | `$PI_AGENT_DIR/mcp.json`（默认 `~/.pi/agent/`） |
+
+> ZCode 说明：工作区级 `<项目>/.zcode/config.json` 是项目内文件（可能被提交），刻意不碰；共享
+> `~/.agents/mcp.json` fallback 亦不改写（多宿主文件，身份归属未定）。用 ZCode 设置面板配置
+> MCP（默认写回用户级 `.zcode` 配置）的用户获得完整保护。pi 的 `mcp.json` 不存在即"无可保护
+> 项"——绝不会替你创建。
+
+本指南余下部分是**手动路径** —— 用于非 Claude agent(Codex / Cursor /
 Zed / …)或你想显式控制 `serve` 网关及其 `upstreams.json` 时。
 
 ## 第 1 步 —— 冒烟测试 `vigil-hub`（30 秒，不用 agent）


### PR DESCRIPTION
## What

Extends the turnkey MCP gateway (`setup --mcp` / `setup --all` / `--doctor` / `--status` / `quickstart`) to three more agents, and hardens the whole integration surface based on a two-track adversarial code review.

### New wrap surfaces

| Agent | Config | Namespace | Notes |
|---|---|---|---|
| Kimi CLI (Moonshot) | `~/.kimi/mcp.json` (top-level `mcpServers`) | `kimi-` | Kimi hooks deliberately deferred: Beta + officially fail-open |
| ZCode (Z.ai) | nested `mcp.servers` in `~/.zcode/cli/config.json` | `zcode-` | dedicated pipeline; contract evidenced from vendor shipped code; GUI fields (`enabled`, …) preserved verbatim; close ZCode before `--apply` |
| pi (badlogic) | `$PI_AGENT_DIR/mcp.json` (pi-mcp-adapter convention) | `pi-` | pi ships no built-in MCP; missing file = nothing to protect, never created |

### Hardening

- **CODEX_HOME split fixed** — MCP wrap surface now honors `$CODEX_HOME` like the hook surface (custom-home installs were silently unprotected and invisible to status/doctor).
- **Managed-entry grammar unified** — classify and unwrap accept the same wrap grammar (sentinel immediately before `--`); kills the unremovable pseudo-managed state and sentinel spoofing.
- **Supported-agent registry SSOT** — `all_json_mcp_agents()` + validated id-prefix constructor (charset + reserved `user`/`local`/`codex` namespaces) + registry-driven invariant tests; previously 4 hardcoded call sites.
- **Root-shape strictness** — present-but-mistyped `mcpServers`/`mcp_servers` aborts instead of silently reading as “no servers”; Codex inline-table form now supported; `--doctor` emits `ConfigError` rows.
- **`--status` three-state honesty** — unreadable/unparsable config no longer collapses to a `0` count.
- **Preview/apply server-id parity** — single derivation function.
- **Pre-apply PATH warning** extended to every surface, labeled per surface.

Docs (mdBook en/zh) gain an auto-detect coverage matrix; CHANGELOG en/zh updated.

## Verification

- `cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace` — all green on a clean-room build of this branch (95 test suites).
- Round-trip (wrap → uninstall) and registry invariants covered by new tests.