### PR TITLE
docs: catch README + guides up with the current product

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ---
 
-AI agents (Claude Code, Cursor, Zed, MCP clients, browser assistants) call tools, read
+AI agents (Claude Code, Codex, Cursor, Zed, Kimi CLI, ZCode, pi, browser assistants) call tools, read
 files, hit APIs, and paste into web UIs on your behalf. That power is useful — and risky.
 **Vigils sits between your agents and the tools/data they touch**, and it is *local-first*:
 your prompts, secrets, and audit trail never leave your machine.
@@ -58,9 +58,13 @@ Four guarantees, enforced locally:
 - **🔌 MCP gateway** — sits in front of MCP servers over **stdio and HTTP**; descriptor
   pinning with drift detection (alerts when a tool's definition changes); bare-command stdio
   upstreams (`npx`/`node`/`python`) resolve via host PATH before sandboxing.
-- **🖥️ Desktop app** (Tauri 2 + Vue 3) — Approval Queue, Activity Feed, Server Registry,
-  Session Replay, Privacy Findings; keyboard shortcuts, light/dark/system theme, real-time
-  updates, bilingual (zh / en) UI.
+- **🖥️ Desktop app** (Tauri 2 + Vue 3) — the **Aegis command deck**: shield hero with an
+  eight-emblem defense ring, Protection Overview, Approval Queue, Activity Feed, Server
+  Registry, Session Replay, Privacy Findings and Settings on one dark-first design language.
+  Runs as a **resident guardian** (close-to-tray, single-instance) with one-click **Deploy
+  Guardian**, missing-engine detect + secure auto-download, engine-mode / posture switches,
+  daemon lifecycle and ML model install — all driving the same `vigil-hub` engine as the CLI.
+  Bilingual (zh / en), real-time updates.
 - **🌐 Browser extension** (Chrome MV3) — redacts secrets/PII *before* paste or submit on AI
   sites (ChatGPT, Claude, Gemini, Perplexity).
 
@@ -90,7 +94,7 @@ testable and composed by the **Hub** (the MCP gateway).
 | Binary | Crate | What it is |
 |---|---|---|
 | `vigil-hub` | `vigil-hub-cli` | CLI MCP gateway: `vigil-hub serve --stdio`, `add-remote-mcp`, `inspect`, … |
-| `gui` | `apps/desktop` | Tauri 2 desktop app (embeds the Vue 3 UI + an in-process Hub) |
+| `vigils` | `apps/desktop` | Tauri 2 desktop app (embeds the Vue 3 UI + an in-process Hub) |
 | `vigil-native-host` | `apps/native-host` | Native-messaging bridge for the Chrome extension |
 | — | `extensions/chrome-mv3` | Chrome MV3 extension (vanilla JS, zero npm deps) |
 
@@ -114,7 +118,8 @@ Or grab a pre-built installer / binary for **Windows, macOS, or Linux** from any
 | Platform | Desktop app | CLI |
 |---|---|---|
 | **Windows** | `.exe` (NSIS) / `.msi` | `vigil-hub.exe` (in `vigils-cli-windows-x64.zip`) |
-| **macOS** | `.dmg` | `vigil-hub` (in `vigils-cli-macos-arm64.tar.gz`) |
+| **macOS** (Apple Silicon) | `Vigils_<ver>_aarch64.dmg` | `vigil-hub` (in `vigils-cli-macos-arm64.tar.gz`) |
+| **macOS** (Intel) | `Vigils_<ver>_x64.dmg` | `vigil-hub` (in `vigils-cli-macos-x64.tar.gz`) |
 | **Linux** | `.AppImage` / `.deb` / `.rpm` | `vigil-hub` (in `vigils-cli-linux-x64.tar.gz`) |
 
 ### Two redaction engines: hard-fingerprint (default) or ML
@@ -134,7 +139,7 @@ vigil-hub serve --engine ml       # strict ML: fetches models on first run, fail
 vigil-hub serve --engine auto     # ML only if models are already cached and the dylib is present; otherwise degrades to hardfp and never downloads
 ```
 
-Models are fetched from Hugging Face (primary) with a [vigils.ai](https://vigils.ai) mirror fallback, each verified by SHA-256 (fail-closed). The ML build bundles [ONNX Runtime](https://onnxruntime.ai) 1.24 next to `vigil-hub`. Platform floors for the **ML** build: **Linux glibc ≥ 2.28**, **macOS ≥ 14** — the default hard-fingerprint build has neither. _(ML builds ship with every release since v0.4.0 — look for the `vigils-cli-ml-*` assets.)_
+Models are fetched from Hugging Face (primary) with a [vigils.ai](https://vigils.ai) mirror fallback, each verified by SHA-256 (fail-closed). The ML build bundles [ONNX Runtime](https://onnxruntime.ai) 1.24 next to `vigil-hub`. Platform floors for the **ML** build: **Linux glibc ≥ 2.28**, **macOS ≥ 14 (Apple Silicon only** — upstream onnxruntime no longer publishes x86_64 macOS builds, so Intel macs use the default hard-fingerprint engine**)** — the default hard-fingerprint build has neither. _(ML builds ship with every release since v0.4.0 — look for the `vigils-cli-ml-*` assets.)_
 
 > Early releases aren't OS-code-signed yet; your OS may show a Gatekeeper / SmartScreen prompt
 > on first run — they're still independently verifiable (see below, or the full
@@ -214,7 +219,7 @@ What you'll see (real output, trimmed):
 > received the real value. It's a planted scenario with a freshly-generated local fixture; the
 > firewall, redaction, and audit are Vigils' real code, only the model/tool provider is simulated.
 
-### Protect Claude Code in one command (turnkey)
+### Protect your agents in one command (turnkey)
 
 Download the release, then run **one command** to get fully protected. No manual config editing —
 your existing settings are backed up and only Vigils' own entries are added (fully reversible):
@@ -225,13 +230,17 @@ vigil-hub setup --all       # protect everything, in one step
 
 `setup --all` wires up **both** layers of protection:
 
-1. **Native-tool input guard** — a Claude Code `PreToolUse` hook so **every tool call** (Bash,
-   Edit, Write, Read, MCP tools, …) is checked before it runs; a real credential heading *into* a
-   tool is **blocked fail-closed** and recorded in your tamper-evident audit ledger.
-2. **MCP gateway** — routes each of your stdio MCP servers through Vigils so secrets in tool
+1. **Native-tool input guard** — pre-tool-use hooks for **Claude Code, Codex CLI, Gemini CLI
+   and Cursor**, so **every tool call** (Bash, Edit, Write, Read, MCP tools, …) is checked before
+   it runs; a real credential heading *into* a tool is **blocked fail-closed** and recorded in
+   your tamper-evident audit ledger.
+2. **MCP gateway** — rewrites the stdio MCP servers of every detected agent — **Claude Code,
+   Codex, Cursor, Windsurf, Kimi CLI, ZCode and pi** — to run through Vigils, so secrets in tool
    **results** are scrubbed before the model ever sees them, and every call is audited. It defaults
    to **monitor** posture — your servers stay fully usable while every hard protection stays on
    (raw-secret block, result redaction, tamper-evident audit). Add `--enforce` for default-deny gating.
+   The full per-agent coverage matrix lives in the
+   [Agent Integration guide](https://duncatzat.github.io/vigils/getting-started/agent-integration.html).
 
 ```bash
 vigil-hub setup --mcp --doctor    # pre-flight: will each wrapped MCP server actually start? (PATH check, read-only)
@@ -239,7 +248,7 @@ vigil-hub inspect protection      # after using your agent: see what Vigils caug
 vigil-hub setup --all --uninstall # cleanly remove everything (only Vigils' own entries; your settings restored faithfully)
 ```
 
-Restart Claude Code (or start a new session) and you're protected. This is the fastest path from a
+Restart your agent (or start a new session) and you're protected. This is the fastest path from a
 GitHub download to real protection.
 
 ### As an MCP gateway (CLI)
@@ -269,9 +278,13 @@ for per-agent config and how to verify it's gating.
 
 ### Desktop app
 
-Launch the desktop app to watch and control agents in real time: **Approval Queue** (approve /
-deny / bulk), **Activity Feed** (live audit stream), **Server Registry**, **Session Replay**,
-and **Privacy Findings**.
+Launch the desktop app to watch and control agents in real time from the **Aegis command
+deck**: **Protection Overview** (shield hero + eight-emblem defense ring + one-click **Deploy
+Guardian**), **Approval Queue** (approve / deny / bulk), **Activity Feed** (live audit stream),
+**Server Registry**, **Session Replay**, **Privacy Findings**, and **Settings** (engine mode,
+posture, resident daemon, ML model install, audit checkpoint anchor). Closing the window hides
+to the system tray — Vigils keeps guarding in the background (tray menu to reopen / quit; a
+second launch focuses the existing instance).
 
 ## Build from source
 
@@ -289,7 +302,7 @@ cargo build --release -p vigil-hub-cli --bin vigil-hub
 
 # Desktop UI + app (the `gui` feature embeds the built UI)
 cd apps/desktop/ui && npm ci && npm run build && cd -
-cargo build --release -p vigil-desktop --features gui --bin gui
+cargo build --release -p vigil-desktop --features gui --bin vigils
 ```
 
 > Crate names use the historical `vigil-*` prefix; the product and project are **Vigils**.
@@ -313,10 +326,11 @@ don't open a public issue for security reports.
 ## Project structure
 
 ```
-crates/          # 15 library crates (audit, policy, firewall, mcp, redaction, runner,
-                 #   lease, sandbox-linux, http-auth/transport, ui-protocol, browser, sdk, types)
+crates/          # 16 library crates (audit, policy, firewall, mcp, redaction, runner,
+                 #   lease, sandbox-linux, daemon-ipc, http-auth/transport, ui-protocol,
+                 #   browser, sdk, types)
 apps/
-  desktop/       # Tauri 2 + Vue 3 desktop app (bin: gui)
+  desktop/       # Tauri 2 + Vue 3 desktop app (bin: vigils)
   native-host/   # Chrome native-messaging bridge (bin: vigil-native-host)
   vigil-hub-cli/ # CLI MCP gateway (bin: vigil-hub)
 extensions/

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,7 +19,7 @@
 
 ---
 
-AI Agent(Claude Code、Cursor、Zed、MCP 客户端、浏览器助手)会代你调用工具、读文件、请求
+AI Agent(Claude Code、Codex、Cursor、Zed、Kimi CLI、ZCode、pi、浏览器助手)会代你调用工具、读文件、请求
 API、往网页里粘贴。这种能力很有用 —— 也有风险。**Vigils 位于你的 Agent 与它们所触及的
 工具/数据之间**,且是 *本地优先* 的:你的 prompt、密钥与审计记录永不离开本机。
 
@@ -56,8 +56,11 @@ API、往网页里粘贴。这种能力很有用 —— 也有风险。**Vigils 
 - **🔌 MCP 网关** —— 位于 MCP server 之前,支持 **stdio 与 HTTP**;descriptor pinning + 漂移
   检测(工具定义变化时告警);裸命令 stdio upstream(`npx`/`node`/`python`)在沙箱化前经
   宿主 PATH 解析。
-- **🖥️ 桌面应用**(Tauri 2 + Vue 3)—— 审批队列、活动流、服务器注册、会话回放、隐私发现;
-  键盘快捷键、浅色/深色/跟随系统主题、实时更新、中英双语 UI。
+- **🖥️ 桌面应用**(Tauri 2 + Vue 3)—— **Aegis 指挥舱**:盾徽 hero + 八徽记防御环,保护成效
+  概览、审批队列、活动流、服务器注册、会话回放、隐私发现与设置统一在深色优先的设计语言下。
+  以**常驻守护**运行(关窗收托盘、单实例),一键**部署守卫**、缺失引擎检测 + 安全自动下载、
+  引擎模式/姿态切换、daemon 生命周期与 ML 模型安装 —— GUI 与 CLI 驱动同一个 `vigil-hub`
+  引擎。中英双语、实时更新。
 - **🌐 浏览器扩展**(Chrome MV3)—— 在 AI 站点(ChatGPT、Claude、Gemini、Perplexity)粘贴或
   提交*之前*脱敏密钥/PII。
 
@@ -87,7 +90,7 @@ Vigils 是一个由聚焦单一职责的 crate 组成的 Rust workspace,外加�
 | 二进制 | Crate | 它是什么 |
 |---|---|---|
 | `vigil-hub` | `vigil-hub-cli` | CLI MCP 网关:`vigil-hub serve --stdio`、`add-remote-mcp`、`inspect`、… |
-| `gui` | `apps/desktop` | Tauri 2 桌面应用(内嵌 Vue 3 UI + 进程内 Hub) |
+| `vigils` | `apps/desktop` | Tauri 2 桌面应用(内嵌 Vue 3 UI + 进程内 Hub) |
 | `vigil-native-host` | `apps/native-host` | Chrome 扩展的 native-messaging 桥 |
 | — | `extensions/chrome-mv3` | Chrome MV3 扩展(纯 vanilla JS,零 npm 依赖) |
 
@@ -111,7 +114,8 @@ Linux** 的预构建安装包与二进制:
 | 平台 | 桌面应用 | CLI |
 |---|---|---|
 | **Windows** | `.exe`(NSIS)/ `.msi` | `vigil-hub.exe`(在 `vigils-cli-windows-x64.zip` 内) |
-| **macOS** | `.dmg` | `vigil-hub`(在 `vigils-cli-macos-arm64.tar.gz` 内) |
+| **macOS**(Apple Silicon) | `Vigils_<版本>_aarch64.dmg` | `vigil-hub`(在 `vigils-cli-macos-arm64.tar.gz` 内) |
+| **macOS**(Intel) | `Vigils_<版本>_x64.dmg` | `vigil-hub`(在 `vigils-cli-macos-x64.tar.gz` 内) |
 | **Linux** | `.AppImage` / `.deb` / `.rpm` | `vigil-hub`(在 `vigils-cli-linux-x64.tar.gz` 内) |
 
 ### 两种脱敏引擎:硬指纹(默认)或 ML
@@ -131,7 +135,7 @@ vigil-hub serve --engine ml       # 严格 ML:首跑下载模型,不可用则 fa
 vigil-hub serve --engine auto     # 仅当模型已缓存且 dylib 就位才启用 ML;否则降级硬指纹,绝不下载
 ```
 
-模型从 Hugging Face(主源)拉取,带 [vigils.ai](https://vigils.ai) 镜像 fallback,逐文件 SHA-256 校验(fail-closed)。ML 构建把 [ONNX Runtime](https://onnxruntime.ai) 1.24 捆在 `vigil-hub` 同目录。**ML** 构建的平台地板:**Linux glibc ≥ 2.28**、**macOS ≥ 14** —— 默认硬指纹构建则没有。_(ML 构建自 v0.4.0 起随每个 release 发布 —— 认准 `vigils-cli-ml-*` 资产。)_
+模型从 Hugging Face(主源)拉取,带 [vigils.ai](https://vigils.ai) 镜像 fallback,逐文件 SHA-256 校验(fail-closed)。ML 构建把 [ONNX Runtime](https://onnxruntime.ai) 1.24 捆在 `vigil-hub` 同目录。**ML** 构建的平台地板:**Linux glibc ≥ 2.28**、**macOS ≥ 14(仅 Apple Silicon** —— 上游 onnxruntime 已停发 x86_64 macOS 构建,Intel mac 使用默认硬指纹引擎**)** —— 默认硬指纹构建则没有。_(ML 构建自 v0.4.0 起随每个 release 发布 —— 认准 `vigils-cli-ml-*` 资产。)_
 
 > 早期版本未签名;首次运行时系统可能弹出 Gatekeeper / SmartScreen 提示。
 
@@ -157,7 +161,7 @@ irm https://vigils.ai/install.ps1 | iex              # Windows(PowerShell)
 什么,你始终掌控。解压前会对 release 发布的 SHA-256 校验(fail-closed)。想先读再 pipe?脚本在
 [`install.sh`](./install.sh) / [`install.ps1`](./install.ps1)。想手动下载?见[安装](#安装)。
 
-### 一键保护 Claude Code(turnkey)
+### 一键保护你的 agent(turnkey)
 
 下载 release 后,只跑**一条命令**即全面受保护。无需手动改配置——你既有的设置会被备份,只新增 Vigils
 自己的条目(完全可逆):
@@ -168,12 +172,14 @@ vigil-hub setup --all       # 一步全保护
 
 `setup --all` 同时接入**两层**保护:
 
-1. **原生工具输入侧守门** —— Claude Code `PreToolUse` hook,于是**每一次工具调用**(Bash、Edit、
-   Write、Read、MCP 工具……)在执行前都先被检查:真实凭据流*入*工具会被 **fail-closed 拦截**,记入
-   防篡改审计账本。
-2. **MCP 网关** —— 把你每个 stdio MCP server 经 Vigils 路由,工具**结果**里的 secret 在模型看到之前
+1. **原生工具输入侧守门** —— 为 **Claude Code、Codex CLI、Gemini CLI、Cursor** 注册
+   pre-tool-use hook,于是**每一次工具调用**(Bash、Edit、Write、Read、MCP 工具……)在执行前都先被
+   检查:真实凭据流*入*工具会被 **fail-closed 拦截**,记入防篡改审计账本。
+2. **MCP 网关** —— 把每个被探测到的 agent(**Claude Code、Codex、Cursor、Windsurf、Kimi CLI、
+   ZCode、pi**)的 stdio MCP server 改写为经 Vigils 运行,工具**结果**里的 secret 在模型看到之前
    被脱敏,每次调用都被审计。默认 **monitor** 姿态 —— 你的 server 保持完全可用,同时所有硬保护照常
    生效(裸 secret 拦截、结果脱敏、防篡改审计)。加 `--enforce` 升级为 default-deny 硬拦。
+   逐 agent 覆盖矩阵见 [Agent 接入指南](https://duncatzat.github.io/vigils/getting-started/agent-integration.zh-CN.html)。
 
 ```bash
 vigil-hub setup --mcp --doctor    # 接入前预检:每个被包裹的 MCP server 真能启动吗?(PATH 检查,只读)
@@ -237,8 +243,11 @@ vigil-hub inspect --db-path ./vigil.db activity --limit 20
 
 ### 桌面应用
 
-启动桌面应用,实时观察与控制 agent:**审批队列**(批准 / 拒绝 / 批量)、**活动流**(实时审计
-流)、**服务器注册**、**会话回放**、**隐私发现**。
+启动桌面应用,从 **Aegis 指挥舱**实时观察与控制 agent:**保护成效概览**(盾徽 hero + 八徽记
+防御环 + 一键**部署守卫**)、**审批队列**(批准 / 拒绝 / 批量)、**活动流**(实时审计流)、
+**服务器注册**、**会话回放**、**隐私发现**与**设置**(引擎模式、姿态、常驻 daemon、ML 模型
+安装、审计检查点锚定)。关闭窗口即收起到系统托盘 —— Vigils 在后台继续守护(托盘菜单可重新
+打开 / 退出;再次启动只会唤起既有实例)。
 
 ## 从源码构建
 
@@ -256,7 +265,7 @@ cargo build --release -p vigil-hub-cli --bin vigil-hub
 
 # 桌面 UI + 应用(`gui` feature 内嵌已构建的 UI)
 cd apps/desktop/ui && npm ci && npm run build && cd -
-cargo build --release -p vigil-desktop --features gui --bin gui
+cargo build --release -p vigil-desktop --features gui --bin vigils
 ```
 
 > crate 名沿用历史 `vigil-*` 前缀;产品与项目名为 **Vigils**。
@@ -277,10 +286,10 @@ cargo build --release -p vigil-desktop --features gui --bin gui
 ## 项目结构
 
 ```
-crates/          # 15 个库 crate(audit、policy、firewall、mcp、redaction、runner、
+crates/          # 16 个库 crate(audit、policy、firewall、mcp、redaction、runner、daemon-ipc、
                  #   lease、sandbox-linux、http-auth/transport、ui-protocol、browser、sdk、types)
 apps/
-  desktop/       # Tauri 2 + Vue 3 桌面应用(bin: gui)
+  desktop/       # Tauri 2 + Vue 3 桌面应用(bin: vigils)
   native-host/   # Chrome native-messaging 桥(bin: vigil-native-host)
   vigil-hub-cli/ # CLI MCP 网关(bin: vigil-hub)
 extensions/

--- a/docs/book/src/getting-started/desktop-quickstart.md
+++ b/docs/book/src/getting-started/desktop-quickstart.md
@@ -2,32 +2,52 @@
 
 ## First launch
 
-The window opens on the **Activity Feed** (empty on first run). There are four tabs:
-Activity Feed, Approval Queue, Server Registry, and Session Replay.
+The window opens on the **Protection Overview** — the Aegis command deck: a shield hero
+surrounded by an eight-emblem defense ring (firewall, approval, policy, sandbox, lease,
+redaction, gateway, audit). On a fresh machine it honestly reports **no protection yet** and
+offers the two one-click paths:
+
+- **Deploy Guardian** — wires protection into every detected agent (per-agent status shown).
+- **Download engine** — if the `vigil-hub` engine isn't on this machine yet, fetches it
+  securely (HTTPS + SHA-pin against the signed engine manifest + run-verify, fail-closed).
+
+Closing the window hides Vigils to the **system tray** — it keeps guarding in the background.
+Reopen or quit from the tray menu; launching the app again focuses the existing instance
+instead of starting a second one.
 
 ## Connect an AI agent
 
-### Claude Code (MCP stdio)
+The fastest path is the CLI turnkey (the desktop app's **Deploy Guardian** button drives the
+same engine):
+
+```bash
+vigil-hub setup --all
+```
+
+This registers native-tool hooks (Claude Code / Codex / Gemini / Cursor) and rewrites each
+detected agent's stdio MCP servers through Vigils (Claude Code / Codex / Cursor / Windsurf /
+Kimi CLI / ZCode / pi). Full matrix: [Agent Integration](./agent-integration.md).
+
+Manual MCP stdio entry (any MCP-capable agent):
 
 ```json
 { "mcpServers": { "vigil": { "command": "vigil-hub", "args": ["serve", "--stdio"] } } }
 ```
 
-### Cursor / Zed / Codex
-
-The same `vigil-hub serve --stdio` MCP stdio entry point.
-
 ### Browser extension
 
-Chrome MV3 extension → native host → desktop app (stdio MCP).
+Chrome MV3 extension → native host → the same local engine and ledger the desktop app shows.
 
-## Tabs at a glance
+## Pages at a glance
 
-| Tab | What it shows |
+| Page | What it shows |
 |---|---|
-| Activity Feed | Recent events, SQLite FTS5 search, hash-chain verification |
-| Approval Queue | Risky effects awaiting a decision — Approve / Reject / Delegate / Defer |
+| Protection Overview | Shield hero + defense ring, per-agent guardian status, browser-guard card, one-click deploy |
+| Approval Queue | Risky effects awaiting a decision — approve / reject, scoped grants |
+| Activity Feed | Live audit stream, SQLite FTS5 search, hash-chain verification |
+| Privacy Findings | What redaction caught — classes, counts, trends (no plaintext) |
 | Server Registry | Active / Pending / Removed servers, descriptor drift |
 | Session Replay | The full decision timeline for a chosen `session_id` |
+| Settings | Engine mode (hardfp / ml / auto), posture, resident daemon, ML model install, audit checkpoint anchor |
 
 See [Architecture](../concepts/architecture.md).

--- a/docs/book/src/getting-started/installation.md
+++ b/docs/book/src/getting-started/installation.md
@@ -26,8 +26,10 @@ Pick your OS, download, run. First launch shows a one-time "unknown developer" p
 2. If a blue **"Windows protected your PC"** box appears → **More info → Run anyway**.
 3. Done. *(The warning fades on its own as more people install.)*
 
-### macOS (Apple Silicon)
-1. Download **`Vigils_<version>_aarch64.dmg`** → open it → drag **Vigils** to **Applications**.
+### macOS
+1. Download the dmg for your chip — **Apple Silicon**: `Vigils_<version>_aarch64.dmg`;
+   **Intel**: `Vigils_<version>_x64.dmg` *(not sure? Apple menu → About This Mac — "Apple M…" means
+   Apple Silicon)* → open it → drag **Vigils** to **Applications**.
 2. First launch is blocked ("Apple could not verify…"). To allow it **once**:
    **  System Settings → Privacy & Security → scroll down → "Open Anyway" → confirm with Touch ID / password.**
 3. Done — it won't ask again.
@@ -68,7 +70,8 @@ block is recorded in a tamper-evident local ledger. Kick the tires with **`vigil
 
 > **ML variant** (optional, semantic PII + prompt-injection detection): download
 > `vigils-cli-ml-<os>` instead and run `vigil-hub serve --engine ml`. Floors: Linux glibc ≥ 2.28,
-> macOS ≥ 14. See [Privacy Filter](../concepts/privacy-filter.md).
+> macOS ≥ 14, Apple Silicon only (upstream onnxruntime dropped x86_64 macOS; Intel macs use the
+> default hard-fingerprint engine). See [Privacy Filter](../concepts/privacy-filter.md).
 
 ---
 

--- a/docs/book/src/getting-started/installation.zh-CN.md
+++ b/docs/book/src/getting-started/installation.zh-CN.md
@@ -25,8 +25,10 @@
 2. 若弹出蓝色 **"Windows 已保护你的电脑"** → **更多信息 → 仍要运行**。
 3. 完成。*(随着安装量增加,该警告会自行消退。)*
 
-### macOS(Apple 芯片)
-1. 下载 **`Vigils_<version>_aarch64.dmg`** → 打开 → 把 **Vigils** 拖进 **应用程序**。
+### macOS
+1. 按芯片下载 dmg —— **Apple Silicon**:`Vigils_<version>_aarch64.dmg`;**Intel**:
+   `Vigils_<version>_x64.dmg`(不确定?苹果菜单 → 关于本机 —— 显示"Apple M…"即 Apple
+   Silicon)→ 打开 → 把 **Vigils** 拖进 **应用程序**。
 2. 首次启动会被拦("Apple 无法验证…")。**一次性**放行:
    **  系统设置 → 隐私与安全性 → 下拉到底 → 点"仍要打开" → 用 Touch ID / 密码确认。**
 3. 完成 —— 之后不再询问。
@@ -64,7 +66,8 @@ vigil-hub setup       # 自动探测 Claude Code / Codex / Cursor 并接好守�
 想先试试就跑 **`vigil-hub demo`**(零设置)。各 agent 细节见 [Agent 集成](./agent-integration.zh-CN.md)。
 
 > **ML 变体**(可选,语义 PII + 提示注入检测):改下载 `vigils-cli-ml-<os>`,跑 `vigil-hub serve --engine ml`。
-> 底线:Linux glibc ≥ 2.28、macOS ≥ 14。见 [隐私过滤器](../concepts/privacy-filter.md)。
+> 底线:Linux glibc ≥ 2.28、macOS ≥ 14(仅 Apple Silicon —— 上游 onnxruntime 已停发 x86_64
+> macOS 构建,Intel mac 使用默认硬指纹引擎)。见 [隐私过滤器](../concepts/privacy-filter.md)。
 
 ---
 

--- a/docs/book/src/getting-started/verifying-downloads.md
+++ b/docs/book/src/getting-started/verifying-downloads.md
@@ -24,7 +24,7 @@ Every downloadable artifact ships with a [SLSA](https://slsa.dev) build-provenan
 attestation, signed through GitHub's Sigstore-backed infrastructure (no key for you to
 manage, nothing to trust besides GitHub and the public source):
 
-- CLI archives — `vigils-cli-linux-x64.tar.gz`, `vigils-cli-macos-arm64.tar.gz`, `vigils-cli-windows-x64.zip`
+- CLI archives — `vigils-cli-linux-x64.tar.gz`, `vigils-cli-macos-arm64.tar.gz`, `vigils-cli-macos-x64.tar.gz`, `vigils-cli-windows-x64.zip`
 - Desktop installers — `.exe`, `.msi`, `.dmg`, `.deb`, `.rpm`, `.AppImage`
 - Browser extension — `vigils-chrome-extension.zip`
 

--- a/docs/book/src/getting-started/verifying-downloads.zh-CN.md
+++ b/docs/book/src/getting-started/verifying-downloads.zh-CN.md
@@ -21,7 +21,7 @@ gh attestation verify <下载的文件> --repo duncatzat/vigils
 每个可下载产物都附带一份 [SLSA](https://slsa.dev) 构建溯源证明，由 GitHub 背后的
 Sigstore 基础设施签发（你无需自管密钥，除 GitHub 与公开源码外无需信任其他方）：
 
-- CLI 压缩包——`vigils-cli-linux-x64.tar.gz`、`vigils-cli-macos-arm64.tar.gz`、`vigils-cli-windows-x64.zip`
+- CLI 压缩包——`vigils-cli-linux-x64.tar.gz`、`vigils-cli-macos-arm64.tar.gz`、`vigils-cli-macos-x64.tar.gz`、`vigils-cli-windows-x64.zip`
 - 桌面安装包——`.exe`、`.msi`、`.dmg`、`.deb`、`.rpm`、`.AppImage`
 - 浏览器扩展——`vigils-chrome-extension.zip`
 


### PR DESCRIPTION
The README (en/zh) still described the product several releases back. This refresh brings it and the affected guides to the beta.4 state:

- **Desktop** — Aegis command deck (shield hero + eight-emblem defense ring), resident guardian (close-to-tray / single-instance), Deploy Guardian, engine & posture controls, daemon lifecycle, ML model install, checkpoint anchor.
- **Agents** — turnkey section names the real coverage (hooks: Claude Code / Codex / Gemini / Cursor; MCP wrap: + Windsurf / Kimi CLI / ZCode / pi) and links the coverage matrix.
- **macOS Intel** — install tables gain `Vigils_<ver>_x64.dmg` + `vigils-cli-macos-x64.tar.gz`; ML floors note Apple-Silicon-only with the upstream reason.
- **bin rename fallout** — `gui` → `vigils` in the apps table / build-from-source / project structure; crate count 15 → 16 (`daemon-ipc`).
- **desktop-quickstart.md rewritten** — it still described the four-tab era; now matches the Aegis pages, tray behavior and turnkey path.
- **verifying-downloads (en/zh)** — asset lists gain the Intel CLI archive.

Docs-only; no product code changes.