### PR TITLE
release: v0.6.0 — eight agents, the Aegis desktop, and Intel macs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ All notable changes to Vigils are documented here. The format follows
 
 ---
 
+## [v0.6.0] — 2026-07-18 — eight agents, the Aegis desktop, and Intel macs
+
+The stable roll-up of v0.6.0-beta.1 → beta.4, verified end-to-end on real machines across
+all three platforms (published-artifact acceptance: ML turnkey install, daemon lifecycle,
+functional sweep — all green).
+
+**Highlights**
+
+- **Three new MCP gateway surfaces — Kimi CLI, ZCode, pi** — bringing turnkey coverage to
+  8 agents (hooks: Claude Code / Codex / Gemini CLI / Cursor; MCP wrap: + Windsurf /
+  Kimi CLI / ZCode / pi), on a systematically hardened integration layer
+  (CODEX_HOME split fix, unified managed-entry grammar, single agent registry with
+  namespace guards, strict root-shape validation, three-state status honesty).
+- **The Aegis command-deck desktop UI lands in the public build** — shield hero +
+  eight-emblem defense ring, per-page rework, resident guardian (close-to-tray,
+  single-instance), one-click Deploy Guardian, secure engine auto-download, engine/posture
+  switches, daemon lifecycle and ML model install from Settings.
+- **macOS Intel (x86_64) builds** — desktop dmg + CLI, cross-compiled and served on its own
+  OTA line (arch-suffixed updater archives so the two mac lines can never collide).
+  ML variant remains Apple-Silicon-only (upstream onnxruntime dropped x86_64 macOS).
+
+See the beta entries below for the full detail.
+
 ## [v0.6.0-beta.4] — 2026-07-17 — macOS Intel (x86_64) builds
 
 ### Added

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -8,6 +8,26 @@ Vigils 的所有重要变更记录于此。格式遵循
 
 ---
 
+## [v0.6.0] — 2026-07-18 — 八个 agent、Aegis 桌面与 Intel mac
+
+v0.6.0-beta.1 → beta.4 的稳定汇总,已在三平台真机对已发布产物完成端到端验收
+(ML turnkey 安装、daemon 生命周期、功能矩阵 —— 全绿)。
+
+**要点**
+
+- **MCP 网关新增三个接入面 —— Kimi CLI、ZCode、pi** —— turnkey 覆盖达 8 个 agent
+  (hook:Claude Code / Codex / Gemini CLI / Cursor;MCP wrap:+ Windsurf / Kimi CLI /
+  ZCode / pi),并对接入层系统性加固(CODEX_HOME 分裂修复、托管条目 grammar 统一、
+  单一 agent registry + 命名空间门禁、根形状严格校验、status 三态诚实化)。
+- **Aegis 指挥舱桌面 UI 落地公开构建** —— 盾徽 hero + 八徽记防御环、逐页重做、常驻守护
+  (关窗收托盘、单实例)、一键部署守卫、引擎安全自动下载、引擎/姿态切换、daemon 生命周期
+  与 ML 模型安装。
+- **macOS Intel(x86_64)构建** —— 桌面 dmg + CLI,交叉编译并走独立 OTA 线(更新器归档带
+  架构后缀,两条 mac 线不可能相撞)。ML 变体仍仅 Apple Silicon(上游 onnxruntime 停发
+  x86_64 macOS)。
+
+完整细节见下方各 beta 条目。
+
 ## [v0.6.0-beta.4] — 2026-07-17 — macOS Intel(x86_64)构建
 
 ### 新增

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6099,7 +6099,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vigil-audit"
-version = "0.6.0-beta.4"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "hex",
@@ -6119,7 +6119,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-browser"
-version = "0.6.0-beta.4"
+version = "0.6.0"
 dependencies = [
  "once_cell",
  "regex",
@@ -6132,7 +6132,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-daemon-ipc"
-version = "0.6.0-beta.4"
+version = "0.6.0"
 dependencies = [
  "dirs 6.0.0",
  "interprocess",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-desktop"
-version = "0.6.0-beta.4"
+version = "0.6.0"
 dependencies = [
  "base64 0.22.1",
  "blake2",
@@ -6182,7 +6182,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-firewall"
-version = "0.6.0-beta.4"
+version = "0.6.0"
 dependencies = [
  "dunce",
  "hex",
@@ -6206,7 +6206,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-http-auth"
-version = "0.6.0-beta.4"
+version = "0.6.0"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -6223,7 +6223,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-http-transport"
-version = "0.6.0-beta.4"
+version = "0.6.0"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -6257,7 +6257,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-hub-cli"
-version = "0.6.0-beta.4"
+version = "0.6.0"
 dependencies = [
  "clap",
  "dirs 6.0.0",
@@ -6297,7 +6297,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-lease"
-version = "0.6.0-beta.4"
+version = "0.6.0"
 dependencies = [
  "hex",
  "keyring",
@@ -6315,7 +6315,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-mcp"
-version = "0.6.0-beta.4"
+version = "0.6.0"
 dependencies = [
  "hex",
  "once_cell",
@@ -6340,7 +6340,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-native-host"
-version = "0.6.0-beta.4"
+version = "0.6.0"
 dependencies = [
  "clap",
  "dirs 6.0.0",
@@ -6355,7 +6355,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-policy"
-version = "0.6.0-beta.4"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -6365,7 +6365,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-redaction"
-version = "0.6.0-beta.4"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "dirs 5.0.1",
@@ -6387,7 +6387,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-runner"
-version = "0.6.0-beta.4"
+version = "0.6.0"
 dependencies = [
  "cap-std",
  "dunce",
@@ -6408,7 +6408,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-runner-types"
-version = "0.6.0-beta.4"
+version = "0.6.0"
 dependencies = [
  "dunce",
  "serde",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-sandbox-linux"
-version = "0.6.0-beta.4"
+version = "0.6.0"
 dependencies = [
  "landlock",
  "libc",
@@ -6427,7 +6427,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-sdk"
-version = "0.6.0-beta.4"
+version = "0.6.0"
 dependencies = [
  "serde_json",
  "uuid",
@@ -6441,7 +6441,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-types"
-version = "0.6.0-beta.4"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -6449,7 +6449,7 @@ dependencies = [
 
 [[package]]
 name = "vigil-ui-protocol"
-version = "0.6.0-beta.4"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_jcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0-beta.4"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Vigils",
-  "version": "0.6.0-beta.4",
+  "version": "0.6.0",
   "identifier": "ai.vigils.desktop",
   "mainBinaryName": "vigils",
   "build": {

--- a/crates/vigil-audit/Cargo.toml
+++ b/crates/vigil-audit/Cargo.toml
@@ -19,10 +19,10 @@ workspace = true
 test-util = []
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.6.0-beta.4" }
+vigil-types = { path = "../vigil-types", version = "0.6.0" }
 # I01 扩展依赖:fail-closed 入口自检(ADR 0002 §D1)。
 # I00 的 "只能依赖 vigil-types" 约束是 I00 阶段性规则,I01 按 ADR 0002 明确放开。
-vigil-redaction = { path = "../vigil-redaction", version = "0.6.0-beta.4" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.6.0" }
 
 # I01 核心依赖
 rusqlite = { workspace = true }

--- a/crates/vigil-firewall/Cargo.toml
+++ b/crates/vigil-firewall/Cargo.toml
@@ -14,12 +14,12 @@ categories = ["api-bindings", "authentication"]
 workspace = true
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.6.0-beta.4" }
-vigil-policy = { path = "../vigil-policy", version = "0.6.0-beta.4" }
-vigil-audit = { path = "../vigil-audit", version = "0.6.0-beta.4" }
+vigil-types = { path = "../vigil-types", version = "0.6.0" }
+vigil-policy = { path = "../vigil-policy", version = "0.6.0" }
+vigil-audit = { path = "../vigil-audit", version = "0.6.0" }
 # ISS-010: T0 preflight 扫描(vigil-firewall 在 evaluate 前调 scan_text 产 PII findings)。
 # 依赖方向 T1 → T0 合法(vigil-redaction 纯函数、无反向依赖)。
-vigil-redaction = { path = "../vigil-redaction", version = "0.6.0-beta.4" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.6.0" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/vigil-lease/Cargo.toml
+++ b/crates/vigil-lease/Cargo.toml
@@ -20,8 +20,8 @@ default = []
 os-keychain = ["dep:keyring"]
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.6.0-beta.4" }
-vigil-audit = { path = "../vigil-audit", version = "0.6.0-beta.4" }
+vigil-types = { path = "../vigil-types", version = "0.6.0" }
+vigil-audit = { path = "../vigil-audit", version = "0.6.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/vigil-mcp/Cargo.toml
+++ b/crates/vigil-mcp/Cargo.toml
@@ -20,24 +20,24 @@ workspace = true
 ort = ["vigil-redaction/ort"]
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.6.0-beta.4" }
-vigil-audit = { path = "../vigil-audit", version = "0.6.0-beta.4" }
-vigil-firewall = { path = "../vigil-firewall", version = "0.6.0-beta.4" }
-vigil-redaction = { path = "../vigil-redaction", version = "0.6.0-beta.4" }
+vigil-types = { path = "../vigil-types", version = "0.6.0" }
+vigil-audit = { path = "../vigil-audit", version = "0.6.0" }
+vigil-firewall = { path = "../vigil-firewall", version = "0.6.0" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.6.0" }
 # I07.5+ (ADR 0007 §I-7.1):共享 Native spawn env 政策 helper(apply_native_env_policy)。
 # ADR 0018 v0.13 split:改依赖 vigil-runner-types(pure types + env policy,0 vigil
 # deps,unblock SDK publish chain),不再拉 vigil-runner concrete impl(wasmtime 等)。
-vigil-runner-types = { path = "../vigil-runner-types", version = "0.6.0-beta.4" }
+vigil-runner-types = { path = "../vigil-runner-types", version = "0.6.0" }
 # v0.5 P1 ADR 0014 α2:`pub fn Hub::resolve_approval` 用到的 typed 协议结构
 # (ResolveApprovalReq / ApprovalAction / ApprovalResolutionDto)。
 # vigil-ui-protocol 自身只依赖 vigil-types / vigil-audit / vigil-runner,
 # 与 vigil-mcp 现有 deps 无循环。
-vigil-ui-protocol = { path = "../vigil-ui-protocol", version = "0.6.0-beta.4" }
+vigil-ui-protocol = { path = "../vigil-ui-protocol", version = "0.6.0" }
 # 可逆脱敏 Slice 2:复用 `SecretValue`(Zeroizing/non-Debug/单一 expose)的值卫生装
 # Hub-owned `SecretAliasMap`。**只取值包装**,不引 LeaseBroker 审批门控语义(设计 D2:
 # broker mint-time 3-tuple 绑定与"运行时选 tool"现实冲突)。不启 os-keychain feature
 # —— keyring 读取在 vigil-hub-cli(已带该 feature)。
-vigil-lease = { path = "../vigil-lease", version = "0.6.0-beta.4" }
+vigil-lease = { path = "../vigil-lease", version = "0.6.0" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -52,7 +52,7 @@ once_cell = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 rusqlite = { workspace = true }
-vigil-policy = { path = "../vigil-policy", version = "0.6.0-beta.4" }
+vigil-policy = { path = "../vigil-policy", version = "0.6.0" }
 # α2 集成测试 `tests/resolve_approval.rs` 用 Ledger 真实建 approval + 调
 # `Hub::resolve_approval` 全链路验证 approve / deny / cancel(已是 main dep,
 # 此处显式声明仅为 IDE / `cargo metadata` 可读性)。

--- a/crates/vigil-policy/Cargo.toml
+++ b/crates/vigil-policy/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["api-bindings", "authentication"]
 workspace = true
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.6.0-beta.4" }
+vigil-types = { path = "../vigil-types", version = "0.6.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/vigil-sdk/Cargo.toml
+++ b/crates/vigil-sdk/Cargo.toml
@@ -23,14 +23,14 @@ ort = ["vigil-firewall/ort", "vigil-redaction/ort"]
 
 [dependencies]
 # Stable SDK re-exports;path-dep,locked to workspace version
-vigil-types = { path = "../vigil-types", version = "0.6.0-beta.4" }
-vigil-firewall = { path = "../vigil-firewall", version = "0.6.0-beta.4" }
-vigil-redaction = { path = "../vigil-redaction", version = "0.6.0-beta.4" }
-vigil-mcp = { path = "../vigil-mcp", version = "0.6.0-beta.4" }
+vigil-types = { path = "../vigil-types", version = "0.6.0" }
+vigil-firewall = { path = "../vigil-firewall", version = "0.6.0" }
+vigil-redaction = { path = "../vigil-redaction", version = "0.6.0" }
+vigil-mcp = { path = "../vigil-mcp", version = "0.6.0" }
 # v0.16 FirewallBuilder facade:内部装配用(Ledger / PolicyEngine + default_ruleset)。
 # **不** re-export —— 仅 firewall_builder 内化使用,守 SDK 边界。
-vigil-audit = { path = "../vigil-audit", version = "0.6.0-beta.4" }
-vigil-policy = { path = "../vigil-policy", version = "0.6.0-beta.4" }
+vigil-audit = { path = "../vigil-audit", version = "0.6.0" }
+vigil-policy = { path = "../vigil-policy", version = "0.6.0" }
 # decide_call 便捷方法生成 invocation_id(UUIDv4);内部用,不进 SDK public API。
 uuid = { workspace = true }
 # decide_call 的 args 形参类型(serde_json::Value 已是 ToolInvocation.args 的公开类型,不扩面)。

--- a/crates/vigil-ui-protocol/Cargo.toml
+++ b/crates/vigil-ui-protocol/Cargo.toml
@@ -14,11 +14,11 @@ categories = ["data-structures", "api-bindings"]
 workspace = true
 
 [dependencies]
-vigil-types = { path = "../vigil-types", version = "0.6.0-beta.4" }
-vigil-audit = { path = "../vigil-audit", version = "0.6.0-beta.4" }
+vigil-types = { path = "../vigil-types", version = "0.6.0" }
+vigil-audit = { path = "../vigil-audit", version = "0.6.0" }
 # ADR 0018 v0.13 split:改依赖 vigil-runner-types(pure types,0 vigil deps),
 # 不再拉 vigil-runner concrete(wasmtime/sandbox-linux),unblock SDK publish。
-vigil-runner-types = { path = "../vigil-runner-types", version = "0.6.0-beta.4" }
+vigil-runner-types = { path = "../vigil-runner-types", version = "0.6.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/scripts/ota/vigils-ota-sync.sh
+++ b/scripts/ota/vigils-ota-sync.sh
@@ -11,13 +11,22 @@ set -euo pipefail
 
 REPO="${VIGILS_REPO:-duncatzat/vigils}"
 DOCROOT="${VIGILS_OTA_DOCROOT:-/var/www/vigils.ai/desktop-updates}"
-PLATFORMS=(windows-x86_64 darwin-aarch64 linux-x86_64)
+PLATFORMS=(windows-x86_64 darwin-aarch64 darwin-x86_64 linux-x86_64)
 TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 log() { echo "[ota-sync] $*"; }
 
 TAG="$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | jq -r '.tag_name // empty')"
 [ -z "$TAG" ] && { log "no latest release tag — nothing to do"; exit 0; }
 log "latest release: $TAG"
+
+# Metric hygiene: the timer fires every 15 min, but asset downloads count toward the
+# release's public download stats — unconditional pulls drowned real-user numbers
+# (~260 machine downloads/day). Only re-download when the latest tag actually changed;
+# the API call above is not an asset download and costs nothing.
+STAMP="$DOCROOT/.last-synced-tag"
+if [ -f "$STAMP" ] && [ "$(cat "$STAMP" 2>/dev/null)" = "$TAG" ]; then
+  log "already synced $TAG — nothing to do"; exit 0
+fi
 
 changed=0
 for PLAT in "${PLATFORMS[@]}"; do
@@ -44,4 +53,7 @@ if [ "$changed" = 1 ]; then
   chmod -R a+rX "$DOCROOT"
   log "permissions refreshed"
 fi
+# Record the synced tag even when nothing changed content-wise (e.g. re-run after a
+# partial first pass) so the early-exit above holds until the next real release.
+mkdir -p "$DOCROOT" && printf '%s' "$TAG" > "$STAMP" 2>/dev/null || true
 log "done"


### PR DESCRIPTION
Stable roll-up of beta.1 → beta.4. Promoted after full real-machine acceptance of the **published** beta.4 artifacts on all three platforms (ML turnkey incl. real ~738MB model download, daemon lifecycle, 18-scenario functional sweep — all green; CI acceptance's desktop-smoke-windows CDP failure is a pre-existing runner-environment issue, not a regression — real-machine CDP verification passed).

Also included: `scripts/ota/vigils-ota-sync.sh` gains the `darwin-x86_64` line (Intel OTA channel was missing server-side) and a tag-based early exit (metric hygiene — deployed and verified on the server).

After merge: tag `v0.6.0` → release → becomes **Latest** (first stable since v0.5.0).