### PR TITLE
docs: desktop click-to-protect story + systematic staleness sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,8 @@ vigil-hub inspect protection
 vigil-hub inspect --db-path ./vigil.db activity --limit 20
 ```
 
-Point your agent (Claude Code / Cursor / Zed) at `vigil-hub` instead of the raw MCP server. See
+Point any MCP-capable agent (Claude Code / Codex / Cursor / Zed / Kimi CLI / …) at `vigil-hub`
+instead of the raw MCP server. See
 the **[Agent Integration & Test guide](https://duncatzat.github.io/vigils/getting-started/agent-integration.html)**
 for per-agent config and how to verify it's gating.
 

--- a/README.md
+++ b/README.md
@@ -58,13 +58,14 @@ Four guarantees, enforced locally:
 - **🔌 MCP gateway** — sits in front of MCP servers over **stdio and HTTP**; descriptor
   pinning with drift detection (alerts when a tool's definition changes); bare-command stdio
   upstreams (`npx`/`node`/`python`) resolve via host PATH before sandboxing.
-- **🖥️ Desktop app** (Tauri 2 + Vue 3) — the **Aegis command deck**: shield hero with an
-  eight-emblem defense ring, Protection Overview, Approval Queue, Activity Feed, Server
-  Registry, Session Replay, Privacy Findings and Settings on one dark-first design language.
-  Runs as a **resident guardian** (close-to-tray, single-instance) with one-click **Deploy
-  Guardian**, missing-engine detect + secure auto-download, engine-mode / posture switches,
-  daemon lifecycle and ML model install — all driving the same `vigil-hub` engine as the CLI.
-  Bilingual (zh / en), real-time updates.
+- **🖥️ Desktop app — protection in a few clicks** (Tauri 2 + Vue 3). Open the **Aegis
+  command deck** and click **Deploy Guardian**: Vigils finds every AI agent on the machine,
+  backs up their configs, wires hook + MCP-gateway protection into all of them, and lights up
+  per-agent status — no terminal, no hand-edited files, fully reversible. Engine missing?
+  One more click downloads it securely (signed manifest + SHA-pin, fail-closed). Close the
+  window and it keeps guarding from the tray (single-instance). Engine mode / posture /
+  resident daemon / ML install are switches on the Settings page — the GUI drives the same
+  `vigil-hub` engine as the CLI. Bilingual (zh / en), real-time.
 - **🌐 Browser extension** (Chrome MV3) — redacts secrets/PII *before* paste or submit on AI
   sites (ChatGPT, Claude, Gemini, Perplexity).
 
@@ -276,15 +277,26 @@ Point your agent (Claude Code / Cursor / Zed) at `vigil-hub` instead of the raw 
 the **[Agent Integration & Test guide](https://duncatzat.github.io/vigils/getting-started/agent-integration.html)**
 for per-agent config and how to verify it's gating.
 
-### Desktop app
+### Desktop app — no terminal needed
 
-Launch the desktop app to watch and control agents in real time from the **Aegis command
-deck**: **Protection Overview** (shield hero + eight-emblem defense ring + one-click **Deploy
-Guardian**), **Approval Queue** (approve / deny / bulk), **Activity Feed** (live audit stream),
-**Server Registry**, **Session Replay**, **Privacy Findings**, and **Settings** (engine mode,
-posture, resident daemon, ML model install, audit checkpoint anchor). Closing the window hides
-to the system tray — Vigils keeps guarding in the background (tray menu to reopen / quit; a
-second launch focuses the existing instance).
+Prefer clicking to typing? The desktop app gets you to the same protection in three clicks:
+
+1. **Open Vigils** — the Protection Overview shows an honest status: which agents are
+   protected, which aren't.
+2. *(first run)* Click **Download engine** if prompted — the `vigil-hub` engine is fetched
+   over HTTPS, pinned to the release's signed manifest, and run-verified before use
+   (fail-closed).
+3. Click **Deploy Guardian** — Vigils detects your installed agents, backs up their configs,
+   registers the hooks, rewrites their MCP servers through the gateway, and lights up
+   per-agent status. Same effect as `setup --all`, zero typing.
+
+From then on it's a **resident guardian**: closing the window hides to the system tray and
+protection keeps running (a second launch just focuses the existing window). Watch and
+control everything live — **Approval Queue** (approve / deny / bulk), **Activity Feed**
+(live audit stream), **Server Registry**, **Session Replay**, **Privacy Findings**, and
+**Settings** (engine mode, posture, resident daemon, ML model install, audit checkpoint
+anchor). Changed your mind? One click (or `vigil-hub setup --all --uninstall`) restores
+every config faithfully.
 
 ## Build from source
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -56,11 +56,12 @@ API、往网页里粘贴。这种能力很有用 —— 也有风险。**Vigils 
 - **🔌 MCP 网关** —— 位于 MCP server 之前,支持 **stdio 与 HTTP**;descriptor pinning + 漂移
   检测(工具定义变化时告警);裸命令 stdio upstream(`npx`/`node`/`python`)在沙箱化前经
   宿主 PATH 解析。
-- **🖥️ 桌面应用**(Tauri 2 + Vue 3)—— **Aegis 指挥舱**:盾徽 hero + 八徽记防御环,保护成效
-  概览、审批队列、活动流、服务器注册、会话回放、隐私发现与设置统一在深色优先的设计语言下。
-  以**常驻守护**运行(关窗收托盘、单实例),一键**部署守卫**、缺失引擎检测 + 安全自动下载、
-  引擎模式/姿态切换、daemon 生命周期与 ML 模型安装 —— GUI 与 CLI 驱动同一个 `vigil-hub`
-  引擎。中英双语、实时更新。
+- **🖥️ 桌面应用 —— 点几下就全护上**(Tauri 2 + Vue 3)。打开 **Aegis 指挥舱**,点一下
+  **部署守卫**:Vigils 自动找到本机每个 AI agent,备份其配置,把 hook + MCP 网关保护一次性
+  接进去,并逐 agent 亮起状态 —— 不用终端、不用手改文件、完全可逆。缺引擎?再点一下即安全
+  下载(签名清单 + SHA-pin,fail-closed)。关窗后从托盘继续守护(单实例)。引擎模式/姿态/
+  常驻 daemon/ML 安装都是设置页里的开关 —— GUI 与 CLI 驱动同一个 `vigil-hub` 引擎。
+  中英双语、实时更新。
 - **🌐 浏览器扩展**(Chrome MV3)—— 在 AI 站点(ChatGPT、Claude、Gemini、Perplexity)粘贴或
   提交*之前*脱敏密钥/PII。
 
@@ -241,13 +242,21 @@ vigil-hub inspect --db-path ./vigil.db activity --limit 20
 把你的 agent(Claude Code / Cursor / Zed)指向 `vigil-hub` 而非原始 MCP server 即可。各 agent 配置
 与"如何验证它在管控"见 **[Agent 接入与测试指南](https://duncatzat.github.io/vigils/getting-started/agent-integration.zh-CN.html)**。
 
-### 桌面应用
+### 桌面应用 —— 不需要终端
 
-启动桌面应用,从 **Aegis 指挥舱**实时观察与控制 agent:**保护成效概览**(盾徽 hero + 八徽记
-防御环 + 一键**部署守卫**)、**审批队列**(批准 / 拒绝 / 批量)、**活动流**(实时审计流)、
-**服务器注册**、**会话回放**、**隐私发现**与**设置**(引擎模式、姿态、常驻 daemon、ML 模型
-安装、审计检查点锚定)。关闭窗口即收起到系统托盘 —— Vigils 在后台继续守护(托盘菜单可重新
-打开 / 退出;再次启动只会唤起既有实例)。
+更喜欢点鼠标而不是敲命令?桌面应用三下点击就到位:
+
+1. **打开 Vigils** —— 保护成效概览如实显示:哪些 agent 已受保护、哪些还没有。
+2. *(首次运行)*按提示点 **下载引擎** —— `vigil-hub` 引擎经 HTTPS 拉取、按 release 签名
+   清单 SHA-pin 校验、运行核验后才启用(fail-closed)。
+3. 点 **部署守卫** —— Vigils 自动探测本机已装的 agent,备份配置、注册 hook、把它们的
+   MCP server 改写为经网关运行,并逐 agent 亮起状态。效果等同 `setup --all`,零打字。
+
+此后它就是**常驻守护**:关窗收进系统托盘,保护持续运行(再次启动只会唤起既有窗口)。一切
+尽在实时掌控 —— **审批队列**(批准 / 拒绝 / 批量)、**活动流**(实时审计流)、**服务器
+注册**、**会话回放**、**隐私发现**与**设置**(引擎模式、姿态、常驻 daemon、ML 模型安装、
+审计检查点锚定)。改主意了?点一下(或 `vigil-hub setup --all --uninstall`)即可把所有
+配置逐一如实还原。
 
 ## 从源码构建
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -239,7 +239,7 @@ vigil-hub add-remote-mcp https://mcp.example.com/
 vigil-hub inspect --db-path ./vigil.db activity --limit 20
 ```
 
-把你的 agent(Claude Code / Cursor / Zed)指向 `vigil-hub` 而非原始 MCP server 即可。各 agent 配置
+把任何兼容 MCP 的 agent(Claude Code / Codex / Cursor / Zed / Kimi CLI / …)指向 `vigil-hub` 而非原始 MCP server 即可。各 agent 配置
 与"如何验证它在管控"见 **[Agent 接入与测试指南](https://duncatzat.github.io/vigils/getting-started/agent-integration.zh-CN.html)**。
 
 ### 桌面应用 —— 不需要终端

--- a/docs/book/src/concepts/approval-queue.md
+++ b/docs/book/src/concepts/approval-queue.md
@@ -5,7 +5,7 @@ Human-in-the-loop gating for risky effects (driven by `FirewallOutcome::Approval
 ```
 firewall::evaluate → ApprovalRequired(req)
   → ApprovalBroker (SQLite, persistent)
-  → Desktop UI "Approval Queue" tab
+  → Desktop UI "Approval Queue" page
   → user: Approve / Reject / Delegate / Defer
   → ledger event
   → vigil-runner spawn (only if approved)

--- a/docs/book/src/concepts/architecture.md
+++ b/docs/book/src/concepts/architecture.md
@@ -27,6 +27,7 @@ T0 — Types + Schemas (vigil-types)
 
 - `vigil-runner` concrete (wasmtime + sandbox-linux + vigil-redaction deps)
 - `vigil-sandbox-linux` (Linux-only, target-gated)
+- `vigil-daemon-ipc` (daemon wire protocol + thin client, shared by hook / native-host)
 - `vigil-http-auth` / `vigil-http-transport` / `vigil-browser`
 - `apps/desktop` / `apps/native-host` / `apps/vigil-hub-cli`
 

--- a/docs/book/src/intro.md
+++ b/docs/book/src/intro.md
@@ -12,6 +12,17 @@
 Vigils sits between AI agents and the effectful tools / APIs they touch, gating each action
 through redaction + policy + audit + approval — and everything stays on your machine.
 
+## Two ways in
+
+- **Desktop app — a few clicks.** Open the Aegis command deck and click **Deploy Guardian**:
+  Vigils detects every installed agent, backs up its config, wires hook + MCP-gateway
+  protection into all of them and shows per-agent status. Missing engine? One click downloads
+  it (signed manifest + SHA-pin, fail-closed). Close the window — it keeps guarding from the
+  tray. See the [Desktop Quickstart](./getting-started/desktop-quickstart.md).
+- **CLI — one command.** `vigil-hub setup --all` does the same from a terminal, and
+  `vigil-hub demo` shows the whole protection story in 30 seconds with zero setup. See
+  [Agent Integration](./getting-started/agent-integration.md).
+
 ## What it protects against — and what it doesn't
 
 Vigils is **defense in depth**, not an airtight barrier. Being honest about the boundary lets you rely on it correctly.
@@ -44,7 +55,7 @@ An **egress proxy** that mediates *all* outbound data is the full answer — it 
 - **Desktop installers** — Linux deb / rpm / AppImage + macOS dmg + Windows nsis / msi (Ed25519-signed, auto-update).
 - **Rust SDK** — `cargo add vigil-sdk` ([crates.io](https://crates.io/crates/vigil-sdk) / [docs.rs](https://docs.rs/vigil-sdk)).
 - **Browser extension** — Chrome MV3 (redacts before paste / submit on AI sites).
-- **CLI agent gateway** — `vigil-hub serve --stdio` (Claude Code / Codex / Cursor / Zed).
+- **CLI agent gateway** — `vigil-hub serve --stdio`; turnkey `setup --all` covers Claude Code / Codex / Gemini CLI / Cursor hooks and MCP wrapping for Claude Code / Codex / Cursor / Windsurf / Kimi CLI / ZCode / pi.
 
 ## License
 
@@ -53,5 +64,7 @@ Apache-2.0 © Vigils Project Contributors
 ## Quick links
 
 - [Installation](./getting-started/installation.md)
+- [Quickstart — Desktop App](./getting-started/desktop-quickstart.md)
+- [Agent Integration & Test](./getting-started/agent-integration.md)
 - [Quickstart — Embedding the SDK](./getting-started/sdk-quickstart.md)
 - [Architecture Overview](./concepts/architecture.md)

--- a/docs/book/src/ops/auto-update.md
+++ b/docs/book/src/ops/auto-update.md
@@ -15,7 +15,9 @@ client startup
 ```
 
 The update endpoint and signing key are operated by the project; release bundles are signed
-in CI.
+in CI. macOS is served as two independent lines — `darwin-aarch64` (Apple Silicon) and
+`darwin-x86_64` (Intel) — each with its own manifest and arch-suffixed updater archive, so an
+update can never deliver the wrong architecture.
 
 ## Building a signed bundle
 

--- a/docs/book/src/ops/multi-platform-build.md
+++ b/docs/book/src/ops/multi-platform-build.md
@@ -1,6 +1,6 @@
 # Multi-Platform Build
 
-Three platforms; seven installer/bundle artifacts.
+Three platforms, four architectures (Windows x64 · Linux x64 · macOS Apple Silicon · macOS Intel).
 
 ## Linux
 
@@ -18,7 +18,15 @@ cd apps/desktop
 cargo tauri build --features gui --bundles app,dmg
 # app target = updater artifact (.app.tar.gz + .sig)
 # dmg target = user-facing installer
+
+# Intel (x86_64) — cross-compile from the arm64 runner; the Apple SDK is dual-arch:
+rustup target add x86_64-apple-darwin
+cargo tauri build --features gui --target x86_64-apple-darwin --bundles app,dmg
+# bundles land under target/x86_64-apple-darwin/release/bundle
 ```
+
+In CI the two mac updater archives are renamed per-arch (`Vigils-darwin-<arch>.app.tar.gz`)
+so they can coexist as release assets; each `latest-darwin-<arch>.json` points at its own.
 
 ## Windows
 


### PR DESCRIPTION
Follow-up to #79 — two gaps remained:

1. **The desktop story was buried.** The README listed desktop features but never told the actual user value: *you click, Vigils wires everything*. The feature bullet and the Quick Start section (en/zh) now walk the real 3-click path — open → (first run) securely fetch the engine (signed manifest + SHA-pin) → Deploy Guardian auto-detects every installed agent, backs up configs, registers hooks + rewrites MCP servers, lights per-agent status — then resident-tray guarding and one-click faithful restore. Benefit-first, guarantees in parentheses.
2. **Deeper docs were still stale.** Systematic sweep: intro.md (new 'Two ways in' + corrected agent coverage + quick links), architecture.md (+ `vigil-daemon-ipc`), multi-platform-build.md (4 architectures + Intel cross recipe + per-arch updater renaming), auto-update.md (two independent macOS lines), approval-queue.md (post-Aegis wording).

Docs-only.