### PR TITLE
release: v0.6.0-beta.1 — three new agent surfaces (Kimi CLI / ZCode / pi) on a hardened integration layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Vigils are documented here. The format follows
 
 ---
 
-## [Unreleased]
+## [v0.6.0-beta.1] — 2026-07-17 — three new agent surfaces (Kimi CLI / ZCode / pi) on a hardened integration layer
 
 ### Added
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -8,7 +8,7 @@ Vigils 的所有重要变更记录于此。格式遵循
 
 ---
 
-## [Unreleased]
+## [v0.6.0-beta.1] — 2026-07-17 — 三个新 agent 接入面(Kimi CLI / ZCode / pi)与接入面系统性加固
 
 ### 新增
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5790,7 +5790,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vigil-audit"
-version = "0.5.0"
+version = "0.6.0-beta.1"
 dependencies = [
  "criterion",
  "hex",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-browser"
-version = "0.5.0"
+version = "0.6.0-beta.1"
 dependencies = [
  "once_cell",
  "regex",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-daemon-ipc"
-version = "0.5.0"
+version = "0.6.0-beta.1"
 dependencies = [
  "dirs 6.0.0",
  "interprocess",
@@ -5836,7 +5836,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-desktop"
-version = "0.5.0"
+version = "0.6.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "blake2",
@@ -5872,7 +5872,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-firewall"
-version = "0.5.0"
+version = "0.6.0-beta.1"
 dependencies = [
  "dunce",
  "hex",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-http-auth"
-version = "0.5.0"
+version = "0.6.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -5913,7 +5913,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-http-transport"
-version = "0.5.0"
+version = "0.6.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -5947,7 +5947,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-hub-cli"
-version = "0.5.0"
+version = "0.6.0-beta.1"
 dependencies = [
  "clap",
  "dirs 6.0.0",
@@ -5987,7 +5987,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-lease"
-version = "0.5.0"
+version = "0.6.0-beta.1"
 dependencies = [
  "hex",
  "keyring",
@@ -6005,7 +6005,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-mcp"
-version = "0.5.0"
+version = "0.6.0-beta.1"
 dependencies = [
  "hex",
  "once_cell",
@@ -6030,7 +6030,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-native-host"
-version = "0.5.0"
+version = "0.6.0-beta.1"
 dependencies = [
  "clap",
  "dirs 6.0.0",
@@ -6045,7 +6045,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-policy"
-version = "0.5.0"
+version = "0.6.0-beta.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -6055,7 +6055,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-redaction"
-version = "0.5.0"
+version = "0.6.0-beta.1"
 dependencies = [
  "criterion",
  "dirs 5.0.1",
@@ -6077,7 +6077,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-runner"
-version = "0.5.0"
+version = "0.6.0-beta.1"
 dependencies = [
  "cap-std",
  "dunce",
@@ -6098,7 +6098,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-runner-types"
-version = "0.5.0"
+version = "0.6.0-beta.1"
 dependencies = [
  "dunce",
  "serde",
@@ -6107,7 +6107,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-sandbox-linux"
-version = "0.5.0"
+version = "0.6.0-beta.1"
 dependencies = [
  "landlock",
  "libc",
@@ -6117,7 +6117,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-sdk"
-version = "0.5.0"
+version = "0.6.0-beta.1"
 dependencies = [
  "serde_json",
  "uuid",
@@ -6131,7 +6131,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-types"
-version = "0.5.0"
+version = "0.6.0-beta.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -6139,7 +6139,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-ui-protocol"
-version = "0.5.0"
+version = "0.6.0-beta.1"
 dependencies = [
  "serde",
  "serde_jcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0-beta.1"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Vigils",
-  "version": "0.5.0",
+  "version": "0.6.0-beta.1",
   "identifier": "ai.vigils.desktop",
   "mainBinaryName": "vigils",
   "build": {

--- a/crates/vigil-audit/Cargo.toml
+++ b/crates/vigil-audit/Cargo.toml
@@ -19,10 +19,10 @@ workspace = true
 test-util = []
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.5.0" }
+vigil-types = { path = "../vigil-types", version = "0.6.0-beta.1" }
 # I01 扩展依赖:fail-closed 入口自检(ADR 0002 §D1)。
 # I00 的 "只能依赖 vigil-types" 约束是 I00 阶段性规则,I01 按 ADR 0002 明确放开。
-vigil-redaction = { path = "../vigil-redaction", version = "0.5.0" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.6.0-beta.1" }
 
 # I01 核心依赖
 rusqlite = { workspace = true }

--- a/crates/vigil-firewall/Cargo.toml
+++ b/crates/vigil-firewall/Cargo.toml
@@ -14,12 +14,12 @@ categories = ["api-bindings", "authentication"]
 workspace = true
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.5.0" }
-vigil-policy = { path = "../vigil-policy", version = "0.5.0" }
-vigil-audit = { path = "../vigil-audit", version = "0.5.0" }
+vigil-types = { path = "../vigil-types", version = "0.6.0-beta.1" }
+vigil-policy = { path = "../vigil-policy", version = "0.6.0-beta.1" }
+vigil-audit = { path = "../vigil-audit", version = "0.6.0-beta.1" }
 # ISS-010: T0 preflight 扫描(vigil-firewall 在 evaluate 前调 scan_text 产 PII findings)。
 # 依赖方向 T1 → T0 合法(vigil-redaction 纯函数、无反向依赖)。
-vigil-redaction = { path = "../vigil-redaction", version = "0.5.0" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.6.0-beta.1" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/vigil-lease/Cargo.toml
+++ b/crates/vigil-lease/Cargo.toml
@@ -20,8 +20,8 @@ default = []
 os-keychain = ["dep:keyring"]
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.5.0" }
-vigil-audit = { path = "../vigil-audit", version = "0.5.0" }
+vigil-types = { path = "../vigil-types", version = "0.6.0-beta.1" }
+vigil-audit = { path = "../vigil-audit", version = "0.6.0-beta.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/vigil-mcp/Cargo.toml
+++ b/crates/vigil-mcp/Cargo.toml
@@ -20,24 +20,24 @@ workspace = true
 ort = ["vigil-redaction/ort"]
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.5.0" }
-vigil-audit = { path = "../vigil-audit", version = "0.5.0" }
-vigil-firewall = { path = "../vigil-firewall", version = "0.5.0" }
-vigil-redaction = { path = "../vigil-redaction", version = "0.5.0" }
+vigil-types = { path = "../vigil-types", version = "0.6.0-beta.1" }
+vigil-audit = { path = "../vigil-audit", version = "0.6.0-beta.1" }
+vigil-firewall = { path = "../vigil-firewall", version = "0.6.0-beta.1" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.6.0-beta.1" }
 # I07.5+ (ADR 0007 §I-7.1):共享 Native spawn env 政策 helper(apply_native_env_policy)。
 # ADR 0018 v0.13 split:改依赖 vigil-runner-types(pure types + env policy,0 vigil
 # deps,unblock SDK publish chain),不再拉 vigil-runner concrete impl(wasmtime 等)。
-vigil-runner-types = { path = "../vigil-runner-types", version = "0.5.0" }
+vigil-runner-types = { path = "../vigil-runner-types", version = "0.6.0-beta.1" }
 # v0.5 P1 ADR 0014 α2:`pub fn Hub::resolve_approval` 用到的 typed 协议结构
 # (ResolveApprovalReq / ApprovalAction / ApprovalResolutionDto)。
 # vigil-ui-protocol 自身只依赖 vigil-types / vigil-audit / vigil-runner,
 # 与 vigil-mcp 现有 deps 无循环。
-vigil-ui-protocol = { path = "../vigil-ui-protocol", version = "0.5.0" }
+vigil-ui-protocol = { path = "../vigil-ui-protocol", version = "0.6.0-beta.1" }
 # 可逆脱敏 Slice 2:复用 `SecretValue`(Zeroizing/non-Debug/单一 expose)的值卫生装
 # Hub-owned `SecretAliasMap`。**只取值包装**,不引 LeaseBroker 审批门控语义(设计 D2:
 # broker mint-time 3-tuple 绑定与"运行时选 tool"现实冲突)。不启 os-keychain feature
 # —— keyring 读取在 vigil-hub-cli(已带该 feature)。
-vigil-lease = { path = "../vigil-lease", version = "0.5.0" }
+vigil-lease = { path = "../vigil-lease", version = "0.6.0-beta.1" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -52,7 +52,7 @@ once_cell = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 rusqlite = { workspace = true }
-vigil-policy = { path = "../vigil-policy", version = "0.5.0" }
+vigil-policy = { path = "../vigil-policy", version = "0.6.0-beta.1" }
 # α2 集成测试 `tests/resolve_approval.rs` 用 Ledger 真实建 approval + 调
 # `Hub::resolve_approval` 全链路验证 approve / deny / cancel(已是 main dep,
 # 此处显式声明仅为 IDE / `cargo metadata` 可读性)。

--- a/crates/vigil-policy/Cargo.toml
+++ b/crates/vigil-policy/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["api-bindings", "authentication"]
 workspace = true
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.5.0" }
+vigil-types = { path = "../vigil-types", version = "0.6.0-beta.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/vigil-sdk/Cargo.toml
+++ b/crates/vigil-sdk/Cargo.toml
@@ -23,14 +23,14 @@ ort = ["vigil-firewall/ort", "vigil-redaction/ort"]
 
 [dependencies]
 # Stable SDK re-exports;path-dep,locked to workspace version
-vigil-types = { path = "../vigil-types", version = "0.5.0" }
-vigil-firewall = { path = "../vigil-firewall", version = "0.5.0" }
-vigil-redaction = { path = "../vigil-redaction", version = "0.5.0" }
-vigil-mcp = { path = "../vigil-mcp", version = "0.5.0" }
+vigil-types = { path = "../vigil-types", version = "0.6.0-beta.1" }
+vigil-firewall = { path = "../vigil-firewall", version = "0.6.0-beta.1" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.6.0-beta.1" }
+vigil-mcp = { path = "../vigil-mcp", version = "0.6.0-beta.1" }
 # v0.16 FirewallBuilder facade:内部装配用(Ledger / PolicyEngine + default_ruleset)。
 # **不** re-export —— 仅 firewall_builder 内化使用,守 SDK 边界。
-vigil-audit = { path = "../vigil-audit", version = "0.5.0" }
-vigil-policy = { path = "../vigil-policy", version = "0.5.0" }
+vigil-audit = { path = "../vigil-audit", version = "0.6.0-beta.1" }
+vigil-policy = { path = "../vigil-policy", version = "0.6.0-beta.1" }
 # decide_call 便捷方法生成 invocation_id(UUIDv4);内部用,不进 SDK public API。
 uuid = { workspace = true }
 # decide_call 的 args 形参类型(serde_json::Value 已是 ToolInvocation.args 的公开类型,不扩面)。

--- a/crates/vigil-ui-protocol/Cargo.toml
+++ b/crates/vigil-ui-protocol/Cargo.toml
@@ -14,11 +14,11 @@ categories = ["data-structures", "api-bindings"]
 workspace = true
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.5.0" }
-vigil-audit = { path = "../vigil-audit", version = "0.5.0" }
+vigil-types = { path = "../vigil-types", version = "0.6.0-beta.1" }
+vigil-audit = { path = "../vigil-audit", version = "0.6.0-beta.1" }
 # ADR 0018 v0.13 split:改依赖 vigil-runner-types(pure types,0 vigil deps),
 # 不再拉 vigil-runner concrete(wasmtime/sandbox-linux),unblock SDK publish。
-vigil-runner-types = { path = "../vigil-runner-types", version = "0.5.0" }
+vigil-runner-types = { path = "../vigil-runner-types", version = "0.6.0-beta.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
Version bump to **v0.6.0-beta.1**: workspace version, 26 internal dependency pins, `tauri.conf.json`, `Cargo.lock` (19 workspace entries), and the changelog cut (en/zh) for the beta.

Feature content landed in #71. After merge, tag `v0.6.0-beta.1` on main triggers the release workflow.