### PR TITLE
fix(setup): absolutize relative CODEX_HOME/PI_AGENT_DIR against CWD — match vendor semantics

### DIFF
--- a/apps/vigil-hub-cli/src/command_guard.rs
+++ b/apps/vigil-hub-cli/src/command_guard.rs
@@ -200,6 +200,18 @@ fn classify_depth(command: &str, project_root: Option<&str>, depth: u8) -> Optio
                 continue;
             }
         };
+        // GNU `env -S <payload>`:payload 是 env split 后执行的完整命令,当嵌套脚本递归分类。用
+        // **raw_argv**(env 尚未 unwrap)。**必须在 `argv.is_empty()` 提前 continue 之前** —— 粘连式
+        // `-S<payload>` / `--split-string=<payload>` / payload 含 `=` 会被 `unwrap_argv` 当 flag/assign
+        // 吞成空 argv(真机实证这几个变体曾漏),故不能等到 argv 分类阶段。
+        if depth < MAX_NEST_DEPTH {
+            if let Some(payload) = env_split_string_payload(&raw_argv) {
+                if let Some(risk) = classify_depth(payload, project_root, depth + 1) {
+                    consider(risk);
+                }
+            }
+        }
+
         // 剥离 sudo / env / nohup 等前缀 wrapper,拿到真正的命令(`sudo rm -rf /` 的 rm)。
         let argv = unwrap_argv(&raw_argv);
         if argv.is_empty() {
@@ -451,6 +463,34 @@ fn eval_flag_script(argv: &[String]) -> Option<&str> {
     for i in 1..argv.len() {
         if EVAL_FLAGS.contains(&argv[i].as_str()) {
             return argv.get(i + 1).map(String::as_str);
+        }
+    }
+    None
+}
+
+/// GNU coreutils `env -S <payload>` / `env --split-string=<payload>`:env 把 payload 按类 shell
+/// 词法 split 后**作为真实命令执行**。payload 是自包含命令(不依赖 stdin),故当嵌套脚本递归分类
+/// —— 否则 `env -S 'rm -rf /'` 的 payload 落单 token,basename 不匹配 `rm` → `_` 分支绕过 argv
+/// 级灾难检测(真机实证放行,codex review)。用**未剥离**的 raw_argv(env 尚在);扫到 env wrapper
+/// (可带 sudo 等前缀)之后的分裂选项。递归受 `MAX_NEST_DEPTH` 守门,`env -S` 套 `env -S` 不失控。
+fn env_split_string_payload(argv: &[String]) -> Option<&str> {
+    let env_pos = argv.iter().position(|a| {
+        let b = basename(a).to_ascii_lowercase();
+        let b = b.strip_suffix(".exe").unwrap_or(&b);
+        b == "env"
+    })?;
+    for i in (env_pos + 1)..argv.len() {
+        let a = &argv[i];
+        if a == "-S" || a == "--split-string" {
+            return argv.get(i + 1).map(String::as_str); // `-S <payload>` / `--split-string <payload>`
+        }
+        if let Some(p) = a.strip_prefix("--split-string=") {
+            return Some(p); // `--split-string=<payload>`
+        }
+        if let Some(p) = a.strip_prefix("-S") {
+            if !p.is_empty() {
+                return Some(p); // `-S<payload>` 粘连式
+            }
         }
     }
     None
@@ -721,6 +761,38 @@ mod tests {
         assert!(
             classify("grep --color=auto pattern file", Some("/proj")).is_none(),
             "--flag=x 不是环境赋值,不应误命中"
+        );
+    }
+
+    #[test]
+    fn env_split_string_does_not_bypass_argv_detection() {
+        // 回归(review followup:codex HIGH + 真机实证放行):GNU `env -S <payload>` 把 payload
+        // 按类 shell 词法 split 后当**完整命令**执行。payload 曾落单 token(basename 不匹配 rm)
+        // → `_` 分支绕过 argv 级灾难检测。四语法变体 + wrapper 前缀 + payload 内含前导赋值(验证
+        // 递归里 #84 的裸赋值剥离亦生效)均须灾难级。
+        for cmd in [
+            "env -S 'rm -rf /'",
+            "env -S'rm -rf /'",
+            "env --split-string='rm -rf /'",
+            "env --split-string 'rm -rf /'",
+            "env -S 'FOO=1 rm -rf /'",
+            "sudo env -S 'rm -rf /'",
+        ] {
+            let r = cat(cmd, Some("/proj"));
+            assert_eq!(
+                r.tier,
+                GuardTier::Catastrophic,
+                "`{cmd}` 应灾难级(env split-string 不绕过)"
+            );
+        }
+        // 良性 payload 不被误命中(payload 递归分类无危险 → None)。
+        assert!(
+            classify("env -S 'ls -la'", Some("/proj")).is_none(),
+            "良性 env -S payload 不应命中"
+        );
+        assert!(
+            classify("env -S 'echo hello'", Some("/proj")).is_none(),
+            "良性 env -S payload 不应命中"
         );
     }
 

--- a/apps/vigil-hub-cli/src/daemon/server.rs
+++ b/apps/vigil-hub-cli/src/daemon/server.rs
@@ -262,19 +262,24 @@ fn spawn_classify_injection(caps: &DaemonCaps, session_id: &str, text: &str) {
     if !acquire_slot(&ACTIVE, MAX_ACTIVE_CLASSIFIES) {
         return; // 满员丢弃:软信号损失,绝不累积推理线程
     }
+    // RAII 退坑:guard 必须在 `thread::spawn` **之前**构造 —— spawn 是 `.expect()`,OS 拒绝建线程
+    // (EAGAIN / RLIMIT_NPROC,负载下真实)会 panic,此时若 guard 尚未建则坑永久泄漏(8 次后注入
+    // 分类静默永久禁用)。spawn 前建 + move 进闭包:panic 时随栈展开 drop 退坑,成功时闭包末尾
+    // drop 退坑。与 [`serve_with_limit`] 的 SlotGuard 同范式(classify 曾分叉,hostile review 抓出)。
+    // classify panic 也不漏坑;推理失败 = 无信号,hook 正则元指令仍兜底。
+    struct ClassifyGuard;
+    impl Drop for ClassifyGuard {
+        fn drop(&mut self) {
+            ACTIVE.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+    let guard = ClassifyGuard;
     let inj = Arc::clone(inj);
     let ledger = Arc::clone(ledger);
     let sid = session_id.to_string();
     let text = text.to_string();
     std::thread::spawn(move || {
-        // RAII 退坑(classify panic 也不漏坑;推理失败 = 无信号,hook 正则元指令仍兜底)。
-        struct ClassifyGuard;
-        impl Drop for ClassifyGuard {
-            fn drop(&mut self) {
-                ACTIVE.fetch_sub(1, Ordering::SeqCst);
-            }
-        }
-        let _guard = ClassifyGuard;
+        let _guard = guard;
         if let Ok(score) = inj.classify(&text) {
             maybe_bump_injection(&ledger, &sid, score);
         }

--- a/apps/vigil-hub-cli/src/setup_hooks.rs
+++ b/apps/vigil-hub-cli/src/setup_hooks.rs
@@ -118,10 +118,31 @@ pub struct AgentHookSpec {
     versioned_root: bool,
 }
 
-/// 通用 agent 配置目录解析:env 非空白 → 该值(`~`/`~/...` 展开到 home);否则 `default()`。
-/// Codex(`CODEX_HOME`)与 pi(`PI_AGENT_DIR`)共用同一展开语义(SSOT,注入式可测)。
+/// 通用 agent 配置目录解析:env 非空白 → 该值(`~`/`~/...` 展开到 home;**无根相对路径在本
+/// 进程 CWD 绝对化**);否则 `default()`。Codex(`CODEX_HOME`)与 pi(`PI_AGENT_DIR`)共用
+/// 同一展开语义(SSOT,注入式可测)。
+///
+/// 相对路径语义**对齐 vendor**:openai/codex(`codex-utils-home-dir`,源码实证)把 env 值
+/// `canonicalize()` —— 即按 codex 进程 CWD 解析;pi adapter 为 node 生态同 CWD 惯例。用户在
+/// 项目目录内 `setup`,写入位置与其在同目录跑 agent 时 vendor 读取的位置一致。此前相对值
+/// 原样透传,后续 join 出 CWD 依赖的未绝对化路径 —— setup/status/doctor 换目录即漂移且不
+/// 自知;绝对化后单次调用内确定,跨目录差异回归 vendor 本身的语义。判据用 `has_root`(非
+/// `is_absolute`):Windows 上 `/x`(root-relative)与 `C:x`(drive-relative)保持原样交 OS
+/// 按其规则解析,不强行拼接。
 pub(crate) fn resolve_agent_dir(
     home: &Path,
+    env_val: Option<&str>,
+    default: impl FnOnce() -> PathBuf,
+) -> PathBuf {
+    let cwd = std::env::current_dir().unwrap_or_default();
+    resolve_agent_dir_with_cwd(home, &cwd, env_val, default)
+}
+
+/// [`resolve_agent_dir`] 的纯核心(cwd 注入可测)。`cwd` 空(取 CWD 失败)→ 相对值退回
+/// 原样透传(不 panic,行为等同旧版)。
+fn resolve_agent_dir_with_cwd(
+    home: &Path,
+    cwd: &Path,
     env_val: Option<&str>,
     default: impl FnOnce() -> PathBuf,
 ) -> PathBuf {
@@ -130,8 +151,10 @@ pub(crate) fn resolve_agent_dir(
         Some(s) => {
             if let Some(rest) = s.strip_prefix("~/").or_else(|| s.strip_prefix("~\\")) {
                 home.join(rest)
-            } else {
+            } else if Path::new(s).has_root() || cwd.as_os_str().is_empty() {
                 PathBuf::from(s)
+            } else {
+                cwd.join(s)
             }
         }
         None => default(),
@@ -645,6 +668,40 @@ mod tests {
         assert_eq!(
             resolve_codex_home(home, Some("/opt/codex")),
             PathBuf::from("/opt/codex")
+        );
+    }
+
+    #[test]
+    fn relative_agent_dir_env_is_absolutized_against_cwd() {
+        // vendor 契约(openai/codex `codex-utils-home-dir`,源码实证):相对 CODEX_HOME 按
+        // 进程 CWD canonicalize。本解析对齐之 —— 绝不原样透传相对路径(那会随每次调用的
+        // CWD 漂移且不自知)。
+        let home = Path::new("/home/u");
+        let cwd = Path::new(if cfg!(windows) { r"C:\proj" } else { "/proj" });
+        assert_eq!(
+            super::resolve_agent_dir_with_cwd(home, cwd, Some("./ch"), || unreachable!()),
+            cwd.join("./ch")
+        );
+        assert_eq!(
+            super::resolve_agent_dir_with_cwd(home, cwd, Some("sub/dir"), || unreachable!()),
+            cwd.join("sub/dir")
+        );
+        // 有根路径原样(Windows `/x` root-relative 交 OS 解析,不强行拼接)
+        assert_eq!(
+            super::resolve_agent_dir_with_cwd(home, cwd, Some("/opt/codex"), || unreachable!()),
+            PathBuf::from("/opt/codex")
+        );
+        // 取 CWD 失败(空 cwd)→ 相对值退回原样透传(不 panic,等同旧行为)
+        assert_eq!(
+            super::resolve_agent_dir_with_cwd(home, Path::new(""), Some("rel"), || {
+                unreachable!()
+            }),
+            PathBuf::from("rel")
+        );
+        // 默认分支不受影响
+        assert_eq!(
+            super::resolve_agent_dir_with_cwd(home, cwd, None, || PathBuf::from("/d")),
+            PathBuf::from("/d")
         );
     }
 


### PR DESCRIPTION
resolve_agent_dir passed non-tilde env values through verbatim, so a
relative CODEX_HOME (e.g. ./ch, a supported per-project pattern) yielded
CWD-dependent unabsolutized paths: setup wrote the hook config relative
to wherever setup happened to run, and status/doctor silently drifted to
a different directory per invocation.

Vendor truth (source-verified, openai/codex codex-utils-home-dir):
codex requires the CODEX_HOME path to exist and canonicalize()s it —
i.e. resolves relative values against the codex process CWD. The pi
adapter is a node tool with the same CWD convention (not source-
verified; identical treatment is at worst a harmless absolutization).

So the fix mirrors the vendor: rootless relative values are joined onto
the current dir at resolution time — a user who runs setup in their
project dir now writes exactly where the agent launched from that dir
will read. Rooted-but-not-absolute Windows forms (/x, C:x) stay
verbatim for the OS to resolve by its own rules (has_root predicate,
which also keeps the existing /opt/codex expectation green on Windows).
current_dir() failure falls back to the old verbatim behavior instead
of panicking. Core extracted as resolve_agent_dir_with_cwd (cwd
injected) for deterministic tests; both consumers (codex hook+MCP
surfaces, pi MCP surface) inherit via the SSOT.

Verified on real Windows: fmt/clippy clean, setup-scoped 122 tests
green including the new relative/rooted/empty-cwd matrix.
