### PR TITLE
fix(ci): restore desktop-smoke CDP gate (WebView2 --user-data-dir)

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -230,10 +230,19 @@ jobs:
       - name: GUI smoke over CDP
         shell: bash
         run: |
-          WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS="--remote-debugging-port=9222 --remote-allow-origins=*" "$VIGILS_EXE" >gui.log 2>&1 &
+          # --user-data-dir into a fresh dir is REQUIRED to open the WebView2/Edge remote-debugging
+          # port on current runner-image Edge builds. Without it the port silently never opens
+          # (regressed the whole desktop-smoke gate between v0.5.0 and v0.6.0-beta.1 as GitHub's
+          # windows-latest Edge auto-updated). A pre-existing profile blocks the debug port; a
+          # dedicated empty profile restores it. Harmless on older Edge (verified real-machine).
+          UDD="$(mktemp -d)/wv2"
+          WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS="--remote-debugging-port=9222 --remote-allow-origins=* --user-data-dir=$UDD" "$VIGILS_EXE" >gui.log 2>&1 &
           node tests/acceptance/gui-smoke.mjs 9222 gui-shots | tee gsmoke.out
           RC=${PIPESTATUS[0]}
           taskkill //F //IM vigils.exe >/dev/null 2>&1 || true
+          # On failure, surface the app's own stdout/stderr so a future break is diagnosable
+          # (launch crash vs. debug-port-not-open are very different fixes).
+          if [ "$RC" != 0 ]; then echo "----- gui.log (app output) -----"; cat gui.log || true; fi
           exit "$RC"
       - name: Job summary
         if: always()

--- a/tests/acceptance/gui-smoke.mjs
+++ b/tests/acceptance/gui-smoke.mjs
@@ -7,8 +7,10 @@
 //   G4 全程零未捕获异常 / console error
 //
 // 前置:vigils.exe 以
-//   WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS="--remote-debugging-port=<port> --remote-allow-origins=*"
-// 启动。用法: node gui-smoke.mjs <port> <out-dir>
+//   WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS="--remote-debugging-port=<port> --remote-allow-origins=* --user-data-dir=<fresh-empty-dir>"
+// 启动。**`--user-data-dir` 指向一个新建空目录是必需的**:当前版本 Edge/WebView2 在存在既有
+// 用户配置时不再开放远程调试端口(端口静默不开,连不上 CDP)——专用空 profile 才恢复。缺它会让
+// desktop-smoke 门在 runner Edge 自升级后整体失效。用法: node gui-smoke.mjs <port> <out-dir>
 import { writeFileSync, mkdirSync } from "node:fs";
 
 const PORT = process.argv[2] || "9222";


### PR DESCRIPTION
**The desktop-smoke-windows acceptance gate has been silently failing since v0.6.0-beta.1** — every v0.6.0 line shipped without desktop packaging being CDP-verified in CI.

Root cause (evidence): it *passed* on v0.5.0 (run 28874449398/28917945150/29229379818) and turned to a hard `no CDP page target` failure from beta.1 onward (29555299314+). beta.1's desktop was still the old UI, so it's not a code regression — GitHub's `windows-latest` Edge/WebView2 auto-updated to a build that refuses to open the remote-debugging port when a pre-existing user profile exists.

Fix: pass `--user-data-dir=<fresh dir>` in the WebView2 launch args (the documented workaround). **Verified on a real Win11 machine that the flag does not break the previously-working path** (12/12 gui-smoke green). Also dumps `gui.log` on failure so future breaks are diagnosable (launch-crash vs port-not-open).

After merge I'll dispatch the acceptance workflow against v0.6.0 to confirm the gate is green on CI.