### PR TITLE
harden(daemon): server-side peer-cred gate (unix) + per-euid Linux socket name

### DIFF
--- a/apps/vigil-hub-cli/src/command_guard.rs
+++ b/apps/vigil-hub-cli/src/command_guard.rs
@@ -224,33 +224,31 @@ fn classify_depth(command: &str, project_root: Option<&str>, depth: u8) -> Optio
                     consider(risk);
                 }
             }
-            "dd" => {
-                if argv.iter().any(|a| {
-                    a.strip_prefix("of=")
-                        .map(|t| t.starts_with("/dev/"))
-                        .unwrap_or(false)
-                }) {
-                    consider(CommandRisk {
-                        tier: GuardTier::Catastrophic,
-                        category: GuardCategory::DeviceOrDiskWrite,
-                        detail: "dd writes directly to a block device (of=/dev/…) — overwrites a disk/partition",
-                    });
-                }
+            // guard-arm 形式(clippy 1.95 collapsible_match):guard 不满足 → **落穿**后续 arm——
+            // 当前 dd/shred 落穿只会被 `_ => {}` 接住;新增前缀 guard arm 时注意落穿语义。
+            "dd" if argv.iter().any(|a| {
+                a.strip_prefix("of=")
+                    .map(|t| t.starts_with("/dev/"))
+                    .unwrap_or(false)
+            }) =>
+            {
+                consider(CommandRisk {
+                    tier: GuardTier::Catastrophic,
+                    category: GuardCategory::DeviceOrDiskWrite,
+                    detail: "dd writes directly to a block device (of=/dev/…) — overwrites a disk/partition",
+                });
             }
             b if b.starts_with("mkfs") => consider(CommandRisk {
                 tier: GuardTier::Catastrophic,
                 category: GuardCategory::DeviceOrDiskWrite,
                 detail: "mkfs formats a filesystem — destroys all data on the target device",
             }),
-            "shred" => {
-                if argv.iter().skip(1).any(|a| a.starts_with("/dev/")) {
-                    consider(CommandRisk {
-                        tier: GuardTier::Catastrophic,
-                        category: GuardCategory::DeviceOrDiskWrite,
-                        detail:
-                            "shred targets a block device (/dev/…) — irrecoverably wipes a disk",
-                    });
-                }
+            "shred" if argv.iter().skip(1).any(|a| a.starts_with("/dev/")) => {
+                consider(CommandRisk {
+                    tier: GuardTier::Catastrophic,
+                    category: GuardCategory::DeviceOrDiskWrite,
+                    detail: "shred targets a block device (/dev/…) — irrecoverably wipes a disk",
+                });
             }
             "chmod" | "chown" => {
                 let recursive = argv

--- a/apps/vigil-hub-cli/src/daemon/mod.rs
+++ b/apps/vigil-hub-cli/src/daemon/mod.rs
@@ -21,7 +21,9 @@
 //! ledger;dispatch 出真 findings / 软信号 risk bump)、`daemon start|stop|status` 子命令、hook 接
 //! `query_daemon`(PostToolUse PII 再脱敏 + 注入 fire-forget,fail-closed)、**F2** 并发上限门
 //! (conn 64 / classify 8;超限丢弃 —— 连接侧客户端 fail-closed 降级硬指纹,classify 侧软信号
-//! 丢弃,线程不随负载无界累积;见 `server::serve` 诚实边界注释)。后续:R6 socket 权限硬化。
+//! 丢弃,线程不随负载无界累积;见 `server::serve` 诚实边界注释)、**R1'** 服务端 accept 门
+//! (unix:对端 client euid 必须为本用户,Linux 抽象 NS 的结构性跨用户屏障)+ Linux per-euid
+//! 默认 socket 名(消除多用户固定名 bind 互撞)。后续:R6 Windows pipe 显式 DACL。
 //!
 //! # 不变量(ADR 0024 Revised,实施前必决 R1–R6 已落决策)
 //!

--- a/apps/vigil-hub-cli/src/daemon/server.rs
+++ b/apps/vigil-hub-cli/src/daemon/server.rs
@@ -187,6 +187,13 @@ fn serve_with_limit(listener: interprocess::local_socket::Listener, caps: Daemon
             Ok(s) => s,
             Err(_) => continue,
         };
+        // **R1'(服务端,unix)**:占坑前核对端 client euid == 本用户;取不到/不符 → fail-closed
+        // 丢弃。Linux 抽象 NS 无文件系统权限 → 此门是结构性跨用户屏障(token 挡不住握手前占坑)。
+        // Windows 由默认 pipe 安全描述符挡跨用户 duplex 连接(显式 DACL = R6 后续)。
+        #[cfg(unix)]
+        if !crate::daemon::transport::peer_is_current_user(&stream) {
+            continue;
+        }
         if !acquire_slot(&active, max) {
             continue; // 满员:drop(stream) → 客户端 EOF → fail-closed 降级硬指纹
         }

--- a/crates/vigil-daemon-ipc/Cargo.toml
+++ b/crates/vigil-daemon-ipc/Cargo.toml
@@ -23,8 +23,9 @@ interprocess = "2"
 dirs = "6"
 
 # macOS daemon R1:`peer_creds().pid()` 在 macOS UDS 恒 None(无 SO_PEERCRED),euid 可用。
-# 用 rustix(安全封装,本 crate 仍 forbid unsafe)取自身 euid 与对端比对。版本对齐 lock 既有 1.x。
-[target.'cfg(target_os = "macos")'.dependencies]
+# 用 rustix(安全封装,本 crate 仍 forbid unsafe)取自身 euid 与对端比对(macOS 客户端 R1 +
+# 全 unix 服务端 accept 门)+ Linux per-euid 默认 socket 名。版本对齐 lock 既有 1.x。
+[target.'cfg(unix)'.dependencies]
 rustix = { version = "1", features = ["process"] }
 
 [dev-dependencies]

--- a/crates/vigil-daemon-ipc/src/transport.rs
+++ b/crates/vigil-daemon-ipc/src/transport.rs
@@ -10,7 +10,11 @@
 //!   身份运行)。注意:macOS 为 **euid-only,不作 pid 绑定**,故不主张 pid-reuse 保护——cross-user
 //!   由用户私有目录权限排除,同用户冒充由 token + 单实例 bind 兜底;且**永不 fail-open**(硬指纹
 //!   底座在 hook 内先跑,冒充/缺失至多抑制 ML recall)。取不到 / 不符 → fail-closed → 硬指纹。
-//! - **R6**(socket 权限硬化,后续):Unix 0600 / Windows pipe DACL。
+//! - **R1'(服务端 accept 门,unix)**:accept 后、占 handler 坑前核**对端 client euid == 本用户**
+//!   (取不到/不符 → fail-closed 丢弃)。Linux 抽象 NS 无文件系统权限 → 这是结构性跨用户屏障
+//!   (token 只挡请求,挡不住握手前静默占坑);macOS 上是 0700 目录/0600 节点之外的纵深。
+//!   见 [`peer_is_current_user`](服务端消费在 vigil-hub-cli `daemon::server::serve`)。
+//! - **R6**(socket 权限硬化,后续):Windows pipe 显式 DACL(当前依赖默认安全描述符挡跨用户)。
 
 use std::sync::mpsc;
 use std::time::Duration;
@@ -28,7 +32,9 @@ use crate::protocol::{Request, Response};
 
 /// 默认 daemon socket 标识。
 ///
-/// - **Linux**:`GenericNamespaced` → 抽象 UDS(`\0` 前缀,内核在进程死亡时自动回收,无 stale)。
+/// - **Linux**:`GenericNamespaced` → 抽象 UDS(`\0` 前缀,内核在进程死亡时自动回收,无 stale);
+///   名含本用户 euid(抽象 NS 跨用户共享,固定名多用户互撞 —— 见 [`platform_default_socket_name`]
+///   内注释)。
 /// - **Windows**:`GenericNamespaced` → `\\.\pipe\vigil-daemon.sock`(named pipe,句柄关即清)。
 /// - **macOS**:**无抽象命名空间** —— namespaced 会落到世界可读的 `/tmp` 文件 socket、非干净
 ///   退出不回收(EADDRINUSE 永久卡死重启)、且 `peer_creds().pid()` 恒 None(R1 失效)。故改用
@@ -68,7 +74,16 @@ fn platform_default_socket_name() -> String {
                     .into_owned()
             })
     }
-    #[cfg(not(target_os = "macos"))]
+    // Linux:抽象命名空间跨用户共享且无属主 —— 固定名下多用户互撞(后 bind 者 daemon 起不来,
+    // ML 降级硬指纹)。per-euid 名消除**意外**互撞;恶意 squat(抽象名无属主,无法根绝)由客户端
+    // R1 + 服务端 euid 门 fail-closed 兜底(至多可用性损失,绝不 fail-open)。
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        format!("vigil-daemon-{}.sock", rustix::process::geteuid().as_raw())
+    }
+    // Windows:保持既有 named pipe 名。跨用户 duplex 连接被默认 pipe 安全描述符挡住
+    // (Everyone 仅读,连接需读+写);显式 DACL 与多席互撞处理 = R6 后续。
+    #[cfg(windows)]
     {
         "vigil-daemon.sock".to_string()
     }
@@ -193,10 +208,13 @@ fn connect_and_verify(socket_name: &str, expected_pid: u32) -> Option<LocalStrea
     Some(stream)
 }
 
-/// macOS R1:对端(server)euid == 本进程 euid(都是当前用户)。取不到 → fail-closed。
-/// `rustix::process::geteuid` 安全封装(本 crate 仍 `forbid(unsafe_code)`)。
-#[cfg(target_os = "macos")]
-fn peer_is_current_user(stream: &LocalStream) -> bool {
+/// 对端 euid == 本进程 euid(同一用户)。取不到 → `false`(fail-closed)。**双向复用**:
+/// macOS 客户端 R1(核 server 身份,见 [`connect_and_verify`])+ **全 unix 服务端 accept 门**
+/// (核 client 身份 —— Linux 抽象命名空间 UDS 无文件系统权限,任意本机用户可连;token 只挡请求,
+/// 挡不住握手前静默占坑,此门是结构性跨用户屏障)。`SO_PEERCRED`/`LOCAL_PEERCRED` 两端对称,
+/// 同一 API 双向可用。`rustix::process::geteuid` 安全封装(本 crate 仍 `forbid(unsafe_code)`)。
+#[cfg(unix)]
+pub fn peer_is_current_user(stream: &LocalStream) -> bool {
     match stream.peer_creds().ok().and_then(|c| c.euid()) {
         Some(peer_euid) => peer_euid == rustix::process::geteuid().as_raw(),
         None => false,
@@ -255,6 +273,17 @@ mod tests {
             platform_default_socket_name()
         );
         assert_eq!(resolve_socket_name(None), platform_default_socket_name());
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn linux_default_socket_name_is_per_euid() {
+        // 抽象 NS 跨用户共享:固定名多用户互撞 → 默认名必须含本用户 euid(消除意外互撞)。
+        let name = platform_default_socket_name();
+        assert!(
+            name.contains(&rustix::process::geteuid().as_raw().to_string()),
+            "Linux 默认 socket 名应含本用户 euid,got {name}"
+        );
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
Robustness round, follow-on to #86 (the F2 caps raised the value of closing this gap).

## R1' — server-side accept gate (unix)
On Linux the daemon listens on an **abstract-namespace UDS** — no filesystem permissions, any local user can connect. The token only guards requests; it cannot stop **pre-handshake silent slot-holding**, which matters more now that #86 caps handler slots at 64. Every accepted connection is now gated on **peer euid == our euid** before it takes a slot; missing or mismatched creds → dropped fail-closed. `SO_PEERCRED`/`LOCAL_PEERCRED` are symmetric, so this reuses the same `peer_is_current_user` the macOS client R1 already used (now `pub`, all-unix). macOS: defense-in-depth beyond 0700-dir/0600-node. Windows: default named-pipe security descriptor already blocks cross-user duplex connects (explicit DACL stays R6).

## Per-euid Linux socket name
`vigil-daemon-<euid>.sock` — the abstract namespace is shared host-wide, so the old fixed name made the **second user's daemon fail to bind** on multi-seat machines (their ML path silently floored to hard fingerprints). Clients discover the socket via `daemon.json`, so the rename has **zero compat surface** (verified: `default_socket_name` has exactly one consumer, `lifecycle::run_start`).

Honest notes:
- Abstract names have no owner — malicious squatting stays possible; client R1 + the new server gate keep it fail-closed (availability loss only, never fail-open).
- One-time upgrade edge: an old daemon still running under the fixed name is orphaned once the new daemon binds the per-euid name and rewrites daemon.json. Normal `stop → upgrade → start` is unaffected.

## clippy 1.95 future-proof (command_guard)
rustc 1.95's clippy **denies `collapsible_match`** on two `match`-arm `if`s in command_guard (found by verifying this PR on a 1.95 box — CI's older toolchain doesn't flag them yet, so CI would break when the runner toolchain rolls). Collapsed into guard arms; **fallthrough audited**: non-matching `dd`/`shred` guards can only reach `_ => {}`.

## Verification
- **Windows** (older toolchain, 252.20): fmt + clippy `-D warnings` clean, daemon-ipc 34 / daemon 19 / 95 workspace suites green, live `daemon start → status` roundtrip
- **macOS** (rustc 1.95, real arm64): clippy clean, full `cargo fmt --check` clean (LF-normalized), daemon-ipc 35 / daemon 18 / command_guard 32 green — mac runs the **active unix gate** in the real-socket e2e
- **Linux**: CI ubuntu job = real-Linux validation (new `linux_default_socket_name_is_per_euid` unit test + real-socket e2e through the gate)